### PR TITLE
missing json import

### DIFF
--- a/fuzzers/074-dump_all/reduce_site_types.py
+++ b/fuzzers/074-dump_all/reduce_site_types.py
@@ -11,6 +11,7 @@ import prjxray.lib
 import os
 import os.path
 import re
+import json
 
 from utils import xjson
 


### PR DESCRIPTION
fixes following. Although xjson is used to dump, json is still needed to load

```
 + python3 reduce_site_types.py --output_dir output
Traceback (most recent call last):
  File "reduce_site_types.py", line 63, in <module>
    main()
  File "reduce_site_types.py", line 42, in main
    instance_site_type = json.load(f)
NameError: name 'json' is not defined
Makefile:16: recipe for target 'specimen_001/OK' failed
make[2]: *** [specimen_001/OK] Error 1
make[2]: Leaving directory '/mnt/m10_2/buffer/prjxray.2/fuzzers/074-dump_all'
Makefile:20: recipe for target 'run' failed
make[1]: *** [run] Error 2
make[1]: Leaving directory '/mnt/m10_2/buffer/prjxray.2/fuzzers/074-dump_all'
Makefile:49: recipe for target '074-dump_all/run.ok' failed
make: *** [074-dump_all/run.ok] Error 2
```