### PR TITLE
fuzzers: remove db assert where possible

### DIFF
--- a/fuzzers/015-clbnffmux/generate.py
+++ b/fuzzers/015-clbnffmux/generate.py
@@ -3,6 +3,7 @@
 import sys, os, re
 
 from prjxray.segmaker import Segmaker
+from prjxray import util
 
 segmk = Segmaker("design.bits")
 cache = dict()
@@ -67,12 +68,5 @@ for loc, muxes in cache.items():
             tag = "%sFFMUX.%s" % (which, src)
             segmk.add_site_tag(loc, tag, 0)
 
-
-# we know that all bits for those MUXes are in frames 30 and 31, so filter all other bits
-def bitfilter(frame_idx, bit_idx):
-    assert os.getenv("XRAY_DATABASE") == "artix7"
-    return frame_idx in [30, 31]
-
-
-segmk.compile(bitfilter=bitfilter)
+segmk.compile(bitfilter=util.bitfilter_clb_mux)
 segmk.write()

--- a/fuzzers/016-clbnoutmux/generate.py
+++ b/fuzzers/016-clbnoutmux/generate.py
@@ -3,6 +3,7 @@
 import sys, os, re
 
 from prjxray.segmaker import Segmaker
+from prjxray import util
 
 segmk = Segmaker("design.bits")
 cache = dict()
@@ -69,8 +70,6 @@ for loc, muxes in cache.items():
 
 
 def bitfilter(frame_idx, bit_idx):
-    assert os.getenv("XRAY_DATABASE") == "artix7"
-
     # locations of A5MA, B5MA, C5MA, D5MA bits. because of the way we generate specimens
     # in this fuzzer we get some aliasing with those bits, so we have to manually exclude
     # them. (Maybe FIXME: read the bit locations from the database files)
@@ -86,8 +85,7 @@ def bitfilter(frame_idx, bit_idx):
     ]:
         return False
 
-    # we know that all bits for those MUXes are in frames 30 and 31, so filter all other bits
-    return frame_idx in [30, 31]
+    return util.bitfilter_clb_mux(frame_idx, bit_idx)
 
 
 segmk.compile(bitfilter=bitfilter)

--- a/fuzzers/018-clbram/generate.py
+++ b/fuzzers/018-clbram/generate.py
@@ -132,7 +132,6 @@ for l in f:
 def bitfilter(frame_idx, bit_idx):
     # Hack to remove aliased PIP bits on CE
     # We should either mix up routing more or exclude previous DB entries
-    assert os.getenv("XRAY_DATABASE") == "artix7"
     return (frame_idx, bit_idx) not in [(0, 27), (1, 25), (1, 26), (1, 29)]
 
 

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -71,3 +71,8 @@ def gen_sites(site_types=None, tilegrid=None):
 #print(list(gen_tiles(['CLBLL_L', 'CLBLL_R', 'CLBLM_L', 'CLBLM_R'])))
 #print(list(gen_sites(['SLICEL', 'SLICEM'])))
 #print(list(gen_sites(['SLICEM'])))
+
+
+# we know that all bits for CLB MUXes are in frames 30 and 31, so filter all other bits
+def bitfilter_clb_mux(frame_idx, bit_idx):
+    return frame_idx in [30, 31]


### PR DESCRIPTION
Signed-off-by: John McMaster <johndmcmaster@gmail.com>

The following have assertions, but have existing issues and so were not touched:
- 051-imuxlout
- 052-clkin
- 053-ctrlin
- 057-bipips
