### PR TITLE
tilegrid: /bin/dash compatibility

### DIFF
--- a/fuzzers/005-tilegrid/Makefile
+++ b/fuzzers/005-tilegrid/Makefile
@@ -35,7 +35,7 @@ iob/build/segbits_tilegrid.tdb: build/basicdb/tilegrid.json
 build/tilegrid.json: generate_full.py build/tilegrid_tdb.json build/clb/deltas build/bram/deltas
 	cd build && python3 ${FUZDIR}/generate_full.py \
         --json-in tilegrid_tdb.json --json-out ${BUILD_DIR}/tilegrid.json \
-        --tiles $(FUZDIR)/build/tiles/tiles.txt {clb,bram}/design_*.delta
+        --tiles $(FUZDIR)/build/tiles/tiles.txt clb/design_*.delta bram/design_*.delta
 
 run:
 	$(MAKE) clean


### PR DESCRIPTION
Some of our systems have /bin/sh as bash, some as dash. So far this hasn't been an issue. However, I recently used {a,b} notation, which evidently doesn't work in dash. Seems the simplest option is to just revert this. We can think about setting SHELL or such later if it becomes problematic 