### PR TITLE
Dbfixup fix

### DIFF
--- a/fuzzers/050-intpips/Makefile
+++ b/fuzzers/050-intpips/Makefile
@@ -26,13 +26,14 @@ database: $(SPECIMENS_OK)
 	${XRAY_MASKMERGE} build/mask_clbll_r.db $(shell find build -name segdata_int_r.txt)
 	${XRAY_MASKMERGE} build/mask_clblm_l.db $(shell find build -name segdata_int_l.txt)
 	${XRAY_MASKMERGE} build/mask_clblm_r.db $(shell find build -name segdata_int_r.txt)
+	# Keep a copy to track iter progress
+	# Also is pre-fixup, which drops and converts
+	cp build/segbits_int_l.db build/$(ITER)/segbits_int_l.db
+	cp build/segbits_int_r.db build/$(ITER)/segbits_int_r.db
 # May be undersolved
 ifneq ($(QUICK),Y)
 	${XRAY_DBFIXUP} --db-root build --clb-int
 endif
-	# Keep a copy to track iter progress
-	cp build/segbits_int_l.db build/$(ITER)/segbits_int_l.db
-	cp build/segbits_int_r.db build/$(ITER)/segbits_int_r.db
 
 pushdb:
 	${XRAY_MERGEDB} int_l build/segbits_int_l.db

--- a/fuzzers/int_loop.mk
+++ b/fuzzers/int_loop.mk
@@ -27,13 +27,14 @@ export FUZDIR=$(shell pwd)
 database: $(SPECIMENS_OK)
 	${XRAY_SEGMATCH} $(SEGMATCH_FLAGS) -o build/segbits_int_l.db $(shell find build -name segdata_int_l.txt)
 	${XRAY_SEGMATCH} $(SEGMATCH_FLAGS) -o build/segbits_int_r.db $(shell find build -name segdata_int_r.txt)
+	# Keep a copy to track iter progress
+	# Also is pre-fixup, which drops and converts
+	cp build/segbits_int_l.db build/$(ITER)/segbits_int_l.db
+	cp build/segbits_int_r.db build/$(ITER)/segbits_int_r.db
 # May be undersolved
 ifneq ($(QUICK),Y)
 	${XRAY_DBFIXUP} --db-root build --clb-int
 endif
-	# Keep a copy to track iter progress
-	cp build/segbits_int_l.db build/$(ITER)/segbits_int_l.db
-	cp build/segbits_int_r.db build/$(ITER)/segbits_int_r.db
 
 pushdb:
 	${XRAY_MERGEDB} int_l build/segbits_int_l.db

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -234,3 +234,12 @@ def gen_fuzz_states(nvals):
     for i in range(nvals):
         mask = (1 << i)
         yield int(bool(bits & mask))
+
+
+def add_bool_arg(parser, yes_arg, default=False, **kwargs):
+    dashed = yes_arg.replace('--', '')
+    dest = dashed.replace('-', '_')
+    parser.add_argument(
+        yes_arg, dest=dest, action='store_true', default=default, **kwargs)
+    parser.add_argument(
+        '--no-' + dashed, dest=dest, action='store_false', **kwargs)


### PR DESCRIPTION
Fixes https://github.com/SymbiFlow/prjxray/issues/363

Regression from moving dbfixup to db instead of pushdb target. This is due to MERGEDB implicitly/silently filtering out unresolved entries. Solved by making --clb-int allow dropping unresolved entries, since this type of fuzzer often has them