### PR TITLE
fuzzers: don't use EXCLUDE_PLACEMENT on ROI

### DIFF
--- a/fuzzers/007-timing/minitest/test_unique/generate.tcl
+++ b/fuzzers/007-timing/minitest/test_unique/generate.tcl
@@ -19,7 +19,6 @@ proc build_design {} {
     puts "pblocking"
     create_pblock roi
     set roipb [get_pblocks roi]
-    set_property EXCLUDE_PLACEMENT 1 $roipb
     add_cells_to_pblock $roipb [get_cells roi]
     resize_pblock $roipb -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/007-timing/projects/oneblinkw/generate.tcl
+++ b/fuzzers/007-timing/projects/oneblinkw/generate.tcl
@@ -19,7 +19,6 @@ proc build_design {} {
     puts "pblocking"
     create_pblock roi
     set roipb [get_pblocks roi]
-    set_property EXCLUDE_PLACEMENT 1 $roipb
     add_cells_to_pblock $roipb [get_cells roi]
     resize_pblock $roipb -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/007-timing/projects/picorv32/generate.tcl
+++ b/fuzzers/007-timing/projects/picorv32/generate.tcl
@@ -20,7 +20,6 @@ proc build_design {} {
     puts "pblocking"
     create_pblock roi
     set roipb [get_pblocks roi]
-    set_property EXCLUDE_PLACEMENT 1 $roipb
     add_cells_to_pblock $roipb [get_cells roi]
     resize_pblock $roipb -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/007-timing/projects/placelut/generate.tcl
+++ b/fuzzers/007-timing/projects/placelut/generate.tcl
@@ -19,7 +19,6 @@ proc build_design {} {
     puts "pblocking"
     create_pblock roi
     set roipb [get_pblocks roi]
-    set_property EXCLUDE_PLACEMENT 1 $roipb
     add_cells_to_pblock $roipb [get_cells roi]
     resize_pblock $roipb -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/007-timing/projects/placelut_fb/generate.tcl
+++ b/fuzzers/007-timing/projects/placelut_fb/generate.tcl
@@ -19,7 +19,6 @@ proc build_design {} {
     puts "pblocking"
     create_pblock roi
     set roipb [get_pblocks roi]
-    set_property EXCLUDE_PLACEMENT 1 $roipb
     add_cells_to_pblock $roipb [get_cells roi]
     resize_pblock $roipb -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/007-timing/projects/placelut_ff_fb/generate.tcl
+++ b/fuzzers/007-timing/projects/placelut_ff_fb/generate.tcl
@@ -19,7 +19,6 @@ proc build_design {} {
     puts "pblocking"
     create_pblock roi
     set roipb [get_pblocks roi]
-    set_property EXCLUDE_PLACEMENT 1 $roipb
     add_cells_to_pblock $roipb [get_cells roi]
     resize_pblock $roipb -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/011-ffconfig/generate.tcl
+++ b/fuzzers/011-ffconfig/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/012-clbn5ffmux/generate.tcl
+++ b/fuzzers/012-clbn5ffmux/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/013-clbncy0/generate.tcl
+++ b/fuzzers/013-clbncy0/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/014-ffsrcemux/generate.tcl
+++ b/fuzzers/014-ffsrcemux/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/015-clbnffmux/generate.tcl
+++ b/fuzzers/015-clbnffmux/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/016-clbnoutmux/generate.tcl
+++ b/fuzzers/016-clbnoutmux/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/017-clbprecyinit/generate.tcl
+++ b/fuzzers/017-clbprecyinit/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/018-clbram/generate.tcl
+++ b/fuzzers/018-clbram/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/019-ndi1mux/generate.tcl
+++ b/fuzzers/019-ndi1mux/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/101-bram-config/generate.tcl
+++ b/fuzzers/101-bram-config/generate.tcl
@@ -8,7 +8,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/101-bram-config/minitest/runme.tcl
+++ b/fuzzers/101-bram-config/minitest/runme.tcl
@@ -9,7 +9,7 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/fuzzers/102-bram-data/generate.tcl
+++ b/fuzzers/102-bram-data/generate.tcl
@@ -8,7 +8,6 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/minitests/clbconfigs/runme.tcl
+++ b/minitests/clbconfigs/runme.tcl
@@ -9,7 +9,6 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/minitests/picorv32-v/runme.tcl
+++ b/minitests/picorv32-v/runme.tcl
@@ -9,7 +9,6 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/minitests/picorv32-y/runme.tcl
+++ b/minitests/picorv32-y/runme.tcl
@@ -15,7 +15,6 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 

--- a/minitests/util/runme.tcl
+++ b/minitests/util/runme.tcl
@@ -8,7 +8,6 @@ set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_po
 set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
 create_pblock roi
-set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
 add_cells_to_pblock [get_pblocks roi] [get_cells roi]
 resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 


### PR DESCRIPTION
Fixes: https://github.com/SymbiFlow/prjxray/issues/212

A recent change got the ROI X/Y out of sync with the ROI primitives. This caused issues for many fuzzers which used EXCLUDE_PLACEMENT to create a sharp boundary between the ROI and the rest of the FPGA. This is problematic because the site ROI was expanded to include most of the chip, and this precluded placing harness test logic in the top module.

Really, we need to separate out the ROI that we are using for tilegrid generation vs fuzzers. Or, if the idea is to no longer use an ROI for tilegrid, we should just remove the ROI entirely from that fuzzer