### PR TITLE
rempips: fix todo.txt path

### DIFF
--- a/fuzzers/056-rempips/generate.tcl
+++ b/fuzzers/056-rempips/generate.tcl
@@ -21,7 +21,7 @@ route_design
 
 # write_checkpoint -force design.dcp
 
-set fp [open "../todo.txt" r]
+set fp [open "../../todo.txt" r]
 set todo_lines {}
 for {gets $fp line} {$line != ""} {gets $fp line} {
     lappend todo_lines [split $line .]


### PR DESCRIPTION
Fixes https://github.com/SymbiFlow/prjxray/issues/331

I had a "bad path" failure after, but this is because of https://github.com/SymbiFlow/prjxray/issues/332