### PR TITLE
pip (especially imuxlout) quick

### DIFF
--- a/fuzzers/int_loop.mk
+++ b/fuzzers/int_loop.mk
@@ -1,6 +1,8 @@
+TODO_N ?= 10
 # Number of spcimens
 ifeq ($(QUICK),Y)
-N ?= 1
+N = 1
+TODO_N = 3
 SEGMATCH_FLAGS=
 else
 # Should be at least the -m value
@@ -11,7 +13,6 @@ endif
 # Driven by int_loop.sh
 ITER ?= 1
 MAKETODO_FLAGS ?=
-TODO_N ?= 10
 PIP_TYPE?=pips_int
 PIPLIST_TCL?=$(XRAY_DIR)/fuzzers/piplist.tcl
 

--- a/fuzzers/piplist.tcl
+++ b/fuzzers/piplist.tcl
@@ -1,39 +1,51 @@
-create_project -force -part $::env(XRAY_PART) piplist piplist
-
-read_verilog $::env(XRAY_DIR)/fuzzers/piplist.v
-synth_design -top top
-
-set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports i]
-set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports o]
-
-create_pblock roi
-resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
-
-set_property CFGBVS VCCO [current_design]
-set_property CONFIG_VOLTAGE 3.3 [current_design]
-set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
-
-place_design
-route_design
-
-write_checkpoint -force piplist.dcp
-
 source "$::env(XRAY_DIR)/utils/utils.tcl"
 
-proc print_tile_pips {tile_type filename} {
-    set tile [lindex [get_tiles -filter "TYPE == $tile_type"] 0]
-    puts "Dumping PIPs for tile $tile ($tile_type) to $filename"
-    set fp [open $filename w]
-    foreach pip [lsort [get_pips -filter {IS_DIRECTIONAL} -of_objects [get_tiles $tile]]] {
-        set src [get_wires -uphill -of_objects $pip]
-        set dst [get_wires -downhill -of_objects $pip]
-        if {[llength [get_nodes -uphill -of_objects [get_nodes -of_objects $dst]]] != 1} {
-            puts $fp "$tile_type.[regsub {.*/} $dst ""].[regsub {.*/} $src ""]"
-        }
-    }
-    close $fp
+proc build_project {} {
+    create_project -force -part $::env(XRAY_PART) piplist piplist
+
+    read_verilog $::env(XRAY_DIR)/fuzzers/piplist.v
+    synth_design -top top
+
+    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports i]
+    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports o]
+
+    create_pblock roi
+    resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI)"
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+    place_design
+    route_design
+
+    write_checkpoint -force piplist.dcp
 }
 
-print_tile_pips INT_L pips_int_l.txt
-print_tile_pips INT_R pips_int_r.txt
-puts "Done"
+proc dump_pips {} {
+    proc print_tile_pips {tile_type filename} {
+        set tile [lindex [get_tiles -filter "TYPE == $tile_type"] 0]
+        puts "Dumping PIPs for tile $tile ($tile_type) to $filename"
+        set fp [open $filename w]
+        foreach pip [lsort [get_pips -filter {IS_DIRECTIONAL} -of_objects [get_tiles $tile]]] {
+            set src [get_wires -uphill -of_objects $pip]
+            set dst [get_wires -downhill -of_objects $pip]
+            if {[llength [get_nodes -uphill -of_objects [get_nodes -of_objects $dst]]] != 1} {
+                puts $fp "$tile_type.[regsub {.*/} $dst ""].[regsub {.*/} $src ""]"
+            }
+        }
+        close $fp
+    }
+
+    print_tile_pips INT_L pips_int_l.txt
+    print_tile_pips INT_R pips_int_r.txt
+    puts "Done"
+
+}
+
+proc run {} {
+    build_project
+    dump_pips
+}
+
+run


### PR DESCRIPTION
Recently imuxlout got some rework which included things like adding a riscv and increasing the batch size from 10 to 50 pips. I suspected this might be slowing down quick runs, so I looked into tuning to keep builds fast

Results:
  * QUICK=N: IP
  * QUICK=Y (pre-commit): ? not sure if recorded
  * Also reduce todo from 50 to 3: real    5m45.993s
  * Also reduce the number of tiles we dump: real    2m24.778s

Although this was primarily targeted at 50, the first optimization should also reduce other fuzzers from 10 to 3, which should speed them up slightly.
