### PR TITLE
checkdb: optimized script and added out-of-bound check

### DIFF
--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -1,7 +1,6 @@
 import os
 import re
 from .roi import Roi
-from prjxray.grid import BlockType
 
 
 def get_db_root():
@@ -198,8 +197,8 @@ def gen_tile_bits(tile_segbits, tile, strict=False, verbose=False):
             for bit in tile_segbits[block_type][tag]:
                 # 31_06
                 word_column, word_bit, isset = bit
-                assert word_column <= frames, "ERROR: bit out of bound --> word_column = %s; frames = %s" % (
-                    word_column, frames)
+                assert word_column <= frames, "ERROR: bit out of bound --> tag: %s; word_column = %s; frames = %s" % (
+                    tag, word_column, frames)
                 yield word_column + baseaddr, word_bit + bitbase, tag
 
 

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -3,6 +3,7 @@ import re
 from .roi import Roi
 from prjxray.grid import BlockType
 
+
 def get_db_root():
     # Used during tilegrid db bootstrap
     ret = os.getenv("XRAY_DATABASE_ROOT", None)
@@ -184,7 +185,8 @@ def gen_tile_bits(tile_segbits, tile, strict=False, verbose=False):
     '''
 
     for block_type in tile_segbits:
-        assert block_type.value in tile["bits"], "block type %s is not present in current tile" % block_type.value
+        assert block_type.value in tile[
+            "bits"], "block type %s is not present in current tile" % block_type.value
 
         block = tile["bits"][block_type.value]
 
@@ -196,7 +198,8 @@ def gen_tile_bits(tile_segbits, tile, strict=False, verbose=False):
             for bit in tile_segbits[block_type][tag]:
                 # 31_06
                 word_column, word_bit, isset = bit
-                assert word_column <= frames, "ERROR: bit out of bound --> word_column = %s; frames = %s" % (word_column, frames)
+                assert word_column <= frames, "ERROR: bit out of bound --> word_column = %s; frames = %s" % (
+                    word_column, frames)
                 yield word_column + baseaddr, word_bit + bitbase, tag
 
 

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -189,15 +189,19 @@ def gen_tile_bits(db_root, tilej, strict=False, verbose=False):
     for block_type, blockj in tilej["bits"].items():
         baseaddr = int(blockj["baseaddr"], 0)
         bitbase = 32 * blockj["offset"]
+        frames = tilej["bits"][block_type]["frames"]
 
         if block_type == "CLB_IO_CLK":
             fn = "%s/segbits_%s.db" % (db_root, tilej["type"].lower())
         else:
-            fn = "%s/segbits_%s.db.%s" % (
+            fn = "%s/segbits_%s.%s.db" % (
                 db_root, tilej["type"].lower(), block_type.lower())
         # tilegrid runs a lot earlier than fuzzers
         # may not have been created yet
         verbose and print("Check %s: %s" % (fn, os.path.exists(fn)))
+
+        # FIXME: some segbits files are not present and the strict check produces assertion errors
+        # e.g. segbits_cmt_top_r_lower_b.db
         if strict:
             assert os.path.exists(fn)
         elif not os.path.exists(fn):
@@ -208,6 +212,7 @@ def gen_tile_bits(db_root, tilej, strict=False, verbose=False):
             for bitstr in bits:
                 # 31_06
                 _bit_inv, (bit_addroff, bit_bitoff) = parse_tagbit(bitstr)
+                assert bit_addroff <= frames, "ERROR: bit out of bound"
                 yield (baseaddr + bit_addroff, bitbase + bit_bitoff, tag)
 
 

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -172,36 +172,6 @@ def addr2btype(base_addr):
     return block_type_i2s[block_type_i]
 
 
-def gen_tile_bits(tile_segbits, tile, strict=False, verbose=False):
-    '''
-    For given tile and corresponding db_file structure yield
-    (absolute address, absolute FDRI bit offset, tag)
-
-    db_file:
-    {'<block_type_1>': [<bit lines>], '<block_type_2>': [<bit lines>], ...}
-
-    For each tag bit in the corresponding block_type entry, calculate absolute address and bit offsets
-    '''
-
-    for block_type in tile_segbits:
-        assert block_type.value in tile[
-            "bits"], "block type %s is not present in current tile" % block_type.value
-
-        block = tile["bits"][block_type.value]
-
-        baseaddr = int(block["baseaddr"], 0)
-        bitbase = 32 * block["offset"]
-        frames = block["frames"]
-
-        for tag in tile_segbits[block_type]:
-            for bit in tile_segbits[block_type][tag]:
-                # 31_06
-                word_column, word_bit, isset = bit
-                assert word_column <= frames, "ERROR: bit out of bound --> tag: %s; word_column = %s; frames = %s" % (
-                    tag, word_column, frames)
-                yield word_column + baseaddr, word_bit + bitbase, tag
-
-
 def specn():
     # ex: build/specimen_001
     specdir = os.getenv("SPECDIR")

--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -17,7 +17,8 @@ import parsedb
 import glob
 
 
-def make_tile_mask(tile_segbits, tile_name, tilej, strict=False, verbose=False):
+def make_tile_mask(
+        tile_segbits, tile_name, tilej, strict=False, verbose=False):
     '''
     Return dict
     key: (address, bit index)

--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -17,7 +17,7 @@ import parsedb
 import glob
 
 
-def gen_tile_bits(tile_segbits, tile_bits, strict=False, verbose=False):
+def gen_tile_bits(tile_segbits, tile_bits):
     '''
     For given tile and corresponding db_file structure yield
     (absolute address, absolute FDRI bit offset, tag)
@@ -44,8 +44,7 @@ def gen_tile_bits(tile_segbits, tile_bits, strict=False, verbose=False):
                 yield word_column + baseaddr, word_bit + bitbase, tag
 
 
-def make_tile_mask(
-        tile_segbits, tile_name, tile_bits, strict=False, verbose=False):
+def make_tile_mask(tile_segbits, tile_name, tile_bits):
     '''
     Return dict
     key: (address, bit index)
@@ -57,8 +56,7 @@ def make_tile_mask(
     # We may want this to build them anyway
 
     ret = dict()
-    for absaddr, bitaddr, tag in gen_tile_bits(tile_segbits, tile_bits,
-                                               strict=strict, verbose=verbose):
+    for absaddr, bitaddr, tag in gen_tile_bits(tile_segbits, tile_bits):
         name = "%s.%s" % (tile_name, tag)
         ret.setdefault((absaddr, bitaddr), name)
     return ret
@@ -82,7 +80,7 @@ def parsedb_all(db_root, verbose=False):
     print("mask_*.db: %d okay" % files)
 
 
-def check_tile_overlap(db, db_root, strict=False, verbose=False):
+def check_tile_overlap(db, verbose=False):
     '''
     Verifies that no two tiles use the same bit
 
@@ -117,15 +115,10 @@ def check_tile_overlap(db, db_root, strict=False, verbose=False):
         if tiles_type_done[tile_type]:
             continue
 
-        mtile = make_tile_mask(
-            tile_segbits[tile_type],
-            tile_name,
-            tile_bits,
-            strict=strict,
-            verbose=verbose)
+        mtile = make_tile_mask(tile_segbits[tile_type], tile_name, tile_bits)
         verbose and print(
             "Checking %s, type %s, bits: %s" %
-            (tile_name, tilej["type"], len(mtile)))
+            (tile_name, tile_type, len(mtile)))
         if len(mtile) == 0:
             continue
 
@@ -149,7 +142,7 @@ def check_tile_overlap(db, db_root, strict=False, verbose=False):
     print("Checked %s tiles, %s bits" % (tiles_checked, len(mall)))
 
 
-def run(db_root, strict=False, verbose=False):
+def run(db_root, verbose=False):
     # Start by running a basic check on db files
     print("Checking individual .db...")
     parsedb_all(db_root, verbose=verbose)
@@ -167,7 +160,7 @@ def run(db_root, strict=False, verbose=False):
     verbose and print("")
 
     print("Checking aggregate dir...")
-    check_tile_overlap(db, db_root, strict=strict, verbose=verbose)
+    check_tile_overlap(db, verbose=verbose)
 
 
 def main():
@@ -177,11 +170,10 @@ def main():
         description="Parse a db repository, checking for consistency")
 
     util.db_root_arg(parser)
-    parser.add_argument('--strict', action='store_true', help='')
     parser.add_argument('--verbose', action='store_true', help='')
     args = parser.parse_args()
 
-    run(args.db_root, strict=args.strict, verbose=args.verbose)
+    run(args.db_root, verbose=args.verbose)
 
 
 if __name__ == '__main__':

--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -64,6 +64,7 @@ def check_tile_overlap(db, db_root, strict=False, verbose=False):
     Throw an exception if two tiles share an address
     '''
     mall = dict()
+    tiles_type_done = set()
 
     tiles_checked = 0
 
@@ -73,6 +74,10 @@ def check_tile_overlap(db, db_root, strict=False, verbose=False):
 
     for tile_name, tilej in db.tilegrid.items():
         # for tile_name, tilej in subtiles(["CLBLL_L_X14Y112", "INT_L_X14Y112"]):
+
+        if tilej['type'] in tiles_type_done or not tilej["bits"]:
+            continue
+        tiles_type_done.add(tilej['type'])
 
         mtile = make_tile_mask(
             db_root, tile_name, tilej, strict=strict, verbose=verbose)

--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -15,7 +15,7 @@ import os
 import parsedb
 #from prjxray import db as prjxraydb
 import glob
-import json
+
 
 def make_tile_mask(db_file, tile_name, tilej, strict=False, verbose=False):
     '''
@@ -108,22 +108,28 @@ def check_tile_overlap(db, db_root, strict=False, verbose=False):
             mall[tile_type] = {}
 
         mtile = make_tile_mask(
-            db_files[tile_type], tile_name, tilej, strict=strict, verbose=verbose)
+            db_files[tile_type],
+            tile_name,
+            tilej,
+            strict=strict,
+            verbose=verbose)
         verbose and print(
             "Checking %s, type %s, bits: %s" %
             (tile_name, tilej["type"], len(mtile)))
         if len(mtile) == 0:
             continue
 
-        collisions = set(mall[tile_type].keys()).intersection(set(mtile.keys()))
+        collisions = set(mall[tile_type].keys()).intersection(
+            set(mtile.keys()))
         if collisions:
             print("ERROR: %s collisions" % len(collisions))
             for ck in sorted(collisions):
                 addr, bitaddr = ck
                 word, bit = util.addr_bit2word(bitaddr)
                 print(
-                    "  %s: had %s, got %s" %
-                    (util.addr2str(addr, word, bit), mall[tile_type][ck], mtile[ck]))
+                    "  %s: had %s, got %s" % (
+                        util.addr2str(addr, word, bit), mall[tile_type][ck],
+                        mtile[ck]))
             raise ValueError("%s collisions" % len(collisions))
         mall[tile_type].update(mtile)
         tiles_checked += 1


### PR DESCRIPTION
This PR is to solve two issues:

- https://github.com/SymbiFlow/prjxray/issues/583: I have noticed that all the tiles are being checked. I have also seen that all the tiles with the same `tile_type` share the same bits, making it highly time consuming if there is the need to check every single one of them. This way the script is much faster, but I am not sure it is the best solution, because maybe some tiles of the same type have differences.
- https://github.com/SymbiFlow/prjxray/issues/575: during the extraction of the bits there is an assertion that checks whether the bit is consistent with the `frames` number of the tile.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>