### PR TITLE
01x CLB rerun if pushdb fails

### DIFF
--- a/fuzzers/011-clb-ffconfig/top.py
+++ b/fuzzers/011-clb-ffconfig/top.py
@@ -1,11 +1,14 @@
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
 from prims import *
 
-CLBN = 600
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 600 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 f = open("top.txt", "w")

--- a/fuzzers/012-clb-n5ffmux/top.py
+++ b/fuzzers/012-clb-n5ffmux/top.py
@@ -1,9 +1,12 @@
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 40
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 40 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 

--- a/fuzzers/013-clb-ncy0/top.py
+++ b/fuzzers/013-clb-ncy0/top.py
@@ -1,9 +1,12 @@
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 400
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 400 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 
@@ -107,7 +110,7 @@ module clb_NCY0_O5 (input clk, input [7:0] din, output [7:0] dout);
     always @(*) begin
         s = din[7:4];
         s[N] = o6;
-        
+
         di = {din[3:0]};
         di[N] = o5;
     end

--- a/fuzzers/014-clb-ffsrcemux/top.py
+++ b/fuzzers/014-clb-ffsrcemux/top.py
@@ -5,7 +5,10 @@ import re
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 600
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 600 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 

--- a/fuzzers/015-clb-nffmux/top.py
+++ b/fuzzers/015-clb-nffmux/top.py
@@ -1,9 +1,12 @@
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 400
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 400 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 

--- a/fuzzers/016-clb-noutmux/top.py
+++ b/fuzzers/016-clb-noutmux/top.py
@@ -1,9 +1,12 @@
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 400
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 400 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 

--- a/fuzzers/017-clb-precyinit/top.py
+++ b/fuzzers/017-clb-precyinit/top.py
@@ -5,7 +5,10 @@ import re
 from prjxray import verilog
 from prjxray import util
 
-CLBN = 400
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 400 + int(INCREMENT)
 SLICEX, SLICEY = util.site_xy_minmax([
     'SLICEL',
     'SLICEM',

--- a/fuzzers/018-clb-ram/top.py
+++ b/fuzzers/018-clb-ram/top.py
@@ -15,12 +15,15 @@ SRLC32E_N
 Note: LUT6 was added to try to simplify reduction, although it might not be needed
 '''
 
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 50
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 50 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 

--- a/fuzzers/019-clb-ndi1mux/top.py
+++ b/fuzzers/019-clb-ndi1mux/top.py
@@ -1,9 +1,12 @@
-import random
+import os, random
 random.seed(0)
 from prjxray import util
 from prjxray import verilog
 
-CLBN = 50
+# INCREMENT is the amount of additional CLBN to be instantiated in the design.
+# This makes the fuzzer compilation more robust against failures.
+INCREMENT = os.getenv('CLBN', 0)
+CLBN = 50 + int(INCREMENT)
 print('//Requested CLBs: %s' % str(CLBN))
 
 

--- a/fuzzers/clb.mk
+++ b/fuzzers/clb.mk
@@ -4,6 +4,14 @@ CLB_DBFIXUP ?=
 # ie set to N if only for SLICEM
 SLICEL ?= Y
 
+# This set of variables are used to store the increment
+# in the number of CLBs in case they are not enough and
+# the generated database is inconsistent
+CLBN ?= 0
+INC ?= 50
+VAR ?= "CLBN=$$(($(CLBN) + $(INC)))"
+ENV_VAR ?= "CLBN=$(CLBN)"
+
 include ../fuzzer.mk
 
 database: build/segbits_clbx.db

--- a/fuzzers/fuzzer.mk
+++ b/fuzzers/fuzzer.mk
@@ -2,26 +2,19 @@ N ?= 1
 SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
 SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
 ENV_VAR ?=
-VAR ?=
-ITER ?= 0
-MAX_ITER ?= 10
+FUZDIR ?= ${PWD}
 
 all: database
 
 $(SPECIMENS_OK):
+	echo ${ENV_VAR}
 	mkdir -p build
-	if [ -f `pwd`/generate.sh ]; then export $(ENV_VAR); bash `pwd`/generate.sh $(subst /OK,,$@); else bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@); fi
+	if [ -f $(FUZDIR)/generate.sh ]; then export $(ENV_VAR); bash $(FUZDIR)/generate.sh $(subst /OK,,$@); else bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@); fi
 
 run:
-	# If the database presents errors or is incomplete, the fuzzer is rerun.
-	# When it reaches the maximum number of iterations it fails.
-	@if [ $(ITER) -gt $(MAX_ITER) ]; then \
-		echo "Max Iterations reached. Fuzzer unsolvable."; \
-		exit 1; \
-	fi
 	$(MAKE) clean
 	$(MAKE) database
-	$(MAKE) pushdb || $(MAKE) $(VAR) ITER=$$(($(ITER) + 1)) run
+	$(MAKE) pushdb
 	touch run.ok
 
 clean:

--- a/fuzzers/fuzzer.mk
+++ b/fuzzers/fuzzer.mk
@@ -1,17 +1,27 @@
 N ?= 1
 SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
 SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
+ENV_VAR ?=
+VAR ?=
+ITER ?= 0
+MAX_ITER ?= 10
 
 all: database
 
 $(SPECIMENS_OK):
 	mkdir -p build
-	bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@)
+	if [ -f `pwd`/generate.sh ]; then export $(ENV_VAR); bash `pwd`/generate.sh $(subst /OK,,$@); else bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@); fi
 
 run:
+	# If the database presents errors or is incomplete, the fuzzer is rerun.
+	# When it reaches the maximum number of iterations it fails.
+	@if [ $(ITER) -gt $(MAX_ITER) ]; then \
+		echo "Max Iterations reached. Fuzzer unsolvable."; \
+		exit 1; \
+	fi
 	$(MAKE) clean
 	$(MAKE) database
-	$(MAKE) pushdb
+	$(MAKE) pushdb || $(MAKE) $(VAR) ITER=$$(($(ITER) + 1)) run
 	touch run.ok
 
 clean:


### PR DESCRIPTION
This PR solves https://github.com/SymbiFlow/prjxray/issues/534 issue and issues related to the CLB fuzzers for which the segmatch solver is unable to find a solution.

Basically the CLB fuzzers are now re-run whenever the pushdb fails because of a bad db file generation.
The top.py of the CLB fuzzers now adds to the CLBN variable an increment calculated in the clb.mk file.
The increment allows to have an higher probability of getting a suitable design for the fuzzer.

Mainly this was done to ensure the correct clb .db file generation with targets that do require more CLBs to be instantiated.