### PR TITLE
Remove circular import dependency.

### DIFF
--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -1,7 +1,6 @@
 import os
 import re
 from .roi import Roi
-from .db import Database
 
 
 def get_db_root():
@@ -35,6 +34,7 @@ def slice_xy():
 
 
 def get_roi():
+    from .db import Database
     (x1, x2), (y1, y2) = roi_xy()
     db = Database(get_db_root())
     return Roi(db=db, x1=x1, x2=x2, y1=y1, y2=y2)


### PR DESCRIPTION
Fixes error if prjxray.db is imported directly:

```
$ python3
Python 3.5.4rc1 (default, Jul 25 2017, 08:53:34) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import prjxray.db
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/google/home/keithrothman/cat_x/prjxray/prjxray/db.py", line 3, in <module>
    from prjxray import grid
  File "/usr/local/google/home/keithrothman/cat_x/prjxray/prjxray/grid.py", line 3, in <module>
    from prjxray import segment_map
  File "/usr/local/google/home/keithrothman/cat_x/prjxray/prjxray/segment_map.py", line 2, in <module>
    from prjxray import bitstream
  File "/usr/local/google/home/keithrothman/cat_x/prjxray/prjxray/bitstream.py", line 3, in <module>
    from prjxray import util
  File "/usr/local/google/home/keithrothman/cat_x/prjxray/prjxray/util.py", line 4, in <module>
    from .db import Database
ImportError: cannot import name 'Database'
>>> 
```
