### PR TITLE
Fuzzers: Makefile: use single colon target for run.ok targets

### DIFF
--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -9,7 +9,7 @@ FUZZONLY=N
 BITONLY=N
 
 define fuzzer
-all:: $(1)/run.ok
+all: $(1)/run.ok
 clean::
 	$$(MAKE) -C $(1) clean
 $(1)/run.ok: $(addsuffix /run.ok,$(2))


### PR DESCRIPTION
Fixes #568 . At least for a clean build.