### PR TITLE
utils: add cleandb tool

### DIFF
--- a/utils/cleandb.py
+++ b/utils/cleandb.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import sys, re
+import os
+from prjxray import util
+
+
+def run(globaldb, localdb, verbose=False):
+
+    local_db_files = list()
+    work_db_files = list()
+
+    # get DB files
+
+    global_entries = {}
+    local_entries = {}
+    final_entries = {}
+
+    verbose and print("removing %s from %s" % (localdb, globaldb))
+    # parse global db
+    for line, (tag, bits, mode) in util.parse_db_lines(globaldb):
+        global_entries[tag] = bits
+    # parse local db
+    for line, (tag, bits, mode) in util.parse_db_lines(localdb):
+        local_entries[tag] = bits
+
+    for entry in global_entries:
+        if entry not in local_entries:
+            final_entries[entry] = global_entries[entry]
+        else:
+            verbose and print("Removing entry %s" % entry)
+
+    util.write_db_lines(globaldb, final_entries)
+
+
+def main():
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Remove partial DB from global DB")
+    parser.add_argument('--verbose', action='store_true', help='')
+    parser.add_argument(
+        '--localdb', action='store', help='Path to work database')
+    parser.add_argument(
+        '--globaldb', action='store', help='Path to global database')
+
+    args = parser.parse_args()
+
+    run(args.globaldb, args.localdb, args.verbose)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a tool for removing partial DB from a global one. This is useful when a certain fuzzer is rerun during development