### PR TITLE
Increase N for NFFMUX and NOUTMUX to prevent false matches.

### DIFF
--- a/fuzzers/015-clb-nffmux/Makefile
+++ b/fuzzers/015-clb-nffmux/Makefile
@@ -1,4 +1,4 @@
-N := 1
+N := 3
 CLB_DBFIXUP=Y
 include ../clb.mk
 

--- a/fuzzers/016-clb-noutmux/Makefile
+++ b/fuzzers/016-clb-noutmux/Makefile
@@ -1,4 +1,4 @@
-N := 1
+N := 3
 CLB_DBFIXUP=Y
 include ../clb.mk
 


### PR DESCRIPTION
Some INT bits were getting matched into the NFFMUX and NOUTMUX fuzzers.  Increasing N to 3 appears to prevent this.