### PR TITLE
quick.mk quicker

### DIFF
--- a/fuzzers/quick.mk
+++ b/fuzzers/quick.mk
@@ -1,5 +1,7 @@
 # Intended for CIT quick checks
 
+FUZZONLY=N
+
 define fuzzer
 all:: $(1)/run.ok
 clean::
@@ -8,8 +10,11 @@ $(1)/run.ok: $(addsuffix /run.ok,$(2))
 	$$(MAKE) -C $(1) run
 endef
 
+ifneq ($(FUZZONLY),Y)
 $(eval $(call fuzzer,001-part-yaml,))
 $(eval $(call fuzzer,005-tilegrid,001-part-yaml))
+endif
+
 $(eval $(call fuzzer,010-lutinit,005-tilegrid))
 $(eval $(call fuzzer,011-ffconfig,005-tilegrid))
 $(eval $(call fuzzer,012-clbn5ffmux,005-tilegrid))

--- a/fuzzers/quick.mk
+++ b/fuzzers/quick.mk
@@ -1,4 +1,7 @@
 # Intended for CIT quick checks
+# Full run ("Makefile"): 10 hours
+# quick.mk (FUZZONLY=N): 30 min
+# quick.mk (FUZZONLY=Y): 6 min
 
 FUZZONLY=N
 


### PR DESCRIPTION
See comments in commit, but basically this is a much better smoke test for fuzzers since regenerating tilegrid takes a long time