### PR TITLE
minitests: ROI harness: call python interpreter explicitly

### DIFF
--- a/minitests/roi_harness/runme.sh
+++ b/minitests/roi_harness/runme.sh
@@ -57,8 +57,8 @@ test -z "$(fgrep CRITICAL vivado.log)"
 
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 ${XRAY_SEGPRINT} -zd design.bits >design.segp
-${XRAY_DIR}/utils/bit2fasm.py --verbose design.bit > design.fasm
-${XRAY_DIR}/utils/fasm2frames.py design.fasm design.frm
+python3 ${XRAY_DIR}/utils/bit2fasm.py --verbose design.bit > design.fasm
+python3 ${XRAY_DIR}/utils/fasm2frames.py design.fasm design.frm
 python3 ../create_design_json.py --design_info_txt design_info.txt --design_txt design.txt --pad_wires design_pad_wires.txt > design.json
 
 # Hack to get around weird clock error related to clk net not found


### PR DESCRIPTION
The scripts do not have execution rights, so the build fails on calling them.
Explicit interpreter call solves the issue.

Signed-off-by: Karol Gugala <kgugala@antmicro.com>