### PR TITLE
Force amd64 image for nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN cd /source && make -j${NUM_PARALLEL_JOBS} --output-sync=target --warn-undefi
 RUN find /source/database -mindepth 1 -maxdepth 1 -type d -exec /source/htmlgen/htmlgen.py --settings={}/settings.sh --output=/output/html \;
 RUN mkdir -p /output/raw && find /source/database -mindepth 1 -maxdepth 1 -type d -exec cp -R {} /output/raw \;
 
-FROM nginx:alpine
+FROM amd64/nginx:alpine
 COPY --from=db_builder /output /usr/share/nginx/html


### PR DESCRIPTION
Resolves #101 

Per https://github.com/docker-library/official-images/issues/3835,
multi-arch official images are currently updated as each architecture's
builder finishes. This leads to times when the latest tags only have a
few architectures available.  Since our builds only happen on amd64,
pull nginx from the amd64 namespace specifically to avoid the problem.

Signed-off-by: Rick Altherr <kc8apf@kc8apf.net>