### PR TITLE
hclkpips: HCLK bitstream workaround

### DIFF
--- a/fuzzers/058-hclkpips/generate.py
+++ b/fuzzers/058-hclkpips/generate.py
@@ -35,6 +35,12 @@ for arg in sys.argv[1:]:
             _, pip = pip.split("/")
             tile_type, pip = pip.split(".")
             src, dst = pip.split("->>")
+
+            # FIXME: workaround for https://github.com/SymbiFlow/prjxray/issues/392
+            if "CLB_IO_CLK" not in segmk.grid[tile]["bits"]:
+                print("WARNING: dropping tile %s" % tile)
+                continue
+
             tag = "%s.%s" % (dst, src)
             segmk.add_tile_tag(tile, tag, 1)
             if "HCLK_CK_BUFH" in src:

--- a/fuzzers/058-hclkpips/generate.tcl
+++ b/fuzzers/058-hclkpips/generate.tcl
@@ -21,10 +21,19 @@ route_design
 
 write_checkpoint -force design.dcp
 
-if [regexp "_001$" [pwd]] {set tile [lindex [filter [roi_tiles] {TILE_TYPE == HCLK_L}] 0]}
-if [regexp "_002$" [pwd]] {set tile [lindex [filter [roi_tiles] {TILE_TYPE == HCLK_R}] 0]}
-
 set net [get_nets o_OBUF]
+
+if [regexp "_001$" [pwd]] {
+    set hclk_tiles [filter [roi_tiles] {TYPE == HCLK_L}]
+} elseif [regexp "_002$" [pwd]] {
+    set hclk_tiles [filter [roi_tiles] {TYPE == HCLK_R}]
+} else {
+    error "unknown specimen"
+}
+
+# set tile [randsample_list 1 $hclk_tiles]
+set tile [lindex $hclk_tiles end]
+puts "Selected tile $tile"
 set pips [get_pips -of_objects $tile]
 
 for {set i 0} {$i < [llength $pips]} {incr i} {


### PR DESCRIPTION
Mitigation for https://github.com/SymbiFlow/prjxray/issues/392

Still testing a bit, but "probably works". Solves the issue for now by selecting a different tile to play with. The current tile is at the far left, which is currently unsolved. By selecting the last tile, we are at the right (I think) which is currently solved