### PR TITLE
Support IOB tiles with only one site (IOB_SING)

### DIFF
--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -25,10 +25,12 @@ def add_tile_bits(
     bits = tile_db['bits']
     block_type = util.addr2btype(baseaddr)
 
-    assert 0 <= offset <= 100, offset
+    assert offset <= 100, (tile_name, offset)
+    # Few rare cases at X=0 for double width tiles split in half
+    assert offset >= 0 or "IOB" in tile_name, (tile_name, offset)
     assert 1 <= words <= 101
     assert offset + words <= 101, (
-        tile_db, offset + words, offset, words, block_type)
+        tile_name, offset + words, offset, words, block_type)
 
     baseaddr_str = '0x%08X' % baseaddr
 
@@ -148,8 +150,19 @@ def run(fn_in, fn_out, verbose=False):
             bitsj = tilej['bits']
             bt = util.addr2btype(frame)
             verbose and print("Add %s %08X_%03u" % (tile, frame, wordidx))
+            # Special case for half height IOB
+            if tile == "LIOB33_SING_X0Y149":
+                tile_words = 2
+            else:
+                tile_words = words
             add_tile_bits(
-                tile, tilej, frame, wordidx, frames, words, verbose=verbose)
+                tile,
+                tilej,
+                frame,
+                wordidx,
+                frames,
+                tile_words,
+                verbose=verbose)
 
     # Save
     json.dump(

--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -26,7 +26,7 @@ def add_tile_bits(
     block_type = util.addr2btype(baseaddr)
 
     assert offset <= 100, (tile_name, offset)
-    # Few rare cases at X=0 for double width tiles split in half
+    # Few rare cases at X=0 for double width tiles split in half => small negative offset
     assert offset >= 0 or "IOB" in tile_name, (tile_name, offset)
     assert 1 <= words <= 101
     assert offset + words <= 101, (

--- a/fuzzers/005-tilegrid/fuzzaddr/common.mk
+++ b/fuzzers/005-tilegrid/fuzzaddr/common.mk
@@ -1,5 +1,6 @@
 N ?= 10
 GENERATE_ARGS ?=
+GENERATE_PY ?= $(shell realpath ../fuzzaddr/generate.py)
 SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
 SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
 
@@ -9,7 +10,7 @@ build/segbits_tilegrid.tdb: $(SPECIMENS_OK)
 	${XRAY_SEGMATCH} -o build/segbits_tilegrid.tdb $$(find build -name "segdata_tilegrid.txt")
 
 $(SPECIMENS_OK):
-	GENERATE_ARGS=${GENERATE_ARGS} bash ../fuzzaddr/generate.sh $(subst /OK,,$@)
+	GENERATE_ARGS=${GENERATE_ARGS} GENERATE_PY=${GENERATE_PY} bash ../fuzzaddr/generate.sh $(subst /OK,,$@)
 	touch $@
 
 run:

--- a/fuzzers/005-tilegrid/fuzzaddr/generate.sh
+++ b/fuzzers/005-tilegrid/fuzzaddr/generate.sh
@@ -17,5 +17,5 @@ for x in design*.bit; do
 	${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o ${x}s -z -y $x
 done
 
-python3 $FUZDIR/../fuzzaddr/generate.py $GENERATE_ARGS >segdata_tilegrid.txt
+python3 $GENERATE_PY $GENERATE_ARGS >segdata_tilegrid.txt
 

--- a/fuzzers/005-tilegrid/generate_full.py
+++ b/fuzzers/005-tilegrid/generate_full.py
@@ -192,6 +192,7 @@ def make_segments(database, tiles_by_grid, tile_baseaddrs, verbose=False):
                 segtype=tile_type.lower(),
                 baseaddr=tile_baseaddrs.get(tile_name, None))
 
+        # bram config, does not include data
         def process_bram_dsp():
             for k in range(5):
                 if tile_type in ["BRAM_L", "DSP_L"]:
@@ -372,7 +373,9 @@ def seg_base_addr_lr_INT(database, segments, tiles_by_grid, verbose=False):
 
 
 def seg_base_addr_up_INT(database, segments, tiles_by_grid, verbose=False):
-    '''Populate segment base addresses: Up along INT/HCLK columns'''
+    '''
+    Populate segment base addresses: Up along INT/HCLK columns
+    '''
 
     verbose and print('')
     # Copy the initial list containing only base addresses
@@ -610,9 +613,10 @@ def run(json_in_fn, json_out_fn, tiles_fn, deltas_fns, verbose=False):
     tile_baseaddrs = make_tile_baseaddrs(tiles, site_baseaddr, verbose=verbose)
     tiles_by_grid = make_tiles_by_grid(tiles)
 
+    # Group related addresses (ex: INT and CLB)
+    # Base addresses will be propagated below
     segments = make_segments(
         database, tiles_by_grid, tile_baseaddrs, verbose=verbose)
-
     # Reference adjacent CLBs to locate adjacent tiles by known offsets
     seg_base_addr_lr_INT(database, segments, tiles_by_grid, verbose=verbose)
     seg_base_addr_up_INT(database, segments, tiles_by_grid, verbose=verbose)

--- a/fuzzers/005-tilegrid/iob/Makefile
+++ b/fuzzers/005-tilegrid/iob/Makefile
@@ -1,3 +1,4 @@
-N ?= 15
-GENERATE_ARGS?="--oneval KEEPER --dframe 27 --dword 3 --dbit 3"
+N ?= 16
+GENERATE_PY?=$(shell realpath generate.py)
+GENERATE_ARGS=""
 include ../fuzzaddr/common.mk

--- a/fuzzers/005-tilegrid/iob/generate.py
+++ b/fuzzers/005-tilegrid/iob/generate.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import re
+from prjxray import bitsmaker
+
+
+def mktag(tile, dframe, dword, dbit, multi=False):
+    # mimicing tag names, wasn't sure if it would break things otherwise
+    metastr = "DWORD:%u" % dword
+    if dbit is not None:
+        metastr += ".DBIT:%u" % dbit
+    if dframe is not None:
+        metastr += ".DFRAME:%02x" % dframe
+    if multi:
+        metastr += ".MULTI"
+    return "%s.%s" % (tile, metastr)
+
+
+def run(
+        fnout="/dev/stdout",
+        bits_fn="design.bits",
+        design_fn="design.csv",
+        oneval="KEEPER",
+        verbose=False):
+    """
+    LIOB33_SING_X0Y100  LIOB33_SING     00020026_000_28
+    LIOB33_X0Y101       LIOB33          00020027_003_03
+    LIOB33_X0Y103       LIOB33          00020027_007_03
+    LIOB33_X0Y105       LIOB33          00020027_011_03
+    ...
+    LIOB33_X0Y143       LIOB33          00020027_088_03
+    LIOB33_X0Y145       LIOB33          00020027_092_03
+    LIOB33_X0Y147       LIOB33          00020027_096_03
+    LIOB33_SING_X0Y149  LIOB33_SING     00020027_100_03
+    """
+
+    # convert either Y0 or Y1 position to relative offsets
+    dy2delta = {
+        # (dframe, dword, dbit)
+        0: (0x26, 0, 28),
+        1: (0x27, 3, 3),
+    }
+
+    tags = dict()
+    f = open(design_fn, 'r')
+    f.readline()
+    for l in f:
+        l = l.strip()
+        tile, val, site, site_type = l.split(',')[0:4]
+        # IOB_X0Y118 => 118 => 0
+        y = int(re.search(r"_X[0-9]+Y([0-9]+)", site).group(1))
+        dy = y % 2
+        drame, dword, dbit = dy2delta[dy]
+        tags[mktag(tile, drame, dword, dbit)] = val == oneval
+
+    bitsmaker.write(bits_fn, fnout, tags)
+
+
+if __name__ == "__main__":
+    run()

--- a/fuzzers/005-tilegrid/iob/generate.py
+++ b/fuzzers/005-tilegrid/iob/generate.py
@@ -17,16 +17,19 @@ def mktag(tile, dframe, dword, dbit, multi=False):
 
 
 def run(
-        fnout="/dev/stdout",
+        fnout="segdata_tilegrid.txt",
         bits_fn="design.bits",
         design_fn="design.csv",
         oneval="KEEPER",
         verbose=False):
     """
     LIOB33_SING_X0Y100  LIOB33_SING     00020026_000_28
-    LIOB33_X0Y101       LIOB33          00020027_003_03
+    LIOB33_X0Y101                       00020027_003_03
+    LIOB33_X0Y101                       00020026_004_28
     LIOB33_X0Y103       LIOB33          00020027_007_03
+    .
     LIOB33_X0Y105       LIOB33          00020027_011_03
+    .
     ...
     LIOB33_X0Y143       LIOB33          00020027_088_03
     LIOB33_X0Y145       LIOB33          00020027_092_03
@@ -37,8 +40,8 @@ def run(
     # convert either Y0 or Y1 position to relative offsets
     dy2delta = {
         # (dframe, dword, dbit)
-        0: (0x26, 0, 28),
-        1: (0x27, 3, 3),
+        0: (0x26, 2, 28),
+        1: (0x27, 1, 3),
     }
 
     tags = dict()

--- a/fuzzers/005-tilegrid/iob/generate.tcl
+++ b/fuzzers/005-tilegrid/iob/generate.tcl
@@ -32,7 +32,7 @@ proc loc_pins {} {
     set io_pin_sites [make_io_pin_sites]
 
     set fp [open "design.csv" w]
-    puts $fp "port,site,tile,pin,val"
+    puts $fp "port,site,site_type,tile,pin,val"
 
     puts "Looping"
     for {set idx 0} {$idx < [llength $pin_lines]} {incr idx} {
@@ -40,9 +40,10 @@ proc loc_pins {} {
         puts "$line"
 
         set site_str [lindex $line 0]
-        set pin_str [lindex $line 1]
-        set io [lindex $line 2]
-        set cell_str [lindex $line 3]
+        set site_type [lindex $line 1]
+        set pin_str [lindex $line 2]
+        set io [lindex $line 3]
+        set cell_str [lindex $line 4]
 
         # Have: site
         # Want: pin for site
@@ -73,7 +74,7 @@ proc loc_pins {} {
         }
         set_property PULLTYPE $val $port
         # puts "IOB $port $site $tile $pin $val"
-        puts $fp "$tile,$val,$site,$port,$pin"
+        puts $fp "$tile,$val,$site,$site_type,$port,$pin"
     }
     close $fp
 }

--- a/fuzzers/005-tilegrid/iob/top.py
+++ b/fuzzers/005-tilegrid/iob/top.py
@@ -12,7 +12,9 @@ from prjxray import verilog
 
 def gen_iobs():
     for _tile_name, site_name, site_type in util.get_roi().gen_sites(
-        ["IOB33M", "IOB33S"]):
+            # ["IOB33M", "IOB33S", "IOB33"]):
+            # we could also solve IOB33M, but its redundant
+        ["IOB33S", "IOB33"]):
         yield site_name, site_type
 
 
@@ -64,7 +66,8 @@ def run():
     assign_o(rand_site(), 'do[0]')
     # Now assign the rest randomly
     while len(remain_sites()):
-        if random.randint(0, 1):
+        # if random.randint(0, 1):
+        if 0:
             assign_i(rand_site(), 'di[%u]' % DIN_N)
         else:
             assign_o(rand_site(), 'do[%u]' % DOUT_N)

--- a/fuzzers/005-tilegrid/iob/top.py
+++ b/fuzzers/005-tilegrid/iob/top.py
@@ -11,24 +11,17 @@ from prjxray import verilog
 
 
 def gen_iobs():
-    '''
-    IOB33S: main IOB of a diff pair
-    IOB33M: secondary IOB of a diff pair
-    IOB33: not a diff pair. Relatively rare (at least in ROI...2 of them?)
-    Focus on IOB33S to start
-    '''
     for _tile_name, site_name, site_type in util.get_roi().gen_sites(
-            # ['IOB33', 'IOB33S']):
-            # FIXME: special cases on IOB33
-        ['IOB33S']):
+        ["IOB33M", "IOB33S"]):
         yield site_name, site_type
 
 
 def write_params(ports):
     pinstr = ''
-    for site, (name, dir_, cell) in sorted(ports.items(), key=lambda x: x[1]):
+    for site, (name, site_type, dir_, cell) in sorted(ports.items(),
+                                                      key=lambda x: x[1]):
         # pinstr += 'set_property -dict "PACKAGE_PIN %s IOSTANDARD LVCMOS33" [get_ports %s]' % (packpin, port)
-        pinstr += '%s,%s,%s,%s\n' % (site, name, dir_, cell)
+        pinstr += '%s,%s,%s,%s,%s\n' % (site, site_type, name, dir_, cell)
     open('params.csv', 'w').write(pinstr)
 
 
@@ -56,7 +49,7 @@ def run():
         assert site not in ports
         cell = "di_bufs[%u].ibuf" % DIN_N
         DIN_N += 1
-        ports[site] = (name, 'input', cell)
+        ports[site] = (name, iosites[site], 'input', cell)
 
     def assign_o(site, name):
         nonlocal DOUT_N
@@ -64,7 +57,7 @@ def run():
         assert site not in ports
         cell = "do_bufs[%u].obuf" % DOUT_N
         DOUT_N += 1
-        ports[site] = (name, 'output', cell)
+        ports[site] = (name, iosites[site], 'output', cell)
 
     # Assign at least one di and one do
     assign_i(rand_site(), 'di[0]')


### PR DESCRIPTION
Fixes https://github.com/SymbiFlow/prjxray/issues/341

These were held off because they generate some weird special cases I didn't want to think about at the time. So here's a proposed solution.

First, the problem: in a7, IOBs are typically in LIOB33 tiles. These have two IOB sites, just like a SLICE has several CLBs. However, unlike CLBs, these IOBs are sometimes split into LIOB33_SING tiles, which only have a single IOB33. The problem is that in some cases the single instance is the Y=1 case, which basically starts at word 2 in our LIOB33_SING tile (if you follow the pattern in LIOB33 or want a Y=0 and a Y=1 LIOB33_SING to have a consistent address space). The issue is that this actually occurs at FDRI word 0, meaning we essentially have a negative tile address (-2) if we want the reference bits, starting at address 2, to be in frame 0.

Sample tilegrid output from running this fuzzer:

```
//Special bottom entry
//its missing the Y=0 site
"LIOB33_SING_X0Y100": {
    "bits": {
        "CLB_IO_CLK": {
            "baseaddr": "0x00020000",
            "frames": 42,
            "height": 4,
            "offset": -2,
            "words": 4
        }
    },
//A typical entry
"LIOB33_X0Y101": {
    "bits": {
        "CLB_IO_CLK": {
            "baseaddr": "0x00020000",
            "frames": 42,
            "height": 4,
            "offset": 2,
            "words": 4
        }
    },
...
//Special bottom entry
//its missing the Y=1 site
"LIOB33_SING_X0Y149": {
    "bits": {
        "CLB_IO_CLK": {
            "baseaddr": "0x00020000",
            "frames": 42,
            "height": 2,
            "offset": 99,
            "words": 2
        }
    },
```

I ran segprint and the 030-iob fuzzer. Both seemed happy with this, so I'm inclined to commit this as is and move forward.