### PR TITLE
gen_part_base_yaml.cc: Added the possibility to read FAR registers

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,8 +16,8 @@ target_link_libraries(gen_part_base_yaml
 	absl::span
 	libprjxray
 	yaml-cpp
+	gflags
 )
-
 add_executable(xc7patch xc7patch.cc)
 target_link_libraries(xc7patch
 	absl::strings


### PR DESCRIPTION
This PR add possibility to analyze FAR registers in the bitstream

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>