### PR TITLE
005-tilegrid/add_tdb.py: added frame check

### DIFF
--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -55,7 +55,7 @@ def parse_addr(line):
 def check_frames(frames):
     baseaddr = set()
     for frame in frames:
-        baseaddr.add(round(frame / 128))
+        baseaddr.add(frame // 128)
     assert len(baseaddr) == 1, "Multiple base addresses for the same tag"
 
 
@@ -67,16 +67,12 @@ def load_db(fn):
         parts = l.split(' ')
         tagstr = parts[0]
         addrlist = parts[1:]
-
         frames = list()
-
         for addrstr in addrlist:
             frame, wordidx, bitidx = parse_addr(addrstr)
             frames.append(frame)
-
-        # Check the frames base addresses
         check_frames(frames)
-        # Take the first bit in the list
+        # Take the first address in the list
         frame, wordidx, bitidx = parse_addr(addrlist[0])
 
         bitidx_up = False

--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -52,18 +52,33 @@ def parse_addr(line):
     return frame, wordidx, bitidx
 
 
+def check_frames(frames):
+    baseaddr = set()
+    for frame in frames:
+        baseaddr.add(round(frame / 128))
+    assert len(baseaddr) == 1, "Multiple base addresses for the same tag"
+
+
 def load_db(fn):
     for l in open(fn, "r"):
         l = l.strip()
         # FIXME: add offset to name
         # IOB_X0Y101.DFRAME:27.DWORD:3.DBIT:3 00020027_003_03
         parts = l.split(' ')
-        # FIXME: need to check that all bits in part have same baseaddr, for now only the first bit is taken
-        #assert len(parts) == 2, "Unresolved bit: %s" % l
         tagstr = parts[0]
-        addrstr = parts[1]
+        addrlist = parts[1:]
 
-        frame, wordidx, bitidx = parse_addr(addrstr)
+        frames = list()
+
+        for addrstr in addrlist:
+            frame, wordidx, bitidx = parse_addr(addrstr)
+            frames.append(frame)
+
+        # Check the frames base addresses
+        check_frames(frames)
+        # Take the first bit in the list
+        frame, wordidx, bitidx = parse_addr(addrlist[0])
+
         bitidx_up = False
 
         tparts = tagstr.split('.')


### PR DESCRIPTION
This PR solves issue #481. add_tdb.py now checks if all the bits in a same tag have the same base address and, if that is the case, the first of them is selected.