### PR TITLE
Fix the output of internal routing MUXs in the CLBs.

### DIFF
--- a/htmlgen/htmlgen.py
+++ b/htmlgen/htmlgen.py
@@ -110,7 +110,7 @@ def db_read(dbstate, tiletype, db_dir):
                 add_pip_bits(tag, bits)
 
             elif tiletype in ["clbll_l", "clbll_r", "clblm_l", "clblm_r"] and \
-                    re.search(r"(\.[ABCD]MUX\.)|(\.PRECYINIT\.)", tag):
+                    re.search(r"(\.[ABCD].*MUX\.)|(\.PRECYINIT\.)", tag):
                 add_pip_bits(tag, bits)
 
             else:


### PR DESCRIPTION
Before;
```
CLBLL_L.SLICEL_X1.A5FFMUX
Bit Name                        Position
CLBLL_L.SLICEL_X1.A5FFMUX.IN_A  31_08
CLBLL_L.SLICEL_X1.A5FFMUX.IN_B  31_11
```

After;
```
PIPs driving CLBLL_L.SLICEL_X0.B5FFMUX
PIP                            30_18  30_19
CLBLL_L.SLICEL_X0.B5FFMUX.IN_B   1      -
CLBLL_L.SLICEL_X0.B5FFMUX.IN_A   -      1
```

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>