### PR TITLE
tile.py: changed get_instance_sites function

### DIFF
--- a/prjxray/tile.py
+++ b/prjxray/tile.py
@@ -128,11 +128,13 @@ class Tile(object):
             get_instance_sites converts site info from generic to specific
             based on a tile location.
             """
-        origin_x, origin_y = lib.find_origin_coordinate(grid_info.sites.keys())
 
         site_names = set()
 
         for site in self.sites:
+            site_name = '{}_X{}Y{}'.format(site.prefix, site.x, site.y)
+            origin_x, origin_y = lib.find_origin_coordinate(site_name, grid_info.sites.keys())
+
             x = site.x + origin_x
             y = site.y + origin_y
 

--- a/prjxray/tile.py
+++ b/prjxray/tile.py
@@ -133,7 +133,8 @@ class Tile(object):
 
         for site in self.sites:
             site_name = '{}_X{}Y{}'.format(site.prefix, site.x, site.y)
-            origin_x, origin_y = lib.find_origin_coordinate(site_name, grid_info.sites.keys())
+            origin_x, origin_y = lib.find_origin_coordinate(
+                site_name, grid_info.sites.keys())
 
             x = site.x + origin_x
             y = site.y + origin_y

--- a/utils/quick_test.py
+++ b/utils/quick_test.py
@@ -40,15 +40,6 @@ def quick_test(db_root):
 
         tile = db.get_tile_type(gridinfo.tile_type)
 
-        # FIXME: The way sites are named in Tile.get_instance_sites is broken
-        # for thes tile types, skip them until the underlying data is fixed.
-        BROKEN_TILE_TYPES = [
-            'BRAM_L', 'BRAM_R', 'HCLK_IOI3', 'CMT_TOP_L_UPPER_B',
-            'CMT_TOP_R_UPPER_B'
-        ]
-        if gridinfo.tile_type in BROKEN_TILE_TYPES:
-            continue
-
         instance_sites = list(tile.get_instance_sites(gridinfo))
         assert len(instance_sites) == len(tile.get_sites())
 


### PR DESCRIPTION
This PR allows `get_isntance_sites` not to break with the https://github.com/SymbiFlow/prjxray/pull/644 changes, this because the `find_origin_coordinate` in `lib.py` has changed.

the `quick_test` still does not work with the upstream db version because the `074-dump-all` fuzzer should be run with the fixes.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>