### PR TITLE
segmatch.cpp: if f_in does not exits returns -1

### DIFF
--- a/fuzzers/058-pip-hclk/Makefile
+++ b/fuzzers/058-pip-hclk/Makefile
@@ -4,10 +4,10 @@ SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
 SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
 
 database: $(SPECIMENS_OK)
-	${XRAY_SEGMATCH} -o build/segbits_hclk_l.db $(addsuffix /segdata_hclk_l_design_*.txt,$(SPECIMENS))
-	${XRAY_SEGMATCH} -o build/segbits_hclk_r.db $(addsuffix /segdata_hclk_r_design_*.txt,$(SPECIMENS))
-	${XRAY_MASKMERGE} build/mask_hclk_l.db $(addsuffix /segdata_hclk_l_design_*.txt,$(SPECIMENS))
-	${XRAY_MASKMERGE} build/mask_hclk_r.db $(addsuffix /segdata_hclk_r_design_*.txt,$(SPECIMENS))
+	${XRAY_SEGMATCH} -o build/segbits_hclk_l.db $(shell find . -name segdata_hclk_l_design_*.txt)
+	${XRAY_SEGMATCH} -o build/segbits_hclk_r.db $(shell find . -name segdata_hclk_r_design_*.txt)
+	${XRAY_MASKMERGE} build/mask_hclk_l.db $(shell find . -name segdata_hclk_l_design_*.txt)
+	${XRAY_MASKMERGE} build/mask_hclk_r.db $(shell find . -name segdata_hclk_r_design_*.txt)
 	grep CK_INOUT build/segbits_hclk_l.db | sed 's, .*, always,' > build/ppips_hclk_l.txt
 	grep CK_INOUT build/segbits_hclk_r.db | sed 's, .*, always,' > build/ppips_hclk_r.txt
 

--- a/tools/segmatch.cc
+++ b/tools/segmatch.cc
@@ -238,7 +238,8 @@ int main(int argc, char** argv) {
 
 			// Check if input file exists.
 			if (!f.good()) {
-				printf("WARNING: Input file does not exist!\n");
+				printf("ERROR: Input file does not exist!\n");
+				return -1;
 			}
 
 			assert(!f.fail());


### PR DESCRIPTION
This PR is to get en error if segmatch does not find the input file as suggested in https://github.com/SymbiFlow/prjxray/pull/630. This solves https://github.com/SymbiFlow/prjxray/issues/338

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>