### PR TITLE
addrwidth utility

### DIFF
--- a/prjxray/bitstream.py
+++ b/prjxray/bitstream.py
@@ -1,3 +1,7 @@
+import json
+import os
+from prjxray import util
+
 # Break frames into WORD_SIZE bit words.
 WORD_SIZE_BITS = 32
 
@@ -71,3 +75,40 @@ def load_bitdata2(f):
 
         bitdata[frame][wordidx].add(bitidx)
     return bitdata
+
+
+def gen_part_base_addrs():
+    """
+    Return (block_type, top_bottom, cfg_row, cfg_col, frame_count)
+    Where:
+    -block_type ("bus"): typically CLB_IO_CLK, sometimes BLOCK_RAM
+    -top_bottom: either "top" or "bottom"
+    -cfg_row: a relative row
+    -cfg_col: a relative column
+    -frame_count: number of frames to fully configure this minor address
+
+    Example:
+    ('CLB_IO_CLK', 'bottom', 0, 3, 36)
+    ('BLOCK_RAM', 'top', 0, 1, 128)
+    ('CLB_IO_CLK', 'top', 1, 34, 28)
+    """
+    fn = os.getenv("XRAY_PART_YAML").replace(".yaml", ".json")
+    j = json.load(open(fn, "r"))
+    for tbk, tbv in j["global_clock_regions"].items():
+        for rowk, rowv in tbv["rows"].items():
+            for busk, busv in rowv["configuration_buses"].items():
+                for colk, colv in busv["configuration_columns"].items():
+                    yield (
+                        busk, tbk, int(rowk), int(colk), colv["frame_count"])
+
+
+def addr_bits2word(block_type, top_bottom, cfg_row, cfg_col, minor_addr):
+    """Convert a deconstructed address to a 32 bit word"""
+    # https://www.xilinx.com/support/documentation/user_guides/ug470_7Series_Config.pdf
+    ret = 0
+    ret |= util.block_type_s2i[block_type] << 23
+    ret |= {"top": 0, "bottom": 1}[top_bottom] << 22
+    ret |= cfg_row << 17
+    ret |= cfg_col << 7
+    ret |= minor_addr
+    return ret

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -137,6 +137,9 @@ block_type_i2s = {
     # special...maybe should error until we know what it is?
     # 3: 'RESERVED',
 }
+block_type_s2i = {}
+for k, v in block_type_i2s.items():
+    block_type_s2i[v] = k
 
 
 def addr2btype(base_addr):

--- a/utils/addrwidth.py
+++ b/utils/addrwidth.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import json
+from prjxray import bitstream
+
+
+def gen_addrs():
+    for block_type, top_bottom, cfg_row, cfg_col, frame_count in bitstream.gen_part_base_addrs(
+    ):
+        yield bitstream.addr_bits2word(
+            block_type, top_bottom, cfg_row, cfg_col, 0), frame_count
+
+
+def run(verbose=False):
+    for addr, frame_count in sorted(gen_addrs()):
+        print("0x%08X: %u" % (addr, frame_count))
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Print number of frames at a base address')
+    args = parser.parse_args()
+
+    run(verbose=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Prints out part yaml addresses as full 32 bit addresses instead of composite parts