### PR TITLE
055-gnd: fix bad makefile target

### DIFF
--- a/fuzzers/055-gnd/Makefile
+++ b/fuzzers/055-gnd/Makefile
@@ -19,12 +19,12 @@ pushdb:
 	${XRAY_MERGEDB} int_l build/segbits_int_l.db
 	${XRAY_MERGEDB} int_r build/segbits_int_r.db
 
-$(SPECIMENS_OK): todo.txt
+$(SPECIMENS_OK): build/todo.txt
 	mkdir -p build
 	bash generate.sh $(subst /OK,,$@)
 	touch $@
 
-todo.txt:
+build/todo.txt:
 	mkdir -p build
 	echo "INT_L.GFAN0.GND_WIRE" >  build/todo.txt
 	echo "INT_L.GFAN1.GND_WIRE" >> build/todo.txt

--- a/fuzzers/055-gnd/generate.tcl
+++ b/fuzzers/055-gnd/generate.tcl
@@ -21,7 +21,7 @@ route_design
 
 # write_checkpoint -force design.dcp
 
-set fp [open "../../todo.txt" r]
+set fp [open "../todo.txt" r]
 set todo_lines {}
 for {gets $fp line} {$line != ""} {gets $fp line} {
     lappend todo_lines [split $line .]


### PR DESCRIPTION
This was a bad interaction with some stale files, causing mismatch between my local builds and the build server