### PR TITLE
minitests: flatten hiearchy

### DIFF
--- a/minitests/util/runme.tcl
+++ b/minitests/util/runme.tcl
@@ -1,6 +1,6 @@
 create_project -force -part $::env(XRAY_PART) design design
 read_verilog top.v
-synth_design -top top
+synth_design -top top -flatten_hierarchy none
 
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports clk]
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports stb]


### PR DESCRIPTION
This forces better ROI to outside separation. I haven't tested this extensively, but this would only effect the minitests if there are any issues

Signed-off-by: John McMaster <johndmcmaster@gmail.com>