### PR TITLE
Filter some CLB bits that the INT fuzzers tend to include due to high correlation

### DIFF
--- a/fuzzers/050-pip-seed/generate.py
+++ b/fuzzers/050-pip-seed/generate.py
@@ -61,5 +61,5 @@ for tile, pips_srcs_dsts in tiledata.items():
         elif src_dst[1] not in dsts:
             segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
 
-segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_PART'), 'INT'))
+segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_DATABASE'), 'INT'))
 segmk.write()

--- a/fuzzers/050-pip-seed/generate.py
+++ b/fuzzers/050-pip-seed/generate.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import re
+import os
 
 from prjxray.segmaker import Segmaker
+from prjxray.bitfilter import get_bitfilter
 
 segmk = Segmaker("design.bits")
 
@@ -39,7 +41,7 @@ with open("design.txt", "r") as f:
         # Okay: BYP_ALT0.VCC_WIRE
         # Skip: INT.IMUX13.VCC_WIRE, INT.IMUX_L43.VCC_WIRE
         if pnum == 1 or pdir == 0 or \
-                (src == "VCC_WIRE" and dst.startswith("IMUX")) or \
+                src == "VCC_WIRE" or \
                 re.match(r"^(L[HV]B?|G?CLK)(_L)?(_B)?[0-9]", src) or \
                 re.match(r"^(L[HV]B?|G?CLK)(_L)?(_B)?[0-9]", dst) or \
                 re.match(r"^(CTRL|GFAN)(_L)?[0-9]", dst):
@@ -59,5 +61,5 @@ for tile, pips_srcs_dsts in tiledata.items():
         elif src_dst[1] not in dsts:
             segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
 
-segmk.compile()
+segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_PART'), 'INT'))
 segmk.write()

--- a/fuzzers/055-pip-gnd/generate.py
+++ b/fuzzers/055-pip-gnd/generate.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import re
+import os
 
 from prjxray.segmaker import Segmaker
+from prjxray.bitfilter import get_bitfilter
 
 segmk = Segmaker("design.bits")
 
@@ -53,5 +55,5 @@ for tile, pips_srcs_dsts in tiledata.items():
         elif src_dst[1] not in dsts:
             segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
 
-segmk.compile()
+segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_PART'), 'INT'))
 segmk.write()

--- a/fuzzers/055-pip-gnd/generate.py
+++ b/fuzzers/055-pip-gnd/generate.py
@@ -55,5 +55,5 @@ for tile, pips_srcs_dsts in tiledata.items():
         elif src_dst[1] not in dsts:
             segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
 
-segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_PART'), 'INT'))
+segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_DATABASE'), 'INT'))
 segmk.write()

--- a/fuzzers/int_generate.py
+++ b/fuzzers/int_generate.py
@@ -86,5 +86,5 @@ for tile, pips_srcs_dsts in tiledata.items():
         elif src_dst[1] not in dsts:
             segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
 
-segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_PART'), 'INT'))
+segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_DATABASE'), 'INT'))
 segmk.write()

--- a/fuzzers/int_generate.py
+++ b/fuzzers/int_generate.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
+from __future__ import print_function
+
+import os
+
 from prjxray.segmaker import Segmaker
+from prjxray.bitfilter import get_bitfilter
 import argparse
 
 parser = argparse.ArgumentParser(description="Generate int segfiles")
@@ -81,5 +86,5 @@ for tile, pips_srcs_dsts in tiledata.items():
         elif src_dst[1] not in dsts:
             segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
 
-segmk.compile()
+segmk.compile(bitfilter=get_bitfilter(os.getenv('XRAY_PART'), 'INT'))
 segmk.write()

--- a/prjxray/bitfilter.py
+++ b/prjxray/bitfilter.py
@@ -1,5 +1,7 @@
 class Bitfilter(object):
-    def __init__(self, frames_to_include=None, frames_to_exclude=[], bits_to_exclude=[]):
+    def __init__(
+            self, frames_to_include=None, frames_to_exclude=[],
+            bits_to_exclude=[]):
         self.frames_to_include = frames_to_include
         self.frames_to_exclude = frames_to_exclude
         self.bits_to_exclude = bits_to_exclude
@@ -17,16 +19,19 @@ class Bitfilter(object):
 
         return True
 
+
 BITFILTERS = {
-        ('artix7', 'INT'): Bitfilter(
-            frames_to_exclude=[
-                31,
-                ],
-            bits_to_exclude=[
-                #
-                (0, 36)
-                ]),
-        }
+    ('artix7', 'INT'):
+    Bitfilter(
+        frames_to_exclude=[
+            31,
+        ],
+        bits_to_exclude=[
+            #
+            (0, 36)
+        ]),
+}
+
 
 def get_bitfilter(part, tile):
     """ Returns bitfilter for specified part and tile.

--- a/prjxray/bitfilter.py
+++ b/prjxray/bitfilter.py
@@ -1,0 +1,37 @@
+class Bitfilter(object):
+    def __init__(self, frames_to_include=None, frames_to_exclude=[], bits_to_exclude=[]):
+        self.frames_to_include = frames_to_include
+        self.frames_to_exclude = frames_to_exclude
+        self.bits_to_exclude = bits_to_exclude
+
+    def filter(self, frame, bit):
+        if self.frames_to_include is not None:
+            if frame in self.frames_to_include:
+                return True
+
+        if frame in self.frames_to_exclude:
+            return False
+
+        if (frame, bit) in self.bits_to_exclude:
+            return False
+
+        return True
+
+BITFILTERS = {
+        ('artix7', 'INT'): Bitfilter(
+            frames_to_exclude=[
+                31,
+                ],
+            bits_to_exclude=[
+                #
+                (0, 36)
+                ]),
+        }
+
+def get_bitfilter(part, tile):
+    """ Returns bitfilter for specified part and tile.
+
+    Either returns bitfilter to specified part and tile type, or the default
+    bitfilter, which includes all bits.
+    """
+    return BITFILTERS.get((part, tile), None)

--- a/prjxray/bitfilter.py
+++ b/prjxray/bitfilter.py
@@ -39,4 +39,8 @@ def get_bitfilter(part, tile):
     Either returns bitfilter to specified part and tile type, or the default
     bitfilter, which includes all bits.
     """
-    return BITFILTERS.get((part, tile), None)
+    key = (part, tile)
+    if key in BITFILTERS:
+        return BITFILTERS[key].filter
+    else:
+        return None

--- a/prjxray/bitfilter.py
+++ b/prjxray/bitfilter.py
@@ -24,7 +24,7 @@ BITFILTERS = {
     ('artix7', 'INT'):
     Bitfilter(
         frames_to_exclude=[
-            31,
+            30, 31,
         ],
         bits_to_exclude=[
             #

--- a/prjxray/bitfilter.py
+++ b/prjxray/bitfilter.py
@@ -24,7 +24,8 @@ BITFILTERS = {
     ('artix7', 'INT'):
     Bitfilter(
         frames_to_exclude=[
-            30, 31,
+            30,
+            31,
         ],
         bits_to_exclude=[
             #


### PR DESCRIPTION
Also prohibit matching VCC_WIRE pips, they are expected to all be default PIPs.