### PR TITLE
074-dump-all: stabilized naming of sites

### DIFF
--- a/fuzzers/074-dump_all/reduce_tile_types.py
+++ b/fuzzers/074-dump_all/reduce_tile_types.py
@@ -160,26 +160,26 @@ def check_wires(wires, sites, pips):
 
 
 def get_sites(tile, site_pin_node_to_wires):
-    min_x_coord, min_y_coord = prjxray.lib.find_origin_coordinate(
-        site['site'] for site in tile['sites'])
-
     for site in tile['sites']:
+        min_x_coord, min_y_coord = prjxray.lib.find_origin_coordinate(
+            site['site'], (site['site'] for site in tile['sites']))
+
         orig_site_name = site['site']
         coordinate = prjxray.lib.get_site_coordinate_from_name(orig_site_name)
 
-        x_coord = coordinate.x_coord
-        y_coord = coordinate.y_coord
+        x_coord = coordinate.x_coord - min_x_coord
+        y_coord = coordinate.y_coord - min_y_coord
 
         yield (
             {
                 'name':
-                'X{}Y{}'.format(x_coord - min_x_coord, y_coord - min_y_coord),
+                'X{}Y{}'.format(x_coord, y_coord),
                 'prefix':
                 coordinate.prefix,
                 'x_coord':
-                x_coord - min_x_coord,
+                x_coord,
                 'y_coord':
-                y_coord - min_y_coord,
+                y_coord,
                 'type':
                 site['type'],
                 'site_pins':

--- a/prjxray/lib.py
+++ b/prjxray/lib.py
@@ -183,17 +183,30 @@ def get_site_coordinate_from_name(name):
     )
 
 
-def find_origin_coordinate(site_names):
-    """ Find the coordinates of each site within the tile, and then subtract the
-      smallest coordinate to re-origin them all to be relative to the tile.
-  """
+def get_site_prefix_from_name(name):
+    """
+    Returns the prefix of a site from its name
+    """
+    coordinate = SITE_COORDINATE_PATTERN.match(name)
+    assert coordinate is not None, name
+
+    return coordinate.group(1)
+
+
+def find_origin_coordinate(site_name, site_names):
+    """
+    Find the coordinates of each site within the tile, and then subtract the
+    smallest coordinate to re-origin them all to be relative to the tile.
+    """
 
     x_coords = []
     y_coords = []
     for site in site_names:
         coordinate = get_site_coordinate_from_name(site)
-        x_coords.append(coordinate.x_coord)
-        y_coords.append(coordinate.y_coord)
+        site_name_prefix = get_site_prefix_from_name(site_name)
+        if coordinate.prefix == site_name_prefix:
+            x_coords.append(coordinate.x_coord)
+            y_coords.append(coordinate.y_coord)
 
     if len(x_coords) == 0 or len(y_coords) == 0:
         return 0, 0


### PR DESCRIPTION
This PR is to solve https://github.com/SymbiFlow/prjxray/issues/134. The naming was wrong because there was the assumption that all the sites in a tile were equal and had adjacent locations in the grid. This is untrue for some kind of tiles such as `BRAM`, `DSP` and some `CMT` related tile. 
With this fix the min_coordinated used to reduce all the site coordinates is calculated for each single `group` of sites in every tile.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>