### PR TITLE
fuzzers: 074-dump_all depends on 005-tilegrid.

### DIFF
--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -54,7 +54,7 @@ $(eval $(call fuzzer,071-ppips,057-pip-bi 058-pip-hclk 060-bram-cascades))
 ifneq ($(BITONLY),Y)
 $(eval $(call fuzzer,072-ordered_wires,))
 $(eval $(call fuzzer,073-get_counts,))
-$(eval $(call fuzzer,074-dump_all,072-ordered_wires))
+$(eval $(call fuzzer,074-dump_all,005-tilegrid 072-ordered_wires))
 endif
 endif
 $(eval $(call fuzzer,100-dsp-mskpat,005-tilegrid))


### PR DESCRIPTION
The `generate_grid.py` tool requires tilegrid.json to run.

Fixes #601.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>