### PR TITLE
reseg: segmatch only build dir

### DIFF
--- a/fuzzers/reseg.sh
+++ b/fuzzers/reseg.sh
@@ -14,6 +14,6 @@ for f in $(find -name design.bits) ; do
 done
 popd
 
-${XRAY_SEGMATCH} -o build/tmp.segbits $(find -name 'segdata_*.txt')
+${XRAY_SEGMATCH} -o build/tmp.segbits $(find build -name 'segdata_*.txt')
 cat build/tmp.segbits
 

--- a/fuzzers/reseg.sh
+++ b/fuzzers/reseg.sh
@@ -7,13 +7,13 @@ set -ex
 FUZDIR=$PWD
 pushd build
 
-for f in $(find -name design.bits) ; do
+for f in $(find -name design.bits |sort) ; do
      pushd $(dirname $f)
      python3 $FUZDIR/generate.py
      popd
 done
 popd
 
-${XRAY_SEGMATCH} -o build/tmp.segbits $(find build -name 'segdata_*.txt')
+${XRAY_SEGMATCH} -o build/tmp.segbits $(find build -name 'segdata_*.txt' |sort)
 cat build/tmp.segbits
 


### PR DESCRIPTION
generate.py is build dir only, but segmatch was greedy match on everything