### PR TITLE
introduce vivado wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ More documentation can be found published on [prjxray ReadTheDocs site](http://p
 # Quickstart Guide
 
 Install Vivado 2017.2 (2017.3 has a known compatibility issue, see
-https://github.com/SymbiFlow/prjxray/issues/14). Then source the settings
-script, ie
+https://github.com/SymbiFlow/prjxray/issues/14). Then set the environment variable
+XRAY_VIVADO_SETTINGS to point to the settings64.sh file of the installed vivado version, ie
 
-    source /opt/Xilinx/Vivado/2017.2/settings64.sh
+    export XRAY_VIVADO_SETTINGS=/opt/Xilinx/Vivado/2017.2/settings64.sh
 
 Pull submodules:
 

--- a/experiments/clbpips/generate.sh
+++ b/experiments/clbpips/generate.sh
@@ -5,7 +5,7 @@ source ${XRAY_GENHEADER}
 
 echo '`define SEED 32'"'h$(echo $1 | md5sum | cut -c1-8)" > setseed.vh
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 ../generate.py

--- a/experiments/example/generate.sh
+++ b/experiments/example/generate.sh
@@ -73,7 +73,7 @@ close \$fp
 EOT
 
 rm -rf design design.log
-vivado -nojournal -log design.log -mode batch -source design.tcl
+${XRAY_VIVADO} -nojournal -log design.log -mode batch -source design.tcl
 
 #${XRAY_BITREAD} -o design_roi.bits -z -y design_roi_partial.bit
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit

--- a/experiments/gndvcc/Makefile
+++ b/experiments/gndvcc/Makefile
@@ -17,7 +17,7 @@ $(SPECIMENS_OK): todo.txt
 	touch $@
 
 todo.txt:
-	vivado -mode batch -source piplist.tcl
+	${XRAY_VIVADO} -mode batch -source piplist.tcl
 	python3 maketodo.py | sort -R | head -n10 > todo.txt
 
 clean:

--- a/experiments/gndvcc/generate.sh
+++ b/experiments/gndvcc/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 ../generate.py

--- a/experiments/pipsroute/Makefile
+++ b/experiments/pipsroute/Makefile
@@ -21,7 +21,7 @@ $(SPECIMENS_OK): todo.txt
 	touch $@
 
 todo.txt:
-	vivado -mode batch -source piplist.tcl
+	${XRAY_VIVADO} -mode batch -source piplist.tcl
 	python3 maketodo.py > todo.txt
 
 clean:

--- a/experiments/pipsroute/generate.sh
+++ b/experiments/pipsroute/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 for x in design_[0-9][0-9][0-9].bit; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o ${x}s -z -y $x

--- a/fuzzers/001-part-yaml/Makefile.specimen
+++ b/fuzzers/001-part-yaml/Makefile.specimen
@@ -2,4 +2,4 @@ part.yaml: design.perframecrc.bit
 	${XRAY_TOOLS_DIR}/gen_part_base_yaml $< -f > $@
 
 design.bit design.perframecrc.bit: ../generate.tcl
-	vivado -mode batch -source ../generate.tcl
+	${XRAY_VIVADO} -mode batch -source ../generate.tcl

--- a/fuzzers/005-tilegrid/fuzzaddr/generate.sh
+++ b/fuzzers/005-tilegrid/fuzzaddr/generate.sh
@@ -10,7 +10,7 @@ if [ -f $FUZDIR/top.py ] ; then
     XRAY_DATABASE_ROOT=$FUZDIR/../build/basicdb python3 $FUZDIR/top.py >top.v
 fi
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 test -z "$(fgrep CRITICAL vivado.log)"
 
 for x in design*.bit; do

--- a/fuzzers/005-tilegrid/generate.sh
+++ b/fuzzers/005-tilegrid/generate.sh
@@ -5,7 +5,7 @@ PRJ=$2
 export FUZDIR=$PWD
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source $FUZDIR/generate_$PRJ.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate_$PRJ.tcl
 test -z "$(fgrep CRITICAL vivado.log)"
 
 if [ $PRJ != "tiles" ] ; then

--- a/fuzzers/007-timing/minitest/test_unique/generate.sh
+++ b/fuzzers/007-timing/minitest/test_unique/generate.sh
@@ -5,5 +5,5 @@ set -ex
 source ${XRAY_GENHEADER}
 TIMFUZ_DIR=$XRAY_DIR/fuzzers/007-timing
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 

--- a/fuzzers/007-timing/projects/oneblinkw/generate.sh
+++ b/fuzzers/007-timing/projects/oneblinkw/generate.sh
@@ -3,6 +3,6 @@
 set -ex
 source ../generate.sh
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 timing_txt2csv
 

--- a/fuzzers/007-timing/projects/picorv32/generate.sh
+++ b/fuzzers/007-timing/projects/picorv32/generate.sh
@@ -3,6 +3,6 @@
 set -ex
 source ../generate.sh
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 timing_txt2csv
 

--- a/fuzzers/007-timing/projects/placelut/generate.sh
+++ b/fuzzers/007-timing/projects/placelut/generate.sh
@@ -6,6 +6,6 @@ source ${XRAY_GENHEADER}
 TIMFUZ_DIR=$XRAY_DIR/fuzzers/007-timing
 
 python ../generate.py --sdx 4 --sdy 4  >top.v
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 python3 $TIMFUZ_DIR/timing_txt2csv.py --speed-json $TIMFUZ_DIR/speed/build/speed.json --out timing4.csv timing4.txt
 

--- a/fuzzers/007-timing/projects/placelut_fb/generate.sh
+++ b/fuzzers/007-timing/projects/placelut_fb/generate.sh
@@ -4,6 +4,6 @@ set -ex
 source ../generate.sh
 
 python ../generate.py --sdx 4 --sdy 4  >top.v
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 timing_txt2csv
 

--- a/fuzzers/007-timing/projects/placelut_ff_fb/generate.sh
+++ b/fuzzers/007-timing/projects/placelut_ff_fb/generate.sh
@@ -4,6 +4,6 @@ set -ex
 source ../generate.sh
 
 python ../generate.py --sdx 4 --sdy 4  >top.v
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 timing_txt2csv
 

--- a/fuzzers/007-timing/speed/Makefile
+++ b/fuzzers/007-timing/speed/Makefile
@@ -2,7 +2,7 @@ all: build/speed.json
 
 build/node.txt: speed_json.py generate.tcl
 	mkdir -p build
-	cd build && vivado -mode batch -source ../generate.tcl
+	cd build && ${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 build/speed.json: build/node.txt
 	cd build && python ../speed_json.py speed_model.txt node.txt speed.json

--- a/fuzzers/007-timing/timgrid/Makefile
+++ b/fuzzers/007-timing/timgrid/Makefile
@@ -2,7 +2,7 @@ all: build/timgrid.json
 
 build/timgrid.txt: generate.tcl
 	mkdir -p build
-	cd build && vivado -mode batch -source ../generate.tcl
+	cd build && ${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 build/timgrid.json: build/timgrid.txt
 	cd build && python3 ../tile_txt2json.py --speed-json ../../speed/build/speed.json timgrid.txt timgrid-s.json

--- a/fuzzers/007-timing/timgrid/generate.sh
+++ b/fuzzers/007-timing/timgrid/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 for x in design*.bit; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o ${x}s -z -y $x

--- a/fuzzers/010-lutinit/generate.sh
+++ b/fuzzers/010-lutinit/generate.sh
@@ -5,7 +5,7 @@ source ${XRAY_GENHEADER}
 
 echo '`define SEED 32'"'h$(echo $1 | md5sum | cut -c1-8)" > setseed.vh
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 
 for i in 0 1 2; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design_$i.bits -z -y design_$i.bit

--- a/fuzzers/012-clbn5ffmux/generate.sh
+++ b/fuzzers/012-clbn5ffmux/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ex
-if [ $(vivado -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then echo "FIXME: requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"; exit 1; fi
+if [ $(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then echo "FIXME: requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"; exit 1; fi
 source ${XRAY_DIR}/utils/top_generate.sh
 

--- a/fuzzers/015-clbnffmux/generate.sh
+++ b/fuzzers/015-clbnffmux/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ex
-if [ $(vivado -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then echo "FIXME: requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"; exit 1; fi
+if [ $(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then echo "FIXME: requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"; exit 1; fi
 source ${XRAY_DIR}/utils/top_generate.sh
 

--- a/fuzzers/016-clbnoutmux/generate.sh
+++ b/fuzzers/016-clbnoutmux/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ex
-if [ $(vivado -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then echo "FIXME: requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"; exit 1; fi
+if [ $(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then echo "FIXME: requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"; exit 1; fi
 source ${XRAY_DIR}/utils/top_generate.sh
 

--- a/fuzzers/025-bram-config/minitest/runme.sh
+++ b/fuzzers/025-bram-config/minitest/runme.sh
@@ -12,7 +12,7 @@ cd $BUILD_DIR
 
 export TOP_V=$SRC_DIR/top.v
 
-vivado -mode batch -source $SRC_DIR/runme.tcl
+${XRAY_VIVADO} -mode batch -source $SRC_DIR/runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 

--- a/fuzzers/026-bram-data/generate.sh
+++ b/fuzzers/026-bram-data/generate.sh
@@ -6,7 +6,7 @@ FUZDIR=$PWD
 source ${XRAY_GENHEADER}
 
 python3 $FUZDIR/top.py >top.v
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 test -z "$(fgrep CRITICAL vivado.log)"
 
 for x in design*.bit; do

--- a/fuzzers/026-bram-data/minitest/runme.sh
+++ b/fuzzers/026-bram-data/minitest/runme.sh
@@ -12,7 +12,7 @@ cd $BUILD_DIR
 
 export TOP_V=$SRC_DIR/top.v
 
-vivado -mode batch -source $SRC_DIR/runme.tcl
+${XRAY_VIVADO} -mode batch -source $SRC_DIR/runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 

--- a/fuzzers/030-iob/minitest/runme.sh
+++ b/fuzzers/030-iob/minitest/runme.sh
@@ -12,7 +12,7 @@ cd $BUILD_DIR
 
 export TOP_V=$SRC_DIR/top.v
 
-vivado -mode batch -source $SRC_DIR/runme.tcl
+${XRAY_VIVADO} -mode batch -source $SRC_DIR/runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 

--- a/fuzzers/030-iob/minitest/runme_tcl.sh
+++ b/fuzzers/030-iob/minitest/runme_tcl.sh
@@ -12,7 +12,7 @@ cd $BUILD_DIR
 
 export TOP_V=$SRC_DIR/tcl.v
 
-vivado -mode batch -source $SRC_DIR/$PROJECT.tcl
+${XRAY_VIVADO} -mode batch -source $SRC_DIR/$PROJECT.tcl
 for x in design*.bit; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o ${x}s -z -y $x
 done

--- a/fuzzers/050-intpips/Makefile
+++ b/fuzzers/050-intpips/Makefile
@@ -65,7 +65,7 @@ $(SPECIMENS_OK): build/todo.txt
 
 build/pips_int_l.txt: $(XRAY_DIR)/fuzzers/piplist.tcl
 	mkdir -p build/$(ITER)
-	cd build && vivado -mode batch -source $(XRAY_DIR)/fuzzers/piplist.tcl
+	cd build && ${XRAY_VIVADO} -mode batch -source $(XRAY_DIR)/fuzzers/piplist.tcl
 
 build/todo.txt: build/pips_int_l.txt $(XRAY_DIR)/fuzzers/int_maketodo.py
 # Doesn't pushdb until very end. Compare against db so far

--- a/fuzzers/050-intpips/generate.sh
+++ b/fuzzers/050-intpips/generate.sh
@@ -7,7 +7,7 @@ source ${XRAY_GENHEADER}
 
 echo '`define SEED 32'"'h$(echo $1 | md5sum | cut -c1-8)" > setseed.vh
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 $FUZDIR/generate.py

--- a/fuzzers/051-imuxlout/generate.sh
+++ b/fuzzers/051-imuxlout/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 ../generate.py

--- a/fuzzers/052-clkin/generate.sh
+++ b/fuzzers/052-clkin/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 ../generate.py

--- a/fuzzers/053-ctrlin/generate.sh
+++ b/fuzzers/053-ctrlin/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 ../generate.py

--- a/fuzzers/054-gfan/generate.sh
+++ b/fuzzers/054-gfan/generate.sh
@@ -4,7 +4,7 @@ echo "test: $PWD"
 FUZDIR=$PWD
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 ../generate.py

--- a/fuzzers/056-rempips/generate.sh
+++ b/fuzzers/056-rempips/generate.sh
@@ -3,7 +3,7 @@
 FUZDIR=$PWD
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 python3 $FUZDIR/generate.py

--- a/fuzzers/057-bipips/generate.sh
+++ b/fuzzers/057-bipips/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-while ! vivado -mode batch -source ../generate.tcl; do
+while ! ${XRAY_VIVADO} -mode batch -source ../generate.tcl; do
 	rm -rf design*
 done
 

--- a/fuzzers/058-hclkpips/generate.sh
+++ b/fuzzers/058-hclkpips/generate.sh
@@ -2,7 +2,7 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 
 for x in design_*.bit; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o ${x}s -z -y ${x}

--- a/fuzzers/071-ppips/generate.sh
+++ b/fuzzers/071-ppips/generate.sh
@@ -2,5 +2,5 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 

--- a/fuzzers/072-ordered_wires/generate.sh
+++ b/fuzzers/072-ordered_wires/generate.sh
@@ -2,4 +2,4 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl

--- a/fuzzers/073-get_counts/generate.sh
+++ b/fuzzers/073-get_counts/generate.sh
@@ -2,4 +2,4 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl

--- a/fuzzers/074-dump_all/generate.sh
+++ b/fuzzers/074-dump_all/generate.sh
@@ -2,6 +2,6 @@
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source ../generate.tcl
+${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 cd .. && ./generate_after_dump.sh

--- a/fuzzers/100-dsp-mskpat/generate.sh
+++ b/fuzzers/100-dsp-mskpat/generate.sh
@@ -4,7 +4,7 @@ set -ex
 
 source ${XRAY_GENHEADER}
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 
 for i in {10..29}; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design_${i}.bits -z -y design_${i}.bit

--- a/fuzzers/int_loop.mk
+++ b/fuzzers/int_loop.mk
@@ -62,7 +62,7 @@ $(SPECIMENS_OK): build/todo.txt
 
 build/$(PIP_TYPE)_l.txt: $(XRAY_DIR)/fuzzers/piplist.tcl
 	mkdir -p build/$(ITER)
-	cd build && vivado -mode batch -source $(PIPLIST_TCL)
+	cd build && ${XRAY_VIVADO} -mode batch -source $(PIPLIST_TCL)
 
 # Used 1) to see if we are done 2) pips to try in generate.tcl
 build/todo.txt: build/$(PIP_TYPE)_l.txt $(XRAY_DIR)/fuzzers/int_maketodo.py build/database/seeded

--- a/gridinfo/runme.sh
+++ b/gridinfo/runme.sh
@@ -50,7 +50,7 @@ source tiledata.tcl
 EOT
 
 rm -f design.log
-vivado -nojournal -log design.log -mode batch -source design.tcl
+${XRAY_VIVADO} -nojournal -log design.log -mode batch -source design.tcl
 
 {
 	sed -e '/^--tiledata--/ { s/[^ ]* //; p; }; d;' design.log

--- a/minitests/clbconfigs/runme.sh
+++ b/minitests/clbconfigs/runme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 ${XRAY_SEGPRINT} design.bits SLICE_X16Y100 SLICE_X16Y101 SLICE_X16Y102 SLICE_X16Y103

--- a/minitests/clkbuf/runme.sh
+++ b/minitests/clkbuf/runme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 ${XRAY_SEGPRINT} -bzd design.bits > design.segs

--- a/minitests/eccbits/runme.sh
+++ b/minitests/eccbits/runme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -z -y -C -o design.bits design.bit
 grep -h _050_ design.bits | cut -f4 -d_ | sort | uniq -c

--- a/minitests/fixedpnr/runme.sh
+++ b/minitests/fixedpnr/runme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 for ff in fdre fdse fdce fdce_inv fdpe ldce ldpe; do
     ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design_$ff.bits -z -y design_$ff.bit
     ${XRAY_SEGPRINT} -z design_$ff.bits >design_$ff.seg

--- a/minitests/lvb_long_mux/runme.sh
+++ b/minitests/lvb_long_mux/runme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design_a.bits -z -y design_a.bit
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design_b.bits -z -y design_b.bit
 ${XRAY_SEGPRINT} design_a.bits INT_L_X12Y132 INT_L_X14Y132 INT_L_X16Y132

--- a/minitests/partial_reconfig_flow/Makefile
+++ b/minitests/partial_reconfig_flow/Makefile
@@ -18,25 +18,25 @@
 # feature.  inv.v is used as a sample reconfiguration design as one is
 # required to generate a partial reconfiguration design.
 harness_synth.dcp: harness_synthesize.tcl harness.v
-	vivado -mode batch -source harness_synthesize.tcl
+	${XRAY_VIVADO} -mode batch -source harness_synthesize.tcl
 
 harness_impl.dcp: harness_synth.dcp inv_synth.dcp harness_implement.tcl
-	vivado -mode batch -source harness_implement.tcl
+	${XRAY_VIVADO} -mode batch -source harness_implement.tcl
 
 # Synthesize an ROI design
 %_synth.dcp: %.v roi_synthesize.tcl
-	vivado -mode batch -source roi_synthesize.tcl -tclargs $< $@
+	${XRAY_VIVADO} -mode batch -source roi_synthesize.tcl -tclargs $< $@
 
 # Implement an ROI design
 %_impl.dcp: %_synth.dcp harness_impl.dcp roi_implement.tcl
-	vivado -mode batch -source roi_implement.tcl -tclargs $< $@
+	${XRAY_VIVADO} -mode batch -source roi_implement.tcl -tclargs $< $@
 
 # Generate bitstreams from an implemented design.  Two bitstreams are
 # generated: one containing a complete design including the harness (.bit) and
 # one that only contains the frames that implement the ROI design
 # (_roi_partial.bit).
 %.bit: %_impl.dcp write_bitstream.tcl
-	vivado -mode batch -source write_bitstream.tcl -tclargs $< $@
+	${XRAY_VIVADO} -mode batch -source write_bitstream.tcl -tclargs $< $@
 %_roi_partial.bit: %.bit ;
 
 # Conversions between various formats.

--- a/minitests/picorv32-v/runme.sh
+++ b/minitests/picorv32-v/runme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 ${XRAY_SEGPRINT} -z -D design.bits  >design.txt

--- a/minitests/picorv32-y/runme.sh
+++ b/minitests/picorv32-y/runme.sh
@@ -2,7 +2,7 @@
 
 set -ex
 yosys run_yosys.ys
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 ${XRAY_SEGPRINT} -z -D design.bits  >design.txt

--- a/minitests/roi_harness/runme.sh
+++ b/minitests/roi_harness/runme.sh
@@ -52,7 +52,7 @@ cat >defines.v <<EOF
 \`endif
 EOF
 
-vivado -mode batch -source ../runme.tcl
+${XRAY_VIVADO} -mode batch -source ../runme.tcl
 test -z "$(fgrep CRITICAL vivado.log)"
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit

--- a/minitests/switchboxes/runme.sh
+++ b/minitests/switchboxes/runme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o routes.bits -z -y routes.bit
 ${XRAY_SEGPRINT} routes.bits INT_L_X12Y119 INT_L_X12Y117 INT_L_X12Y115

--- a/minitests/tiles_wires_pips/runme.sh
+++ b/minitests/tiles_wires_pips/runme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-vivado -mode batch -source runme.tcl
+${XRAY_VIVADO} -mode batch -source runme.tcl
 echo "=========================================================="
 md5sum wires_{INT,CLBLL,CLBLM}_[LR]_*.txt | sed -re 's,X[0-9]+Y[0-9]+,XY,' | sort | uniq -c | sort -k3
 echo "=========================================================="

--- a/minitests/util/runme.sh
+++ b/minitests/util/runme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-vivado -mode batch -source $XRAY_DIR/minitests/util/runme.tcl
+${XRAY_VIVADO} -mode batch -source $XRAY_DIR/minitests/util/runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 ${XRAY_SEGPRINT} -z -D design.bits  >design.txt

--- a/utils/environment.sh
+++ b/utils/environment.sh
@@ -32,4 +32,4 @@ export XRAY_BITTOOL="${XRAY_TOOLS_DIR}/bittool"
 export XRAY_BLOCKWIDTH="python3 ${XRAY_UTILS_DIR}/blockwidth.py"
 export XRAY_PARSEDB="python3 ${XRAY_UTILS_DIR}/parsedb.py"
 export XRAY_TCL_REFORMAT="${XRAY_UTILS_DIR}/tcl-reformat.sh"
-
+export XRAY_VIVADO="${XRAY_UTILS_DIR}/vivado.sh"

--- a/utils/top_generate.sh
+++ b/utils/top_generate.sh
@@ -12,7 +12,7 @@ if [ -f $FUZDIR/top.py ] ; then
     python3 $FUZDIR/top.py >top.v
 fi
 
-vivado -mode batch -source $FUZDIR/generate.tcl
+${XRAY_VIVADO} -mode batch -source $FUZDIR/generate.tcl
 test -z "$(fgrep CRITICAL vivado.log)"
 
 for x in design*.bit; do

--- a/utils/vivado.sh
+++ b/utils/vivado.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "${XRAY_VIVADO_SETTINGS:-/opt/Xilinx/Vivado/2017.2/settings64.sh}"
+
+vivado "$@"


### PR DESCRIPTION
This fixes the problem that when sourcing the vivado settings file the
library search path is modified resulting in non-vivado binaries not working
due to being dynamically linked against the vivado libraries instead of the
system ones.

Signed-off-by: Felix Held <felix-github@felixheld.de>