### PR TITLE
checkdb.py: restored check on all previous tiles

### DIFF
--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -131,9 +131,8 @@ def check_tile_overlap(db, verbose=False):
                 addr, bitaddr = ck
                 word, bit = util.addr_bit2word(bitaddr)
                 print(
-                    "  %s: had %s, got %s" % (
-                        util.addr2str(addr, word, bit), mall[ck],
-                        mtile[ck]))
+                    "  %s: had %s, got %s" %
+                    (util.addr2str(addr, word, bit), mall[ck], mtile[ck]))
             raise ValueError("%s collisions" % len(collisions))
         mall.update(mtile)
         tiles_checked += 1

--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -110,8 +110,6 @@ def check_tile_overlap(db, verbose=False):
             else:
                 tiles_type_done[tile_type] = False
 
-            mall[tile_type] = {}
-
         if tiles_type_done[tile_type]:
             continue
 
@@ -124,7 +122,7 @@ def check_tile_overlap(db, verbose=False):
 
         collisions = set()
         for bits in mtile.keys():
-            if bits in mall[tile_type].keys():
+            if bits in mall.keys():
                 collisions.add(bits)
 
         if collisions:
@@ -134,10 +132,10 @@ def check_tile_overlap(db, verbose=False):
                 word, bit = util.addr_bit2word(bitaddr)
                 print(
                     "  %s: had %s, got %s" % (
-                        util.addr2str(addr, word, bit), mall[tile_type][ck],
+                        util.addr2str(addr, word, bit), mall[ck],
                         mtile[ck]))
             raise ValueError("%s collisions" % len(collisions))
-        mall[tile_type].update(mtile)
+        mall.update(mtile)
         tiles_checked += 1
     print("Checked %s tiles, %s bits" % (tiles_checked, len(mall)))
 


### PR DESCRIPTION
This PR is to restore the check on all the previous tiles instead of only the ones related to the same `tile_type`. The performance remains the same.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>