### PR TITLE
clbram: ignore unexpected LUT contents

### DIFF
--- a/fuzzers/018-clbram/Makefile
+++ b/fuzzers/018-clbram/Makefile
@@ -1,4 +1,4 @@
-N := 1
+N := 2
 SLICEL ?= N
 include ../clb.mk
 

--- a/fuzzers/018-clbram/generate.py
+++ b/fuzzers/018-clbram/generate.py
@@ -122,9 +122,10 @@ for l in f:
     # Now commit bits after marking 1's
     for beli, bel in enumerate('ABCD'):
         segmk.add_site_tag(loc, "%sLUT.RAM" % bel, ram[beli])
-        segmk.add_site_tag(loc, "%sLUT.SRL" % bel, srl[beli])
-        # FIXME
-        module == segmk.add_site_tag(loc, "%sLUT.SMALL" % bel, size[beli])
+        # FIXME: quick fix
+        if bel in "AD":
+            segmk.add_site_tag(loc, "%sLUT.SRL" % bel, srl[beli])
+            segmk.add_site_tag(loc, "%sLUT.SMALL" % bel, size[beli])
 
 
 def bitfilter(frame_idx, bit_idx):

--- a/fuzzers/018-clbram/generate.py
+++ b/fuzzers/018-clbram/generate.py
@@ -105,7 +105,7 @@ for l in f:
         else:
             assert (0)
 
-        # All entries here requiare D
+        # All entries here require D
         assert (ram[3])
 
         if module == 'my_RAM32X1D':
@@ -123,9 +123,8 @@ for l in f:
     for beli, bel in enumerate('ABCD'):
         segmk.add_site_tag(loc, "%sLUT.RAM" % bel, ram[beli])
         # FIXME: quick fix
-        if bel in "AD":
-            segmk.add_site_tag(loc, "%sLUT.SRL" % bel, srl[beli])
-            segmk.add_site_tag(loc, "%sLUT.SMALL" % bel, size[beli])
+        segmk.add_site_tag(loc, "%sLUT.SRL" % bel, srl[beli])
+        segmk.add_site_tag(loc, "%sLUT.SMALL" % bel, size[beli])
 
 
 def bitfilter(frame_idx, bit_idx):

--- a/fuzzers/018-clbram/generate.py
+++ b/fuzzers/018-clbram/generate.py
@@ -16,14 +16,6 @@ multi_bels_bn = [
     'RAM64X1S',
 ]
 
-# Those requiring special resources
-# Just make one per module
-greedy_modules = [
-    'my_RAM128X1D',
-    'my_RAM128X1S',
-    'my_RAM256X1S',
-]
-
 print("Loading tags")
 '''
 module,loc,bela,belb,belc,beld
@@ -39,7 +31,7 @@ for l in f:
 
     segmk.add_site_tag(
         loc, "WA7USED",
-        module in ('my_RAM128X1D', 'my_RAM128X1S', 'my_RAM256X1S'))
+        module in ('my_RAM128X1D', 'my_RAM128X1S_N', 'my_RAM256X1S'))
     segmk.add_site_tag(loc, "WA8USED", module == 'my_RAM256X1S')
 
     # (a, b, c, d)

--- a/fuzzers/018-clbram/generate.tcl
+++ b/fuzzers/018-clbram/generate.tcl
@@ -1,26 +1,66 @@
-create_project -force -part $::env(XRAY_PART) design design
-read_verilog top.v
-synth_design -top top
+proc build {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
 
-set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports clk]
-set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports stb]
-set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_ports di]
-set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
+    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports clk]
+    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports stb]
+    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_ports di]
+    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
 
-create_pblock roi
+    create_pblock roi
 
-add_cells_to_pblock [get_pblocks roi] [get_cells roi]
-resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
+    add_cells_to_pblock [get_pblocks roi] [get_cells roi]
+    resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
 
-set_property CFGBVS VCCO [current_design]
-set_property CONFIG_VOLTAGE 3.3 [current_design]
-set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
-set_param tcl.collectionResultDisplayLimit 0
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+    set_param tcl.collectionResultDisplayLimit 0
 
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF]
+    set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF]
 
-place_design
-route_design
+    place_design
+    route_design
 
-write_checkpoint -force design.dcp
-write_bitstream -force design.bit
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+}
+
+proc dump {} {
+    set roi [get_pblocks roi]
+
+    set fp [open "design.csv" w]
+    puts $fp "tile,site,bel,cell,ref_name,prim_type"
+
+    set sites [get_sites -of_objects $roi]
+    for {set sitei 0} {$sitei < [llength $sites]} {incr sitei} {
+        # set site [get_sites SLICE_X6Y105]
+        set site [lindex $sites $sitei]
+        set tile [get_tiles -of_objects $site]
+
+        set bels [get_bels -of_objects $site -filter {TYPE == LUT_OR_MEM6}]
+        for {set beli 0} {$beli < [llength $bels]} {incr beli} {
+            # set bel [get_bels SLICE_X6Y105/D6LUT]
+            set bel [lindex $bels $beli]
+            set cell [get_cells -of_objects $bel]
+            if { "$cell" == "" } {
+                continue
+            }
+            # Ex SRL16E
+            set ref_name [get_property REF_NAME $cell]
+            # Ex: DMEM.srl.SRL16E
+            set prim_type [get_property PRIMITIVE_TYPE $cell]
+            puts $fp "$tile,$site,$bel,$cell,$ref_name,$prim_type"
+        }
+    }
+    close $fp
+}
+
+proc run {} {
+    build
+    dump
+}
+
+run
+

--- a/fuzzers/018-clbram/top.py
+++ b/fuzzers/018-clbram/top.py
@@ -58,6 +58,8 @@ for clbi in range(CLBN):
         bel_opts = [
             'SRL16E',
             'SRLC32E',
+            # Weight LUT6 more heavily to make WEMUX.CE solve quicker
+            'LUT6',
             'LUT6',
         ]
 


### PR DESCRIPTION
Fixes https://github.com/SymbiFlow/prjxray/issues/293

As this tcl script is currently written design is allowed to PnR the harness LFSR into the ROI. This causes some solves to get messed up as unexpected LUTs are added. I worked around by dumping the actual LUTs used from tcl and dropping that site if the LUTs don't match the expectation. There is a pblock exclude flag we are using in some tcl scripts that we might be able to use alternatively, but this is probably more proper since the flag was unreliable.

I also found an issue with WEMUX.CE failing to solve in rare scenarios caused by a module name typo