### PR TITLE
001-part-yaml: Modified script and tools to generate Zynq YAML.

### DIFF
--- a/fuzzers/001-part-yaml/Makefile.specimen
+++ b/fuzzers/001-part-yaml/Makefile.specimen
@@ -1,5 +1,5 @@
-part.yaml: design.debug.bit
-	${XRAY_TOOLS_DIR}/gen_part_base_yaml $< > $@
+part.yaml: design.perframecrc.bit
+	${XRAY_TOOLS_DIR}/gen_part_base_yaml $< -f > $@
 
-design.bit debug.perframecrc.bit design.debug.bit: ../generate.tcl
+design.bit design.perframecrc.bit: ../generate.tcl
 	vivado -mode batch -source ../generate.tcl

--- a/fuzzers/001-part-yaml/generate.tcl
+++ b/fuzzers/001-part-yaml/generate.tcl
@@ -22,13 +22,9 @@ write_checkpoint -force design.dcp
 # Write a normal bitstream that will do a singe FDRI write of all the frames.
 write_bitstream -force design.bit
 
-# Write a debug bitstream which writes each frame individually followed by
+# Write a perframecrc bitstream which writes each frame individually followed by
 # the frame address.  This shows where there are gaps in the frame address
 # space.
-set_property BITSTREAM.GENERAL.DEBUGBITSTREAM YES [current_design]
-write_bitstream -force design.debug.bit
-set_property BITSTREAM.GENERAL.DEBUGBITSTREAM NO [current_design]
-
 set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
 write_bitstream -force design.perframecrc.bit
 set_property BITSTREAM.GENERAL.PERFRAMECRC NO [current_design]


### PR DESCRIPTION
This PR modifies fuzzer 001 to use PERFRAMECRC botstream for xc7z family. This PR should be merged after the #375 is merged.
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>