### PR TITLE
Fix makefiles to pass -j option

### DIFF
--- a/fuzzers/055-pip-gnd/Makefile
+++ b/fuzzers/055-pip-gnd/Makefile
@@ -21,7 +21,7 @@ pushdb:
 
 $(SPECIMENS_OK): build/todo.txt
 	mkdir -p build
-	bash generate.sh $(subst /OK,,$@)
+	+bash generate.sh $(subst /OK,,$@)
 	touch $@
 
 build/todo.txt:

--- a/fuzzers/pip_loop.mk
+++ b/fuzzers/pip_loop.mk
@@ -30,7 +30,7 @@ include $(SELF_DIR)/pip_list.mk
 
 $(SPECIMENS_OK): build/todo.txt $(SPECIMENS_DEPS)
 	mkdir -p build/$(ITER)
-	if [ -f ${FUZDIR}/generate.sh ] ; then \
+	+if [ -f ${FUZDIR}/generate.sh ] ; then \
 			bash ${FUZDIR}/generate.sh $(subst /OK,,$@) ; \
 		else \
 			bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@) ; \


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>

This PR is to solve #626. 
I ran the fuzzers several times locally while working on the stabilization part and grepped for the:
<pre>
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
</pre>
message.
After this fix the search didn't return any log, so I believe this solves the issue.