### PR TITLE
Add methods to prjxray library.

### DIFF
--- a/prjxray/db.py
+++ b/prjxray/db.py
@@ -2,6 +2,7 @@ import os.path
 import json
 from prjxray import grid
 from prjxray import tile
+from prjxray import site_type
 from prjxray import connections
 
 
@@ -36,6 +37,7 @@ class Database(object):
         self.tile_types = None
 
         self.tile_types = {}
+        self.site_types = {}
         for f in os.listdir(self.db_root):
             if f.endswith('.json') and f.startswith('tile_type_'):
                 tile_type = f[len('tile_type_'):-len('.json')].lower()
@@ -61,6 +63,11 @@ class Database(object):
                     mask=mask,
                     tile_type=tile_type_file,
                 )
+
+            if f.endswith('.json') and f.startswith('site_type_'):
+                site_type_name = f[len('site_type_'):-len('.json')]
+
+                self.site_types[site_type_name] = os.path.join(self.db_root, f)
 
     def get_tile_types(self):
         """ Return list of tile types """
@@ -102,3 +109,12 @@ class Database(object):
             for tile_type, db in self.tile_types.items())
         return connections.Connections(
             self.tilegrid, self.tileconn, tile_wires)
+
+    def get_site_types(self):
+        return self.site_types.keys()
+
+    def get_site_type(self, site_type_name):
+        with open(self.site_types[site_type_name]) as f:
+            site_type_data = json.load(f)
+
+        return site_type.SiteType(site_type_data)

--- a/prjxray/grid.py
+++ b/prjxray/grid.py
@@ -19,6 +19,7 @@ class Grid(object):
         for tile in self.tilegrid['tiles']:
             tileinfo = self.tilegrid['tiles'][tile]
             grid_loc = GridLoc(tileinfo['grid_x'], tileinfo['grid_y'])
+            assert grid_loc not in self.loc
             self.loc[grid_loc] = tile
             self.tileinfo[tile] = GridInfo(
                 segment=tileinfo['segment'] if 'segment' in tileinfo else None,

--- a/prjxray/site_type.py
+++ b/prjxray/site_type.py
@@ -1,0 +1,29 @@
+""" Description of a site type """
+
+from collections import namedtuple
+import enum
+
+
+class SitePinDirection(enum.Enum):
+    IN = "IN"
+    OUT = "OUT"
+
+
+SiteTypePin = namedtuple('SiteTypePin', 'name direction')
+
+
+class SiteType(object):
+    def __init__(self, site_type):
+        self.type = site_type['type']
+        self.site_pins = {}
+        for site_pin, site_pin_info in site_type['site_pins'].items():
+            self.site_pins[site_pin] = SiteTypePin(
+                name=site_pin,
+                direction=SitePinDirection(site_pin_info['direction']),
+            )
+
+    def get_site_pins(self):
+        return self.site_pins.keys()
+
+    def get_site_pin(self, site_pin):
+        return self.site_pins[site_pin]


### PR DESCRIPTION
All data from #125 is now exported from the prjxray library.  A bug was found in how site reduction was done, so some sites in some tile types don't round trip.  This can be fixed in a future PR.