### PR TITLE
Sort tiles and revamp gen_fuzz_states to be more efficient.

### DIFF
--- a/fuzzers/005-tilegrid/bram/Makefile
+++ b/fuzzers/005-tilegrid/bram/Makefile
@@ -1,4 +1,4 @@
-N ?= 30
+N ?= 12
 GENERATE_ARGS?="--oneval 1 --design params.csv --dword 2 --dframe 1B"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/bram/top.py
+++ b/fuzzers/005-tilegrid/bram/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
 

--- a/fuzzers/005-tilegrid/bram_block/Makefile
+++ b/fuzzers/005-tilegrid/bram_block/Makefile
@@ -1,4 +1,4 @@
-N ?= 30
+N ?= 12
 GENERATE_ARGS?="--oneval 1 --design params.csv --dword 0 --dframe 0"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/bram_block/generate.tcl
+++ b/fuzzers/005-tilegrid/bram_block/generate.tcl
@@ -5,16 +5,9 @@ proc run {} {
     read_verilog top.v
     synth_design -top top
 
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports clk]
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports stb]
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_ports di]
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
-
     set_property CFGBVS VCCO [current_design]
     set_property CONFIG_VOLTAGE 3.3 [current_design]
     set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
-
-    set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF]
 
     place_design
     route_design

--- a/fuzzers/005-tilegrid/bram_block/top.py
+++ b/fuzzers/005-tilegrid/bram_block/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
 

--- a/fuzzers/005-tilegrid/bram_block/top.py
+++ b/fuzzers/005-tilegrid/bram_block/top.py
@@ -13,7 +13,7 @@ def gen_sites():
         gridinfo = grid.gridinfo_at_loc(loc)
 
         for site_name, site_type in gridinfo.sites.items():
-            if site_type in ['RAMBFIFO36E1']:
+            if site_type in ['FIFO18E1']:
                 yield tile_name, site_name
 
 
@@ -25,28 +25,8 @@ def write_params(params):
 
 
 def run():
-    print(
-        '''
-module top(input clk, stb, di, output do);
-    localparam integer DIN_N = 8;
-    localparam integer DOUT_N = 8;
-
-    reg [DIN_N-1:0] din;
-    wire [DOUT_N-1:0] dout;
-
-    reg [DIN_N-1:0] din_shr;
-    reg [DOUT_N-1:0] dout_shr;
-
-    always @(posedge clk) begin
-        din_shr <= {din_shr, di};
-        dout_shr <= {dout_shr, din_shr[DIN_N-1]};
-        if (stb) begin
-            din <= din_shr;
-            dout_shr <= dout;
-        end
-    end
-
-    assign do = dout_shr[DOUT_N-1];
+    print('''
+module top();
     ''')
 
     params = {}
@@ -58,33 +38,13 @@ module top(input clk, stb, di, output do);
 
         print(
             '''
-            (* KEEP, DONT_TOUCH, LOC = "%s" *)
-            RAMB36E1 #(
-                    .INIT_00(256'b%u)
-                ) bram_%s (
-                    .CLKARDCLK(),
-                    .CLKBWRCLK(),
-                    .ENARDEN(),
-                    .ENBWREN(),
-                    .REGCEAREGCE(),
-                    .REGCEB(),
-                    .RSTRAMARSTRAM(),
-                    .RSTRAMB(),
-                    .RSTREGARSTREG(),
-                    .RSTREGB(),
-                    .ADDRARDADDR(),
-                    .ADDRBWRADDR(),
-                    .DIADI(),
-                    .DIBDI(),
-                    .DIPADIP(),
-                    .DIPBDIP(),
-                    .WEA(),
-                    .WEBWE(),
-                    .DOADO(),
-                    .DOBDO(),
-                    .DOPADOP(),
-                    .DOPBDOP());
-''' % (site_name, isone, site_name))
+            (* KEEP, DONT_TOUCH, LOC = "{site_name}" *)
+            RAMB18E1 #(
+                    .INIT_00(256'b{isone})
+                ) bram_{site_name} ();'''.format(
+                site_name=site_name,
+                isone=isone,
+            ))
 
     print("endmodule")
     write_params(params)

--- a/fuzzers/005-tilegrid/bram_int/Makefile
+++ b/fuzzers/005-tilegrid/bram_int/Makefile
@@ -1,4 +1,4 @@
-N ?= 30
+N ?= 15
 GENERATE_ARGS?="--oneval 0 --design params.csv --dword 1 --dframe 15"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/clb/Makefile
+++ b/fuzzers/005-tilegrid/clb/Makefile
@@ -1,4 +1,4 @@
-N ?= 30
+N ?= 20
 GENERATE_ARGS?="--oneval 1 --design params.csv --dword 0 --dframe 0"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/clb/top.py
+++ b/fuzzers/005-tilegrid/clb/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
         if gridinfo.tile_type in ['CLBLL_L', 'CLBLL_R', 'CLBLM_L', 'CLBLM_R']:

--- a/fuzzers/005-tilegrid/clb_int/Makefile
+++ b/fuzzers/005-tilegrid/clb_int/Makefile
@@ -1,4 +1,4 @@
-N ?= 30
+N ?= 20
 GENERATE_ARGS?="--oneval 0 --design params.csv --dword 1 --dframe 15"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/clb_int/top.py
+++ b/fuzzers/005-tilegrid/clb_int/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
         if gridinfo.tile_type in ['CLBLL_L', 'CLBLL_R', 'CLBLM_L', 'CLBLM_R']:

--- a/fuzzers/005-tilegrid/clk_hrow/top.py
+++ b/fuzzers/005-tilegrid/clk_hrow/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
         sites = []

--- a/fuzzers/005-tilegrid/dsp/Makefile
+++ b/fuzzers/005-tilegrid/dsp/Makefile
@@ -1,4 +1,4 @@
-N ?= 30
+N ?= 15
 GENERATE_ARGS?="--oneval 1 --design params.csv --dword 0 --dframe 1B"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/dsp/top.py
+++ b/fuzzers/005-tilegrid/dsp/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
         if gridinfo.tile_type in ['DSP_L', 'DSP_R']:

--- a/fuzzers/005-tilegrid/dsp_int/Makefile
+++ b/fuzzers/005-tilegrid/dsp_int/Makefile
@@ -1,4 +1,4 @@
-N ?= 10
+N ?= 17
 GENERATE_ARGS?="--oneval 0 --design params.csv --dword 1 --dframe 15"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/fifo_int/Makefile
+++ b/fuzzers/005-tilegrid/fifo_int/Makefile
@@ -1,4 +1,4 @@
-N ?= 16
+N ?= 20
 GENERATE_ARGS?="--oneval 0 --design params.csv --dword 0 --dframe 15"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/005-tilegrid/iob/Makefile
+++ b/fuzzers/005-tilegrid/iob/Makefile
@@ -1,3 +1,3 @@
-N ?= 35
-GENERATE_ARGS?="--oneval KEEPER --dframe 27 --dword 3 --dbit 3"
+N ?= 15
+GENERATE_ARGS?="--oneval 1 --design params.csv --dframe 26 --dword 1"
 include ../fuzzaddr/common.mk

--- a/fuzzers/005-tilegrid/iob/generate.tcl
+++ b/fuzzers/005-tilegrid/iob/generate.tcl
@@ -31,18 +31,13 @@ proc loc_pins {} {
     set pin_lines [load_pin_lines]
     set io_pin_sites [make_io_pin_sites]
 
-    set fp [open "design.csv" w]
-    puts $fp "port,site,tile,pin,val"
-
     puts "Looping"
     for {set idx 0} {$idx < [llength $pin_lines]} {incr idx} {
         set line [lindex $pin_lines $idx]
         puts "$line"
 
-        set site_str [lindex $line 0]
-        set pin_str [lindex $line 1]
-        set io [lindex $line 2]
-        set cell_str [lindex $line 3]
+        set site_str [lindex $line 2]
+        set pin_str [lindex $line 3]
 
         # Have: site
         # Want: pin for site
@@ -53,29 +48,9 @@ proc loc_pins {} {
         set port [get_ports $pin_str]
         set tile [get_tiles -of_objects $site]
 
-        set pin "FIXME"
         set pin [dict get $io_pin_sites $site]
-        #set pin [get_property PACKAGE_PIN $port]
-
-        #set cell [get_cells $cell_str]
-        # puts "LOCing cell $cell to site $site (from bel $pad_bel)"
-        # set_property LOC $site $cell
-
         set_property -dict "PACKAGE_PIN $pin IOSTANDARD LVCMOS33" $port
-
-
-        # list_property isn't working
-        # set keys [list_property_value PULLTYPE $port]
-        set keys "NONE KEEPER"
-        set val [randsample_list 1 $keys]
-        if { $val == "NONE" } {
-            set val ""
-        }
-        set_property PULLTYPE $val $port
-        # puts "IOB $port $site $tile $pin $val"
-        puts $fp "$tile,$val,$site,$port,$pin"
     }
-    close $fp
 }
 
 proc run {} {
@@ -83,17 +58,12 @@ proc run {} {
     read_verilog top.v
     synth_design -top top
 
-    # Mostly doesn't matter since IOB are special, but add anyway
-    create_pblock roi
-    add_cells_to_pblock [get_pblocks roi] [get_cells roi]
-    resize_pblock [get_pblocks roi] -add "$::env(XRAY_ROI_TILEGRID)"
-
     loc_pins
 
     set_property CFGBVS VCCO [current_design]
     set_property CONFIG_VOLTAGE 3.3 [current_design]
     set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
-    set_param tcl.collectionResultDisplayLimit 0
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-79}]
 
     place_design
     route_design

--- a/fuzzers/005-tilegrid/iob/top.py
+++ b/fuzzers/005-tilegrid/iob/top.py
@@ -49,25 +49,23 @@ module top(input wire [`N_DI-1:0] di);
     for idx, ((tile_name, site_name), isone) in enumerate(zip(
             sites, util.gen_fuzz_states(len(sites)))):
         params[tile_name] = (site_name, isone, "di[%u]" % idx)
-        print('''
+        print(
+            '''
     (* KEEP, DONT_TOUCH *)
     IBUF #(
     ) ibuf_{site_name} (
         .I(di[{idx}]),
         .O(di_buf[{idx}])
-        );'''.format(
-            site_name=site_name,
-            idx=idx))
+        );'''.format(site_name=site_name, idx=idx))
 
         if isone:
-            print('''
+            print(
+                '''
     (* KEEP, DONT_TOUCH *)
     PULLUP #(
     ) pullup_{site_name} (
         .O(di[{idx}])
-        );'''.format(
-            site_name=site_name,
-            idx=idx))
+        );'''.format(site_name=site_name, idx=idx))
 
     print("endmodule")
     write_params(params)

--- a/fuzzers/005-tilegrid/iob/top.py
+++ b/fuzzers/005-tilegrid/iob/top.py
@@ -1,17 +1,12 @@
-'''
-Generate a primitive to place at every I/O
-Unlike CLB tests, the LFSR for this is inside the ROI, not driving it
-'''
-
 import os
 import random
 random.seed(int(os.getenv("SEED"), 16))
 from prjxray import util
-from prjxray.db import Database
 from prjxray import verilog
+from prjxray.db import Database
 
 
-def gen_iobs():
+def gen_sites():
     '''
     IOB33S: main IOB of a diff pair
     IOB33M: secondary IOB of a diff pair
@@ -20,133 +15,62 @@ def gen_iobs():
     '''
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
 
         for site_name, site_type in gridinfo.sites.items():
-            if site_type in ['IOB33S']:
-                yield site_name, site_type
+            if site_type == 'IOB33S':
+                yield tile_name, site_name
 
 
-def write_params(ports):
+def write_params(params):
     pinstr = ''
-    for site, (name, dir_, cell) in sorted(ports.items(), key=lambda x: x[1]):
-        # pinstr += 'set_property -dict "PACKAGE_PIN %s IOSTANDARD LVCMOS33" [get_ports %s]' % (packpin, port)
-        pinstr += '%s,%s,%s,%s\n' % (site, name, dir_, cell)
+    for tile, (site, val, pin) in sorted(params.items()):
+        pinstr += '%s,%s,%s,%s\n' % (tile, val, site, pin)
     open('params.csv', 'w').write(pinstr)
 
 
 def run():
-    # All possible values
-    iosites = {}
-    for site_name, site_type in gen_iobs():
-        iosites[site_name] = site_type
-
-    # Assigned in this design
-    ports = {}
-    DIN_N = 0
-    DOUT_N = 0
-
-    def remain_sites():
-        return set(iosites.keys()) - set(ports.keys())
-
-    def rand_site():
-        '''Get a random, unused site'''
-        return random.choice(list(remain_sites()))
-
-    def assign_i(site, name):
-        nonlocal DIN_N
-
-        assert site not in ports
-        cell = "di_bufs[%u].ibuf" % DIN_N
-        DIN_N += 1
-        ports[site] = (name, 'input', cell)
-
-    def assign_o(site, name):
-        nonlocal DOUT_N
-
-        assert site not in ports
-        cell = "do_bufs[%u].obuf" % DOUT_N
-        DOUT_N += 1
-        ports[site] = (name, 'output', cell)
-
-    # Assign at least one di and one do
-    assign_i(rand_site(), 'di[0]')
-    assign_o(rand_site(), 'do[0]')
-    # Now assign the rest randomly
-    while len(remain_sites()):
-        if random.randint(0, 1):
-            assign_i(rand_site(), 'di[%u]' % DIN_N)
-        else:
-            assign_o(rand_site(), 'do[%u]' % DOUT_N)
-
-    write_params(ports)
-
+    sites = list(gen_sites())
     print(
         '''
-`define N_DI %u
-`define N_DO %u
+`define N_DI {}
 
-module top(input wire [`N_DI-1:0] di, output wire [`N_DO-1:0] do);
-    genvar i;
-
-    //Instantiate BUFs so we can LOC them
-
+module top(input wire [`N_DI-1:0] di);
     wire [`N_DI-1:0] di_buf;
-    generate
-        for (i = 0; i < `N_DI; i = i+1) begin:di_bufs
-            IBUF ibuf(.I(di[i]), .O(di_buf[i]));
-        end
-    endgenerate
+    '''.format(len(sites)))
 
-    wire [`N_DO-1:0] do_unbuf;
-    generate
-        for (i = 0; i < `N_DO; i = i+1) begin:do_bufs
-            OBUF obuf(.I(do_unbuf[i]), .O(do[i]));
-        end
-    endgenerate
+    params = {}
+    print('''
+        (* KEEP, DONT_TOUCH *)
+        LUT6 dummy_lut();''')
 
-    roi roi(.di(di_buf), .do(do_unbuf));
-endmodule
+    for idx, ((tile_name, site_name), isone) in enumerate(zip(
+            sites, util.gen_fuzz_states(len(sites)))):
+        params[tile_name] = (site_name, isone, "di[%u]" % idx)
+        print('''
+    (* KEEP, DONT_TOUCH *)
+    IBUF #(
+    ) ibuf_{site_name} (
+        .I(di[{idx}]),
+        .O(di_buf[{idx}])
+        );'''.format(
+            site_name=site_name,
+            idx=idx))
 
-//Arbitrary terminate into LUTs
-module roi(input wire [`N_DI-1:0] di, output wire [`N_DO-1:0] do);
-    genvar i;
+        if isone:
+            print('''
+    (* KEEP, DONT_TOUCH *)
+    PULLUP #(
+    ) pullup_{site_name} (
+        .O(di[{idx}])
+        );'''.format(
+            site_name=site_name,
+            idx=idx))
 
-    generate
-        for (i = 0; i < `N_DI; i = i+1) begin:dis
-            (* KEEP, DONT_TOUCH *)
-            LUT6 #(
-                    .INIT(64'h8000_0000_0000_0001)
-            ) lut (
-                    .I0(di[i]),
-                    .I1(di[i]),
-                    .I2(di[i]),
-                    .I3(di[i]),
-                    .I4(di[i]),
-                    .I5(di[i]),
-                    .O());
-        end
-    endgenerate
-
-    generate
-        for (i = 0; i < `N_DO; i = i+1) begin:dos
-            (* KEEP, DONT_TOUCH *)
-            LUT6 #(
-                    .INIT(64'h8000_0000_0000_0001)
-            ) lut (
-                    .I0(),
-                    .I1(),
-                    .I2(),
-                    .I3(),
-                    .I4(),
-                    .I5(),
-                    .O(do[i]));
-        end
-    endgenerate
-endmodule
-    ''' % (DIN_N, DOUT_N))
+    print("endmodule")
+    write_params(params)
 
 
 if __name__ == '__main__':

--- a/fuzzers/005-tilegrid/iob_int/Makefile
+++ b/fuzzers/005-tilegrid/iob_int/Makefile
@@ -1,3 +1,3 @@
-N ?= 35
+N ?= 16
 GENERATE_ARGS?="--oneval 0 --design params.csv --dframe 14 --dword 1"
 include ../fuzzaddr/common.mk

--- a/fuzzers/005-tilegrid/mmcm/Makefile
+++ b/fuzzers/005-tilegrid/mmcm/Makefile
@@ -1,4 +1,4 @@
-N ?= 2
+N ?= 5
 # Was expecting oneval 3, but bits might be inverted
 # FIXME: dword
 # Ex: 0002009D_029_15

--- a/fuzzers/005-tilegrid/mmcm/top.py
+++ b/fuzzers/005-tilegrid/mmcm/top.py
@@ -2,13 +2,17 @@ import os
 import random
 random.seed(int(os.getenv("SEED"), 16))
 from prjxray import util
-from prjxray import verilog
+from prjxray.db import Database
 
 
 def gen_sites():
-    for tile_name, site_name, _site_type in util.get_roi().gen_sites(
-        ['MMCME2_ADV']):
-        yield tile_name, site_name
+    db = Database(util.get_db_root())
+    grid = db.grid()
+    for tile_name in sorted(grid.tiles()):
+        gridinfo = grid.gridinfo_at_tilename(tile_name)
+        for site_name, site_type in gridinfo.sites.items():
+            if site_type in ['MMCME2_ADV']:
+                yield tile_name, site_name
 
 
 def write_params(params):
@@ -47,7 +51,6 @@ module top(input clk, stb, di, output do);
     # FIXME: can't LOC?
     # only one for now, worry about later
     sites = list(gen_sites())
-    assert len(sites) == 1, len(sites)
     for (tile_name, site_name), isone in zip(sites,
                                              util.gen_fuzz_states(len(sites))):
         # 0 is invalid

--- a/fuzzers/005-tilegrid/monitor/top.py
+++ b/fuzzers/005-tilegrid/monitor/top.py
@@ -8,7 +8,7 @@ from prjxray.db import Database
 def gen_sites():
     db = Database(util.get_db_root())
     grid = db.grid()
-    for tile_name in grid.tiles():
+    for tile_name in sorted(grid.tiles()):
         loc = grid.loc_of_tilename(tile_name)
         gridinfo = grid.gridinfo_at_loc(loc)
 

--- a/fuzzers/005-tilegrid/pll/Makefile
+++ b/fuzzers/005-tilegrid/pll/Makefile
@@ -1,6 +1,3 @@
-N ?= 2
-# Was expecting oneval 3, but bits might be inverted
-# FIXME: dword
-# Ex: 0002009C_077_16
-GENERATE_ARGS?="--oneval 2 --design params.csv --dframe 1C --dword 77 --dbit 16"
+N ?= 5
+GENERATE_ARGS?="--oneval 1 --design params.csv --dframe 1C --dword 98"
 include ../fuzzaddr/common.mk

--- a/fuzzers/005-tilegrid/pll/generate.tcl
+++ b/fuzzers/005-tilegrid/pll/generate.tcl
@@ -5,16 +5,10 @@ proc run {} {
     read_verilog top.v
     synth_design -top top
 
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_00) IOSTANDARD LVCMOS33" [get_ports clk]
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_01) IOSTANDARD LVCMOS33" [get_ports stb]
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_02) IOSTANDARD LVCMOS33" [get_ports di]
-    set_property -dict "PACKAGE_PIN $::env(XRAY_PIN_03) IOSTANDARD LVCMOS33" [get_ports do]
-
     set_property CFGBVS VCCO [current_design]
     set_property CONFIG_VOLTAGE 3.3 [current_design]
     set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
 
-    set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF]
     # Disable MMCM frequency etc sanity checks
     set_property IS_ENABLED 0 [get_drc_checks {PDRC-29}]
     set_property IS_ENABLED 0 [get_drc_checks {PDRC-30}]

--- a/fuzzers/005-tilegrid/pll/top.py
+++ b/fuzzers/005-tilegrid/pll/top.py
@@ -3,12 +3,17 @@ import random
 random.seed(int(os.getenv("SEED"), 16))
 from prjxray import util
 from prjxray import verilog
+from prjxray.db import Database
 
 
 def gen_sites():
-    for tile_name, site_name, _site_type in util.get_roi().gen_sites(
-        ['PLLE2_ADV']):
-        yield tile_name, site_name
+    db = Database(util.get_db_root())
+    grid = db.grid()
+    for tile_name in sorted(grid.tiles()):
+        gridinfo = grid.gridinfo_at_tilename(tile_name)
+        for site_name, site_type in gridinfo.sites.items():
+            if site_type in ['PLLE2_ADV']:
+                yield tile_name, site_name
 
 
 def write_params(params):
@@ -21,66 +26,25 @@ def write_params(params):
 def run():
     print(
         '''
-module top(input clk, stb, di, output do);
-    localparam integer DIN_N = 8;
-    localparam integer DOUT_N = 8;
-
-    reg [DIN_N-1:0] din;
-    wire [DOUT_N-1:0] dout;
-
-    reg [DIN_N-1:0] din_shr;
-    reg [DOUT_N-1:0] dout_shr;
-
-    always @(posedge clk) begin
-        din_shr <= {din_shr, di};
-        dout_shr <= {dout_shr, din_shr[DIN_N-1]};
-        if (stb) begin
-            din <= din_shr;
-            dout_shr <= dout;
-        end
-    end
-
-    assign do = dout_shr[DOUT_N-1];
+module top();
     ''')
 
     params = {}
     # FIXME: can't LOC?
     # only one for now, worry about later
     sites = list(gen_sites())
-    assert len(sites) == 1
     for (tile_name, site_name), isone in zip(sites,
                                              util.gen_fuzz_states(len(sites))):
-        # 0 is invalid
-        # shift one bit, keeping LSB constant
-        CLKOUT1_DIVIDE = {0: 2, 1: 3}[isone]
-        params[tile_name] = (site_name, CLKOUT1_DIVIDE)
+        params[tile_name] = (site_name, isone)
 
         print(
             '''
-    (* KEEP, DONT_TOUCH *)
-    PLLE2_ADV #(/*.LOC("%s"),*/ .CLKOUT1_DIVIDE(%u)) dut_%s(
-            .CLKFBOUT(),
-            .CLKOUT0(),
-            .CLKOUT1(),
-            .CLKOUT2(),
-            .CLKOUT3(),
-            .CLKOUT4(),
-            .CLKOUT5(),
-            .DRDY(),
-            .LOCKED(),
-            .DO(),
-            .CLKFBIN(),
-            .CLKIN1(),
-            .CLKIN2(),
-            .CLKINSEL(),
-            .DCLK(),
-            .DEN(),
-            .DWE(),
-            .PWRDWN(),
-            .RST(),
-            .DI(),
-            .DADDR());
-''' % (site_name, CLKOUT1_DIVIDE, site_name))
+    (* KEEP, DONT_TOUCH,  LOC = "{site_name}" *)
+    PLLE2_ADV #( .STARTUP_WAIT({isone}) ) dut_{site_name} ();
+'''.format(
+        site_name=site_name,
+        isone=verilog.quote('TRUE' if isone else 'FALSE'),
+        ))
 
     print("endmodule")
     write_params(params)

--- a/fuzzers/005-tilegrid/pll/top.py
+++ b/fuzzers/005-tilegrid/pll/top.py
@@ -24,8 +24,7 @@ def write_params(params):
 
 
 def run():
-    print(
-        '''
+    print('''
 module top();
     ''')
 
@@ -42,9 +41,9 @@ module top();
     (* KEEP, DONT_TOUCH,  LOC = "{site_name}" *)
     PLLE2_ADV #( .STARTUP_WAIT({isone}) ) dut_{site_name} ();
 '''.format(
-        site_name=site_name,
-        isone=verilog.quote('TRUE' if isone else 'FALSE'),
-        ))
+                site_name=site_name,
+                isone=verilog.quote('TRUE' if isone else 'FALSE'),
+            ))
 
     print("endmodule")
     write_params(params)

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -238,19 +238,19 @@ def gen_fuzz_states(nvals):
     next_p2_states = 2**math.ceil(math.log(nvals, 2))
     n = next_p2_states
 
-    full_mask = 2**next_p2_states-1
+    full_mask = 2**next_p2_states - 1
 
     choices = []
     invert_choices = []
 
     num_or = 1
     while n > 0:
-        mask = 2**n-1
+        mask = 2**n - 1
 
         val = 0
 
         for offset in range(0, num_or, 2):
-            shift = offset*next_p2_states//num_or
+            shift = offset * next_p2_states // num_or
             val |= mask << shift
 
         choices.append(full_mask ^ val)


### PR DESCRIPTION
- gen_fuzz_states now generates all states in log2(N) + 2 samples
- Sorting tile names ensures deterministic matching between gen_fuzz_states and sites, which is required for deterministic solutions
- Lowers sample count to log2(Nmax) + 2 samples.  Nmax is set to max count across all 7-series parts
- Modified IOB and PLL fuzzer to be deterministic