### PR TITLE
docs: Fixing markdown files

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+
+submodules:
+  exclude: all

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,3 @@
 _build
+db_dev_process/fuzzers/*.md
+db_dev_process/minitests/*.md

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,49 @@ livehtml:
 
 .PHONY: help livereload Makefile
 
+# Update fuzzer / minitest markdown links.
+fuzzers-links:
+	@cd db_dev_process/fuzzers; rm -f *.md
+	@cd db_dev_process/fuzzers; \
+		for i in ../../../fuzzers/*; do \
+			if [ ! -d $$i ]; then \
+				continue; \
+			fi; \
+			if [ -e $$i/README.md ]; then \
+				echo "Linking $$i/README.md"; \
+				ln -s $$i/README.md $$(basename $$i).md; \
+			else \
+				echo "Missing $$i/README.md"; \
+				echo "# $$(basename $$i)" 	> $$(basename $$i).md; \
+				echo "" 			>> $$(basename $$i).md; \
+				echo "Missing README.md!" 	>> $$(basename $$i).md; \
+			fi; \
+		done
+
+minitests-links:
+	@cd db_dev_process/minitests; rm -f *.md
+	@cd db_dev_process/minitests; \
+		for i in ../../../minitests/*; do \
+			if [ ! -d $$i ]; then \
+				continue; \
+			fi; \
+			if [ -e $$i/README.md ]; then \
+				echo "Linking $$i/README.md"; \
+				ln -s $$i/README.md $$(basename $$i).md; \
+			else \
+				echo "Missing $$i/README.md"; \
+				echo "# $$(basename $$i)" 	> $$(basename $$i).md; \
+				echo "" 			>> $$(basename $$i).md; \
+				echo "Missing README.md!" 	>> $$(basename $$i).md; \
+			fi; \
+		done
+
+links: fuzzers-links minitests-links
+	@true
+
+.PHONY: fuzzers-links minitests-links links
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: Makefile links
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,31 @@ project = u'Project X-Ray'
 copyright = u'2018, SymbiFlow Team'
 author = u'SymbiFlow Team'
 
+# Enable github links when not on readthedocs
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if not on_rtd:
+    html_context = {
+        "display_github": True,  # Integrate GitHub
+        "github_user": "symbiflow",  # Username
+        "github_repo": "prjxray",  # Repo name
+        "github_version": "master",  # Version
+        "conf_py_path": "/doc/",
+    }
+else:
+    import subprocess
+    subprocess.call(
+        'git fetch origin --unshallow',
+        cwd=os.path.abspath(os.path.dirname(__file__)),
+        shell=True)
+    subprocess.check_call(
+        'git fetch origin --tags',
+        cwd=os.path.abspath(os.path.dirname(__file__)),
+        shell=True)
+    subprocess.check_call(
+        'make links',
+        cwd=os.path.abspath(os.path.dirname(__file__)),
+        shell=True)
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
@@ -102,23 +127,6 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 # html_theme_options = {}
-
-# Enable github links when not on readthedocs
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:
-    html_context = {
-        "display_github": True,  # Integrate GitHub
-        "github_user": "symbiflow",  # Username
-        "github_repo": "prjxray",  # Repo name
-        "github_version": "master",  # Version
-        "conf_py_path": "/doc/",
-    }
-else:
-    import subprocess
-    subprocess.check_call(
-        'make links',
-        cwd=os.path.abspath(os.path.dirname(__file__)),
-        shell=True)
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,13 @@ if not on_rtd:
         "github_version": "master",  # Version
         "conf_py_path": "/doc/",
     }
+else:
+    import subprocess
+    subprocess.check_call(
+        'make links',
+        cwd=os.path.abspath(os.path.dirname(__file__)),
+        shell=True)
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,8 +36,13 @@ from markdown_code_symlinks import MarkdownCodeSymlinks
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.imgmath', 'sphinx.ext.autodoc', 'sphinx.ext.doctest',
-    'sphinx.ext.autosummary', 'sphinx.ext.napoleon', 'sphinx.ext.todo'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
+    'sphinx.ext.imgmath',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.todo',
+    'sphinx_markdown_tables',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,6 @@ html_theme = 'sphinx_rtd_theme'
 #
 # html_theme_options = {}
 
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/db_dev_process/fuzzers/011-ffconfig.md
+++ b/docs/db_dev_process/fuzzers/011-ffconfig.md
@@ -1,1 +1,0 @@
-../../../fuzzers/011-ffconfig/README.md

--- a/docs/db_dev_process/fuzzers/012-clbn5ffmux.md
+++ b/docs/db_dev_process/fuzzers/012-clbn5ffmux.md
@@ -1,1 +1,0 @@
-../../../fuzzers/012-clbn5ffmux/README.md

--- a/docs/db_dev_process/fuzzers/013-clbncy0.md
+++ b/docs/db_dev_process/fuzzers/013-clbncy0.md
@@ -1,1 +1,0 @@
-../../../fuzzers/013-clbncy0/README.md

--- a/docs/db_dev_process/fuzzers/014-ffsrcemux.md
+++ b/docs/db_dev_process/fuzzers/014-ffsrcemux.md
@@ -1,1 +1,0 @@
-../../../fuzzers/014-ffsrcemux/README.md

--- a/docs/db_dev_process/fuzzers/015-clbnffmux.md
+++ b/docs/db_dev_process/fuzzers/015-clbnffmux.md
@@ -1,1 +1,0 @@
-../../../fuzzers/015-clbnffmux/README.md

--- a/docs/db_dev_process/fuzzers/016-clbnoutmux.md
+++ b/docs/db_dev_process/fuzzers/016-clbnoutmux.md
@@ -1,1 +1,0 @@
-../../../fuzzers/016-clbnoutmux/README.md

--- a/docs/db_dev_process/fuzzers/017-clbprecyinit.md
+++ b/docs/db_dev_process/fuzzers/017-clbprecyinit.md
@@ -1,1 +1,0 @@
-../../../fuzzers/017-clbprecyinit/README.md

--- a/docs/db_dev_process/fuzzers/018-clbram.md
+++ b/docs/db_dev_process/fuzzers/018-clbram.md
@@ -1,1 +1,0 @@
-../../../fuzzers/018-clbram/README.md

--- a/docs/db_dev_process/fuzzers/019-ndi1mux.md
+++ b/docs/db_dev_process/fuzzers/019-ndi1mux.md
@@ -1,1 +1,0 @@
-../../../fuzzers/019-ndi1mux/README.md

--- a/docs/db_dev_process/fuzzers/050-intpips.md
+++ b/docs/db_dev_process/fuzzers/050-intpips.md
@@ -1,1 +1,0 @@
-../../../fuzzers/050-intpips/README.md

--- a/docs/db_dev_process/fuzzers/051-imuxlout.md
+++ b/docs/db_dev_process/fuzzers/051-imuxlout.md
@@ -1,1 +1,0 @@
-../../../fuzzers/051-imuxlout/README.md

--- a/docs/db_dev_process/fuzzers/052-clkin.md
+++ b/docs/db_dev_process/fuzzers/052-clkin.md
@@ -1,1 +1,0 @@
-../../../fuzzers/052-clkin/README.md

--- a/docs/db_dev_process/fuzzers/053-ctrlin.md
+++ b/docs/db_dev_process/fuzzers/053-ctrlin.md
@@ -1,1 +1,0 @@
-../../../fuzzers/053-ctrlin/README.md

--- a/docs/db_dev_process/fuzzers/054-gfan.md
+++ b/docs/db_dev_process/fuzzers/054-gfan.md
@@ -1,1 +1,0 @@
-../../../fuzzers/054-gfan/README.md

--- a/docs/db_dev_process/fuzzers/055-gnd.md
+++ b/docs/db_dev_process/fuzzers/055-gnd.md
@@ -1,1 +1,0 @@
-../../../fuzzers/055-gnd/README.md

--- a/docs/db_dev_process/fuzzers/056-rempips.md
+++ b/docs/db_dev_process/fuzzers/056-rempips.md
@@ -1,1 +1,0 @@
-../../../fuzzers/056-rempips/README.md

--- a/docs/db_dev_process/fuzzers/057-bipips.md
+++ b/docs/db_dev_process/fuzzers/057-bipips.md
@@ -1,1 +1,0 @@
-../../../fuzzers/057-bipips/README.md

--- a/docs/db_dev_process/fuzzers/058-hclkpips.md
+++ b/docs/db_dev_process/fuzzers/058-hclkpips.md
@@ -1,1 +1,0 @@
-../../../fuzzers/058-hclkpips/README.md

--- a/docs/db_dev_process/minitests/bram.md
+++ b/docs/db_dev_process/minitests/bram.md
@@ -1,1 +1,0 @@
-../../../minitests/bram/README.md

--- a/docs/db_dev_process/minitests/clb_bused.md
+++ b/docs/db_dev_process/minitests/clb_bused.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_bused/README.md

--- a/docs/db_dev_process/minitests/clb_ffcfg.md
+++ b/docs/db_dev_process/minitests/clb_ffcfg.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_ffcfg/README.md

--- a/docs/db_dev_process/minitests/clb_muxf8.md
+++ b/docs/db_dev_process/minitests/clb_muxf8.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_muxf8/README.md

--- a/docs/db_dev_process/minitests/clb_n5ffmux.md
+++ b/docs/db_dev_process/minitests/clb_n5ffmux.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_n5ffmux/README.md

--- a/docs/db_dev_process/minitests/clb_ncy0.md
+++ b/docs/db_dev_process/minitests/clb_ncy0.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_ncy0/README.md

--- a/docs/db_dev_process/minitests/clb_ndi1mux.md
+++ b/docs/db_dev_process/minitests/clb_ndi1mux.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_ndi1mux/README.md

--- a/docs/db_dev_process/minitests/clb_nffmux.md
+++ b/docs/db_dev_process/minitests/clb_nffmux.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_nffmux/README.md

--- a/docs/db_dev_process/minitests/clb_noutmux.md
+++ b/docs/db_dev_process/minitests/clb_noutmux.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_noutmux/README.md

--- a/docs/db_dev_process/minitests/clb_ram.md
+++ b/docs/db_dev_process/minitests/clb_ram.md
@@ -1,1 +1,0 @@
-../../../minitests/clb_ram/README.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ to develop a free and open Verilog to bitstream toolchain for these devices.
    architecture/overview
    architecture/configuration
    architecture/bitstream_format
+   architecture/dram_configuration
    architecture/glossary
 
 .. toctree::

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ sphinx-autobuild
 
 breathe
 recommonmark
+sphinx-markdown-tables
 sphinx_rtd_theme
 sphinxcontrib-napoleon

--- a/fuzzers/012-clb-n5ffmux/README.md
+++ b/fuzzers/012-clb-n5ffmux/README.md
@@ -4,8 +4,8 @@
 
 The A5FFMUX family of CLB muxes feed the D input of A5FF family of FFs
 
-| N5FFMUX  | N5FFMUX.D       | 
-|--------|-----------------|
-| IN_A   | N5LUT.O5        |
-| IN_B   | NX              |
+| N5FFMUX  | N5FFMUX.D       |
+|----------|-----------------|
+| IN_A     | N5LUT.O5        |
+| IN_B     | NX              |
 

--- a/fuzzers/013-clb-ncy0/README.md
+++ b/fuzzers/013-clb-ncy0/README.md
@@ -4,7 +4,7 @@
 
 The ACY0 family of CLB muxes feeds the CARRY4.DI0 family
 
-| NCY0  | CARRY4.DIN       | 
+| NCY0   | CARRY4.DIN       |
 |--------|------------------|
 | 0      | NX               |
 | 1      | O5               |

--- a/fuzzers/014-clb-ffsrcemux/README.md
+++ b/fuzzers/014-clb-ffsrcemux/README.md
@@ -4,7 +4,7 @@
 
 Configures whether clock enable (CE) is used or clock always on
 
-| CEUSEDMUX  | CE               | 
+| CEUSEDMUX  | CE               |
 |------------|------------------|
 | 0          | Always on        |
 | 1          | Controlled       |
@@ -14,7 +14,7 @@ Configures whether clock enable (CE) is used or clock always on
 
 Configures whether FF can be reset or simply uses D value
 
-| SRUSEDMUX  | Resettable?      | 
+| SRUSEDMUX  | Resettable?      |
 |------------|------------------|
 | 0          | No               |
 | 1          | Controlled       |

--- a/fuzzers/015-clb-nffmux/README.md
+++ b/fuzzers/015-clb-nffmux/README.md
@@ -4,5 +4,5 @@
 
 Configures the AFFMUX family of CLB muxes which feed the D input of the AFF series of FFs.
 
-Availible selections varies by A/B/C/D, see db for details.
+Available selections varies by A/B/C/D, see db for details.
 

--- a/fuzzers/016-clb-noutmux/README.md
+++ b/fuzzers/016-clb-noutmux/README.md
@@ -4,5 +4,5 @@
 
 Configures the AOUTMUX family of CLB muxes which feed the AMUX family of CLB outputs
 
-Availible selections varies by A/B/C/D, see db for details.
+Available selections varies by A/B/C/D, see db for details.
 

--- a/fuzzers/017-clb-precyinit/README.md
+++ b/fuzzers/017-clb-precyinit/README.md
@@ -4,7 +4,7 @@
 
 Configures the PRECYINIT mux which provides CARRY4's first carry chain input
 
-| PRECYINIT  | Value                           | 
+| PRECYINIT  | Value                           |
 |------------|---------------------------------|
 | C0         | Logic 0                         |
 | C1         | Logic 1                         |

--- a/fuzzers/018-clb-ram/README.md
+++ b/fuzzers/018-clb-ram/README.md
@@ -43,7 +43,7 @@ Set to 1 to propagate CLB's BX input to WA8
 
 ## WEMUX.CE
 
-| WEMUX.CE  | CLB RAM write enable | 
+| WEMUX.CE  | CLB RAM write enable |
 |-----------|----------------------|
 | 0         | CLB WE input         |
 | 1         | CLB CE input         |

--- a/fuzzers/019-clb-ndi1mux/README.md
+++ b/fuzzers/019-clb-ndi1mux/README.md
@@ -4,5 +4,5 @@
 
 Configures the NDI1MUX mux which provides the DI1 input on CLB RAM.
 
-Availible selections varies by A/B/C/D, see db for details.
+Available selections varies by A/B/C/D, see db for details.
 

--- a/fuzzers/025-bram-config/README.md
+++ b/fuzzers/025-bram-config/README.md
@@ -1,2 +1,4 @@
+# BRAM Configuration
+
 Solves for BRAM configuration bits (18K vs 36K, etc)
 

--- a/fuzzers/026-bram-data/README.md
+++ b/fuzzers/026-bram-data/README.md
@@ -1,3 +1,5 @@
+# BRAM Data
+
 Solves for BRAM data bits
 
 See workflow comments: https://github.com/SymbiFlow/prjxray/pull/180

--- a/fuzzers/032-cmt-pll/README.md
+++ b/fuzzers/032-cmt-pll/README.md
@@ -1,0 +1,3 @@
+# Clock Management Tile (CMT) - Phase Lock Loop (PLL) Fuzzer
+
+FIXME: Add description.

--- a/fuzzers/033-mon-xadc/README.md
+++ b/fuzzers/033-mon-xadc/README.md
@@ -1,3 +1,5 @@
+# XADC Fuzzer
+
 As of this writing, this fuzzer is not in the ROI
 To use it, you must run tilegrid first with these options (artix7):
 

--- a/fuzzers/044-clk-bufg-pips/README.md
+++ b/fuzzers/044-clk-bufg-pips/README.md
@@ -1,4 +1,3 @@
-BUFG interconnect fuzzer
-========================
+# BUFG interconnect fuzzer
 
 Solves pips located within the BUFG switch box.

--- a/fuzzers/045-hclk-cmt-pips/README.md
+++ b/fuzzers/045-hclk-cmt-pips/README.md
@@ -1,4 +1,3 @@
-HCLK\_CMT interconnect fuzzer
-=============================
+# HCLK\_CMT interconnect fuzzer
 
 Solves pips located within the HCLK\_CMT switch box.

--- a/fuzzers/050-pip-seed/README.md
+++ b/fuzzers/050-pip-seed/README.md
@@ -1,6 +1,4 @@
-
-Generic fuzzer for INT PIPs
----------------------------
+# Generic fuzzer for INT PIPs
 
 Run this fuzzer a few times until it stops adding new PIPs to the
 database.

--- a/fuzzers/051-pip-imuxlout-bypalts/README.md
+++ b/fuzzers/051-pip-imuxlout-bypalts/README.md
@@ -1,6 +1,4 @@
-
-Fuzzer for INT LOGIC\_OUTS -> IMUX PIPs
----------------------------------------
+# Fuzzer for INT LOGIC\_OUTS -> IMUX PIPs
 
 Run this fuzzer a few times until it produces an empty todo.txt file (`make run` will run this loop).
 

--- a/fuzzers/052-pip-clkin/README.md
+++ b/fuzzers/052-pip-clkin/README.md
@@ -1,6 +1,5 @@
+# Fuzzer for INT PIPs driving the CLK wires
 
-Fuzzer for INT PIPs driving the CLK wires
------------------------------------------
-
-Run this fuzzer a few times until it produces an empty todo.txt file (`make run` will run this loop).
+Run this fuzzer a few times until it produces an empty todo.txt file (`make
+run` will run this loop).
 

--- a/fuzzers/053-pip-ctrlin/README.md
+++ b/fuzzers/053-pip-ctrlin/README.md
@@ -1,6 +1,4 @@
-
-Fuzzer for INT PIPs driving the CTRL wires
-------------------------------------------
+# Fuzzer for INT PIPs driving the CTRL wires
 
 Run this fuzzer a few times until it produces an empty todo.txt file (`make run` will run this loop).
 

--- a/fuzzers/054-pip-fan-alt/README.md
+++ b/fuzzers/054-pip-fan-alt/README.md
@@ -1,5 +1,3 @@
-
-Fuzzer for the ALT_FAN.*GFAN PIPs
----------------------------------
+# Fuzzer for the ALT_FAN.*GFAN PIPs
 
 This fuzzer solves the ALT_FAN.GFAN PIPs which had collisions with the GFAN PIPs.

--- a/fuzzers/055-pip-gnd/README.md
+++ b/fuzzers/055-pip-gnd/README.md
@@ -1,6 +1,4 @@
-
-Fuzzer for INT PIPs driving the GFAN wires with GND
----------------------------------------------------
+# Fuzzer for INT PIPs driving the GFAN wires with GND
 
 Run this fuzzer once.
 

--- a/fuzzers/056-pip-rem/README.md
+++ b/fuzzers/056-pip-rem/README.md
@@ -1,6 +1,4 @@
-
-Fuzzer for the remaining INT PIPs
----------------------------------
+# Fuzzer for the remaining INT PIPs
 
 Run this fuzzer a few times until it produces an empty todo.txt file (`make run` will run this loop).
 

--- a/fuzzers/057-pip-bi/README.md
+++ b/fuzzers/057-pip-bi/README.md
@@ -1,6 +1,5 @@
+# Fuzzer for bidirectional INT PIPs
 
-Fuzzer for bidirectional INT PIPs
----------------------------------
-
-Run this fuzzer a few times until it produces an empty todo.txt file (`make run` will run this loop).
+Run this fuzzer a few times until it produces an empty todo.txt file (`make
+run` will run this loop).
 

--- a/fuzzers/058-pip-hclk/README.md
+++ b/fuzzers/058-pip-hclk/README.md
@@ -1,6 +1,4 @@
-
-Fuzzer for PIPs in HCLK titles
-------------------------------
+# Fuzzer for PIPs in HCLK titles
 
 Run this fuzzer once.
 


### PR DESCRIPTION
 Results can be previewed at https://mithro-prjxray.readthedocs.io/en/latest

 *  Auto linking the fuzzer and minitest README.md files.
 * Fixing the tables in Markdown.
 * Fixing the headers on files.

#### Before
![image](https://user-images.githubusercontent.com/21212/55522184-b963e600-5638-11e9-9d8d-71e339ef31d3.png)

#### After
![image](https://user-images.githubusercontent.com/21212/55522222-dd272c00-5638-11e9-8fd5-9a2851887419.png)
