### PR TITLE
fuzzers: int: create empty DB if it doesn't exist

### DIFF
--- a/fuzzers/int_create_empty_db.sh
+++ b/fuzzers/int_create_empty_db.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+touch build/database/${XRAY_DATABASE}/segbits_clblm_l.db
+touch build/database/${XRAY_DATABASE}/segbits_clblm_r.db
+touch build/database/${XRAY_DATABASE}/segbits_clbll_l.db
+touch build/database/${XRAY_DATABASE}/segbits_clbll_r.db

--- a/fuzzers/int_loop.mk
+++ b/fuzzers/int_loop.mk
@@ -41,7 +41,7 @@ ifneq ($(QUICK),Y)
 	${XRAY_DBFIXUP} --db-root build --clb-int
 	# https://github.com/SymbiFlow/prjxray/issues/399
 	# Clobber existing .db to eliminate potential conflicts
-	cp ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/segbits_clb*.db build/database/${XRAY_DATABASE}
+	if [ -f ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/segbits_clb*.db ] ; then cp ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/segbits_clb*.db build/database/${XRAY_DATABASE}; else bash ${XRAY_DIR}/fuzzers/int_create_empty_db.sh; fi
 	XRAY_DATABASE_DIR=${FUZDIR}/build/database ${XRAY_MERGEDB} int_l build/segbits_int_l.db
 	XRAY_DATABASE_DIR=${FUZDIR}/build/database ${XRAY_MERGEDB} int_r build/segbits_int_r.db
 endif


### PR DESCRIPTION
05x series were failing when no DB was present. This prevented those fuzzers from being run separately. This PR fixes that.