### PR TITLE
Fix default build settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.0)
 
 project(prjxray)
-option(PRJXRAY_BUILD_TESTING "" ON)
+option(PRJXRAY_BUILD_TESTING "" OFF)
 
 set(CMAKE_CXX_STANDARD 14)
 add_compile_options(-Wall -Werror)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,20 @@ cmake_minimum_required(VERSION 3.5.0)
 project(prjxray)
 option(PRJXRAY_BUILD_TESTING "" OFF)
 
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE Release CACHE STRING
+		"Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+		FORCE)
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 add_compile_options(-Wall -Werror)
 
 # Hack for missing option in cctz
 option(BUILD_TESTING "" OFF)
 
-
 if(PRJXRAY_BUILD_TESTING)
 	enable_testing()
-	add_compile_options(-O0 -g)
-else()
-	add_compile_options(-O3)
 endif()
 
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Creating HTML documentation:
     cd fuzzers/010-lutinit
     make -j$(nproc) run
 
+Tests are not built by default.  Setting the PRJXRAY\_BUILD\_TESTING option to
+ON when running cmake will include them:
+
+    cmake -DPRJXRAY_BUILD_TESTING=ON ..
+    make
+
+The default C++ build configuration is for releases (optimizations enabled, no
+debug info). A build configuration for debugging (no optimizations, debug info)
+can be chosen via the CMAKE\_BUILD\_TYPE option:
+
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    make
+
+The options to build tests and use a debug build configuration are independent
+to allow testing that optimizations do not cause bugs.  The build configuration
+and build tests options may be combined to allow all permutations.
 
 # Process
 


### PR DESCRIPTION
Running 'make go' with no options will generate a Release build (-O3, no debug info, etc).  Debug builds (-O0 -g) can be built by running 'cmake -DCMAKE_BUILD_TYPE=Debug ..' in the build directory.  Tests are not built by default.  To build them, add -DPRXRAY_BUILD_TESTING=ON to the cmake command line.