### PR TITLE
Replace init/final sequence hacks with less hacky solution

### DIFF
--- a/lib/include/prjxray/xilinx/xc7series/bitstream_writer.h
+++ b/lib/include/prjxray/xilinx/xc7series/bitstream_writer.h
@@ -23,7 +23,7 @@ namespace xc7series {
 class BitstreamWriter {
        public:
 	typedef std::array<uint32_t, 6> header_t;
-	typedef std::vector<ConfigurationPacket> packets_t;
+	typedef std::vector<std::unique_ptr<ConfigurationPacket>> packets_t;
 	// Only defined if a packet exists
 	typedef absl::optional<absl::Span<const uint32_t>> op_data_t;
 	typedef absl::Span<const uint32_t>::iterator data_iterator_t;

--- a/lib/include/prjxray/xilinx/xc7series/command.h
+++ b/lib/include/prjxray/xilinx/xc7series/command.h
@@ -1,0 +1,34 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_COMMAND_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_COMMAND_H_
+
+namespace prjxray {
+namespace xilinx {
+namespace xc7series {
+
+enum class Command : uint32_t {
+	NOP = 0x0,
+	WCFG = 0x1,
+	MFW = 0x2,
+	LFRM = 0x3,
+	RCFG = 0x4,
+	START = 0x5,
+	RCAP = 0x6,
+	RCRC = 0x7,
+	AGHIGH = 0x8,
+	SWITCH = 0x9,
+	GRESTORE = 0xA,
+	SHUTDOWN = 0xB,
+	GCAPTURE = 0xC,
+	DESYNC = 0xD,
+	IPROG = 0xF,
+	CRCC = 0x10,
+	LTIMER = 0x11,
+	BSPI_READ = 0x12,
+	FALL_EDGE = 0x13,
+};
+
+}  // namespace xc7series
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_COMMAND_H_

--- a/lib/include/prjxray/xilinx/xc7series/configuration_options_0_value.h
+++ b/lib/include/prjxray/xilinx/xc7series/configuration_options_0_value.h
@@ -1,0 +1,122 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_OPTIONS_0_VALUE_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_OPTIONS_0_VALUE_H
+
+#include <prjxray/bit_ops.h>
+#include <prjxray/xilinx/xc7series/configuration_packet.h>
+#include <prjxray/xilinx/xc7series/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace xc7series {
+
+class ConfigurationOptions0Value {
+       public:
+	enum class StartupClockSource : uint32_t {
+		CCLK = 0x0,
+		User = 0x1,
+		JTAG = 0x2,
+	};
+
+	enum class SignalReleaseCycle : uint32_t {
+		Phase1 = 0x0,
+		Phase2 = 0x1,
+		Phase3 = 0x2,
+		Phase4 = 0x3,
+		Phase5 = 0x4,
+		Phase6 = 0x5,
+		TrackDone = 0x6,
+		Keep = 0x7,
+	};
+
+	enum class StallCycle : uint32_t {
+		Phase0 = 0x0,
+		Phase1 = 0x1,
+		Phase2 = 0x2,
+		Phase3 = 0x3,
+		Phase4 = 0x4,
+		Phase5 = 0x5,
+		Phase6 = 0x6,
+		NoWait = 0x7,
+	};
+
+	ConfigurationOptions0Value() : value_(0) {}
+
+	operator uint32_t() const { return value_; }
+
+	ConfigurationOptions0Value& SetUseDonePinAsPowerdownStatus(
+	    bool enabled) {
+		value_ = bit_field_set(value_, 27, 27, enabled ? 1 : 0);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetAddPipelineStageForDoneIn(bool enabled) {
+		value_ = bit_field_set(value_, 25, 25, enabled ? 1 : 0);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetDriveDoneHigh(bool enabled) {
+		value_ = bit_field_set(value_, 24, 24, enabled);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetReadbackIsSingleShot(bool enabled) {
+		value_ = bit_field_set(value_, 23, 23, enabled);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetCclkFrequency(uint32_t mhz) {
+		value_ = bit_field_set(value_, 22, 17, mhz);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetStartupClockSource(
+	    StartupClockSource source) {
+		value_ = bit_field_set(value_, 16, 15,
+		                       static_cast<uint32_t>(source));
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetReleaseDonePinAtStartupCycle(
+	    SignalReleaseCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 14, 12, static_cast<uint32_t>(cycle));
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetStallAtStartupCycleUntilDciMatch(
+	    StallCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 11, 9, static_cast<uint32_t>(cycle));
+		return *this;
+	};
+
+	ConfigurationOptions0Value& SetStallAtStartupCycleUntilMmcmLock(
+	    StallCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 8, 6, static_cast<uint32_t>(cycle));
+		return *this;
+	};
+
+	ConfigurationOptions0Value& SetReleaseGtsSignalAtStartupCycle(
+	    SignalReleaseCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 5, 3, static_cast<uint32_t>(cycle));
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetReleaseGweSignalAtStartupCycle(
+	    SignalReleaseCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 2, 0, static_cast<uint32_t>(cycle));
+		return *this;
+	}
+
+       private:
+	uint32_t value_;
+};  // namespace xc7series
+
+}  // namespace xc7series
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_OPTIONS_0_VALUE_H

--- a/lib/include/prjxray/xilinx/xc7series/configuration_packet_with_payload.h
+++ b/lib/include/prjxray/xilinx/xc7series/configuration_packet_with_payload.h
@@ -1,0 +1,33 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_g_CONFIGURATION_PACKET_WITH_PAYLOAD_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_g_CONFIGURATION_PACKET_WITH_PAYLOAD_H
+
+#include <memory>
+
+#include <absl/types/span.h>
+#include <prjxray/bit_ops.h>
+#include <prjxray/xilinx/xc7series/configuration_packet.h>
+#include <prjxray/xilinx/xc7series/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace xc7series {
+
+template <int Words>
+class ConfigurationPacketWithPayload : public ConfigurationPacket {
+       public:
+	ConfigurationPacketWithPayload(
+	    Opcode op,
+	    ConfigurationRegister reg,
+	    const std::array<uint32_t, Words>& payload)
+	    : ConfigurationPacket(1, op, reg, absl::Span<uint32_t>(payload_)),
+	      payload_(std::move(payload)) {}
+
+       private:
+	std::array<uint32_t, Words> payload_;
+};  // namespace xc7series
+
+}  // namespace xc7series
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_g_CONFIGURATION_PACKET_WITH_PAYLOAD_H

--- a/lib/include/prjxray/xilinx/xc7series/configuration_register.h
+++ b/lib/include/prjxray/xilinx/xc7series/configuration_register.h
@@ -25,6 +25,7 @@ enum class ConfigurationRegister : unsigned int {
 	COR1 = 0x0e,
 	WBSTAR = 0x10,
 	TIMER = 0x11,
+	UNKNOWN = 0x13,
 	BOOTSTS = 0x16,
 	CTL1 = 0x18,
 	BSPI = 0x1F,

--- a/lib/include/prjxray/xilinx/xc7series/nop_packet.h
+++ b/lib/include/prjxray/xilinx/xc7series/nop_packet.h
@@ -1,0 +1,24 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_NOP_PACKET_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_NOP_PACKET_H
+
+#include <prjxray/xilinx/xc7series/configuration_packet.h>
+#include <prjxray/xilinx/xc7series/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace xc7series {
+
+class NopPacket : public ConfigurationPacket {
+       public:
+	NopPacket()
+	    : ConfigurationPacket(1,
+	                          Opcode::NOP,
+	                          ConfigurationRegister::CRC,
+	                          {}) {}
+};
+
+}  // namespace xc7series
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_NOP_PACKET_H

--- a/lib/xilinx/xc7series/bitstream_writer.cc
+++ b/lib/xilinx/xc7series/bitstream_writer.cc
@@ -28,7 +28,7 @@ BitstreamWriter::BitstreamWriter(const packets_t& packets)
 
 BitstreamWriter::packet_iterator BitstreamWriter::iterator::packet_begin() {
 	// itr_packets = packets.begin();
-	const ConfigurationPacket& packet = *itr_packets_;
+	const ConfigurationPacket& packet = **itr_packets_;
 
 	return BitstreamWriter::packet_iterator(
 	    &packet, BitstreamWriter::packet_iterator::STATE_HEADER,
@@ -36,7 +36,7 @@ BitstreamWriter::packet_iterator BitstreamWriter::iterator::packet_begin() {
 }
 
 BitstreamWriter::packet_iterator BitstreamWriter::iterator::packet_end() {
-	const ConfigurationPacket& packet = *itr_packets_;
+	const ConfigurationPacket& packet = **itr_packets_;
 
 	return BitstreamWriter::packet_iterator(
 	    &packet, BitstreamWriter::packet_iterator::STATE_END,
@@ -138,7 +138,7 @@ BitstreamWriter::iterator BitstreamWriter::begin() {
 	if (itr_packets != packets_.end()) {
 		// op_packet_itr = packet_begin();
 		// FIXME: de-duplicate this
-		const ConfigurationPacket& packet = *itr_packets;
+		const ConfigurationPacket& packet = **itr_packets;
 		packet_iterator packet_itr =
 		    packet_iterator(&packet, packet_iterator::STATE_HEADER,
 		                    packet.data().begin());

--- a/minitests/partial_reconfig_flow/Makefile
+++ b/minitests/partial_reconfig_flow/Makefile
@@ -6,48 +6,13 @@
 # ready for programming to a board.  For example,
 # 'make inv_hand_crafted.bit' will generate a bitstream that includes the
 # design from roi_noninv.fasm. 
-%_hand_crafted.bit: init_sequence.bit %_no_headers.bin final_sequence.bin
-	cat $^ > $@
-
-%_no_headers.bin: %_patched.bin
-	# WARNING: these values need to be tweaked if anything about the
-	# Vivado-generated design changes.
-	xxd -p -s 0x18 $< | xxd -r -p - $@
-
-%_patched.bin: %_roi_partial.frm harness.bit
+%_hand_crafted.bit: %_roi_partial.frm harness.bit
 	${XRAY_TOOLS_DIR}/xc7patch \
-		--part_file ${XRAY_PART_YAML} \
+		--part_name "${XRAY_PART}" \
+		--part_file "${XRAY_PART_YAML}" \
 		--bitstream_file harness.bit \
 		--frm_file $< \
 		--output_file $@
-
-# xc7patch currently only generates the actual frame writes which is
-# insufficient to program a device.  Grab the initialization and finalization
-# sequences from the harness bitstream so they can be tacked on to the
-# xc7patch-generated bitstream to create a programmable bitstream.
-#
-# The offsets used below were determined by manually inspecting
-# harness.bit with a hex editor.  init_sequence.bit is the beginning of
-# the file until just before the actual frame data is sent via a write to FDRI.
-# final_sequence.bin is from just after the frame data write to the end of the
-# file.  Note that final_sequence.bin normally includes at least one CRC check.
-# The sed command replaces any CRC checks with a Reset CRC command which is the
-# same behavior as setting BITSTREAM.GENERAL.CRC to Disabled.  These offset
-# should not change unless you alter the bitstream format used (i.e. setting
-# BITSTREAM.GENERAL.DEBUGBITSTREAM or BITSTREAM.GENERAL.PERFRAMECRC to YES).
-init_sequence.bit: harness.bit
-	# WARNING: these values need to be tweaked if anything about the
-	# Vivado-generated design changes.
-	xxd -p -l 0x147 $< | xxd -r -p - $@
-
-final_sequence.bin: harness.bit
-	# WARNING: these values need to be tweaked if anything about the
-	# Vivado-generated design changes.
-	xxd -p -s 0x216abf $< | \
-		tr -d '\n' | \
-		sed -e 's/30000001.\{8\}/3000800100000007/g' | \
-		fold -w 40 | \
-		xxd -r -p - $@
 
 # Generate a suitable harness by using Vivado's partial reconfiguration
 # feature.  inv.v is used as a sample reconfiguration design as one is

--- a/minitests/partial_reconfig_flow/Makefile
+++ b/minitests/partial_reconfig_flow/Makefile
@@ -1,4 +1,4 @@
-.PRECIOUS: harness_impl.dcp %_impl.dcp %.bit
+.PRECIOUS: harness_impl.dcp %_impl.dcp %.bit %_roi_partial.bit
 
 # Top-level target for generating a programmable bitstream.  Given a .fasm
 # file, calling make with the .fasm extension replaced with _hand_crafted.bit

--- a/minitests/roi_harness/fasm2bit.sh
+++ b/minitests/roi_harness/fasm2bit.sh
@@ -30,28 +30,11 @@ echo "Out .bit: $bit_out"
 ${XRAY_DIR}/tools/fasm2frame.py $fasm_in roi_partial.frm
 
 ${XRAY_TOOLS_DIR}/xc7patch \
+	--part_name ${XRAY_PART} \
 	--part_file ${XRAY_PART_YAML} \
 	--bitstream_file $bit_in \
 	--frm_file roi_partial.frm \
-	--output_file patched.bin
-
-# WARNING: these values need to be tweaked if anything about the
-# Vivado-generated design changes.
-xxd -p -l 0x147 $bit_in | xxd -r -p - init_sequence.bit
-
-# WARNING: these values need to be tweaked if anything about the
-# Vivado-generated design changes.
-xxd -p -s 0x18 patched.bin | xxd -r -p - no_headers.bin
-
-# WARNING: these values need to be tweaked if anything about the
-# Vivado-generated design changes.
-xxd -p -s 0x216abf $bit_in | \
-	tr -d '\n' | \
-	sed -e 's/30000001.\{8\}/3000800100000007/g' | \
-	fold -w 40 | \
-	xxd -r -p - final_sequence.bin
-
-cat init_sequence.bit no_headers.bin final_sequence.bin >$bit_out
+	--output_file $bit_out
 
 #openocd -f $XRAY_DIR/utils/openocd/board-digilent-basys3.cfg -c "init; pld load 0 $bit_out; exit"
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(gen_part_base_yaml
 add_executable(xc7patch xc7patch.cc)
 target_link_libraries(xc7patch
 	absl::strings
+	absl::time
 	gflags
 	libprjxray
 )

--- a/tools/xc7patch.cc
+++ b/tools/xc7patch.cc
@@ -120,18 +120,6 @@ int main(int argc, char* argv[]) {
 		frame_data[0x32] |= (ecc & 0x1FFF);
 	}
 
-#if 0
-	for (auto& frame : frames) {
-		std::cout << "0x" << std::hex
-		          << static_cast<uint32_t>(frame.first) << " ";
-
-		for (auto& word : frame.second) {
-			std::cout << "0x" << std::hex << word << ",";
-		}
-
-		std::cout << std::endl;
-	}
-#endif
 	std::vector<xc7series::ConfigurationPacket> out_packets;
 
 	// Generate a single type 2 packet that writes everything at once.
@@ -157,12 +145,6 @@ int main(int argc, char* argv[]) {
 	out_packets.push_back(xc7series::ConfigurationPacket(
 	    2, xc7series::ConfigurationPacket::Opcode::Write,
 	    xc7series::ConfigurationRegister::FDRI, packet_data));
-
-#if 0
-	for (auto& packet : out_packets) {
-		std::cout << packet << std::endl;
-	}
-#endif
 
 	// Write bitstream.
 	xc7series::BitstreamWriter out_bitstream_writer(out_packets);

--- a/tools/xc7patch.cc
+++ b/tools/xc7patch.cc
@@ -120,7 +120,8 @@ int main(int argc, char* argv[]) {
 		frame_data[0x32] |= (ecc & 0x1FFF);
 	}
 
-	std::vector<xc7series::ConfigurationPacket> out_packets;
+	std::vector<std::unique_ptr<xc7series::ConfigurationPacket>>
+	    out_packets;
 
 	// Generate a single type 2 packet that writes everything at once.
 	std::vector<uint32_t> packet_data;
@@ -139,10 +140,11 @@ int main(int argc, char* argv[]) {
 	}
 	packet_data.insert(packet_data.end(), 202, 0);
 
-	out_packets.push_back(xc7series::ConfigurationPacket(
+	// Frame data write
+	out_packets.emplace_back(new xc7series::ConfigurationPacket(
 	    1, xc7series::ConfigurationPacket::Opcode::Write,
 	    xc7series::ConfigurationRegister::FDRI, {}));
-	out_packets.push_back(xc7series::ConfigurationPacket(
+	out_packets.emplace_back(new xc7series::ConfigurationPacket(
 	    2, xc7series::ConfigurationPacket::Opcode::Write,
 	    xc7series::ConfigurationRegister::FDRI, packet_data));
 


### PR DESCRIPTION
As a quick solution to demonstrate the toolchain working, xc7patch only generates the data frame writes.  The required init and final sequences needed for programming into a part are directly copied over from the Vivado-generated harness.  This is fragile as the exact offsets of the sequences are likely to change with Vivado version changes.

This series generates an equivalent init and final sequence as part of xc7patch which results in a directly usable output bitstream.  Further, the Xilinx BIT header has been added as well which means the resulting bitstream can be programming normally via Vivado's Hardware Manager, iMPACT, and OpenOCD.