### PR TITLE
prjxray: Add INOUT to direction enum.

### DIFF
--- a/prjxray/site_type.py
+++ b/prjxray/site_type.py
@@ -7,6 +7,7 @@ import enum
 class SitePinDirection(enum.Enum):
     IN = "IN"
     OUT = "OUT"
+    INOUT = "INOUT"
 
 
 SiteTypePin = namedtuple('SiteTypePin', 'name direction')


### PR DESCRIPTION
[INOUT is found on the PS7 interface on the Zynq](https://github.com/SymbiFlow/prjxray-db/blob/b9c0324464e4b00f122ea2dc23b24ee2bad50fa7/zynq7/site_type_PS7.json#L2-L46).

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>