### PR TITLE
rempips: fix todo path

### DIFF
--- a/fuzzers/050-intpips/Makefile
+++ b/fuzzers/050-intpips/Makefile
@@ -53,9 +53,11 @@ build/pips_int_l.txt: $(XRAY_DIR)/fuzzers/piplist.tcl
 
 build/todo.txt: build/pips_int_l.txt $(XRAY_DIR)/fuzzers/int_maketodo.py
 # Doesn't pushdb until very end. Compare against db so far
-	python3 $(XRAY_DIR)/fuzzers/int_maketodo.py --db-dir build $(MAKETODO_FLAGS) >build/todo_all.txt
+	python3 $(XRAY_DIR)/fuzzers/int_maketodo.py --db-dir build $(MAKETODO_FLAGS) |sort >build/todo_all.txt
 	cat build/todo_all.txt | sort -R > build/todo.txt.tmp
 	mv build/todo.txt.tmp build/todo.txt
+	mkdir -p build/$(ITER)
+	cp build/todo_all.txt build/todo.txt build/$(ITER)/
 
 # XXX: conider moving to script
 run:

--- a/fuzzers/056-rempips/generate.py
+++ b/fuzzers/056-rempips/generate.py
@@ -12,7 +12,7 @@ ignpip = set()
 todo = set()
 
 print("Loading todo from ../todo.txt.")
-with open("../todo.txt", "r") as f:
+with open("../../todo.txt", "r") as f:
     for line in f:
         line = tuple(line.strip().split("."))
         verbose and print('todo', line)

--- a/fuzzers/int_loop.mk
+++ b/fuzzers/int_loop.mk
@@ -50,9 +50,11 @@ build/$(PIP_TYPE)_l.txt: $(XRAY_DIR)/fuzzers/piplist.tcl
 
 # Used 1) to see if we are done 2) pips to try in generate.tcl
 build/todo.txt: build/$(PIP_TYPE)_l.txt $(XRAY_DIR)/fuzzers/int_maketodo.py
-	python3 $(XRAY_DIR)/fuzzers/int_maketodo.py --pip-type $(PIP_TYPE) $(MAKETODO_FLAGS) >build/todo_all.txt
+	python3 $(XRAY_DIR)/fuzzers/int_maketodo.py --pip-type $(PIP_TYPE) $(MAKETODO_FLAGS) |sort >build/todo_all.txt
 	cat build/todo_all.txt | sort -R | head -n$(TODO_N) > build/todo.txt.tmp
 	mv build/todo.txt.tmp build/todo.txt
+	mkdir -p build/$(ITER)
+	cp build/todo_all.txt build/todo.txt build/$(ITER)/
 
 # XXX: conider moving to script
 run:

--- a/fuzzers/int_loop.sh
+++ b/fuzzers/int_loop.sh
@@ -59,8 +59,6 @@ while true; do
         exit 1
     fi
 
-    cp build/todo.txt todo/${i}.txt;
-    cp build/todo_all.txt todo/${i}_all.txt;
     if ${MAKE} ITER=$i database; then
         if $iter_pushdb ; then
             ${MAKE} pushdb


### PR DESCRIPTION
Odd. I thought I had fixed this, but evidently not. Regression from saving all the iterations, which adds another directory level. I think this bug only exists when you ran "make" outside of "make run", but I've also updated Makefiles to fix that as well

I've also sorted todo_all.txt to make diffing iterations easier