### PR TITLE
Importing remaining wiki contents

### DIFF
--- a/docs/architecture/interconnect.rst
+++ b/docs/architecture/interconnect.rst
@@ -1,26 +1,30 @@
-Interconnect PIPs
-=================
+Interconnect :term:`PIP`s
+=========================
 
-Fake PIPs
----------
+Fake :term:`PIP`s
+-----------------
 
-Some PIPs are not "real", in the sense that no bit pattern in the bit-stream correspond to the PIP being used. This is the case for all the PIPs in the switchbox in a CLB tile (ex: CLBLM_L_INTER): They either correspond to buffers that are always on (i.e. 1:1 connections such as `CLBLL_L.CLBLL_L_AQ->CLBLL_LOGIC_OUTS0`), or they correspond to permutations of LUT input signals, which is handled by changing the LUT init value accordingly, or they are used to "connect" two signals that are driven by the same signal from within the CLB.
+Some :term:`PIP`s are not "real", in the sense that no bit pattern in the bit-stream correspond to the PIP being used. This is the case for all the :term:`PIP`s in the switchbox in a CLB tile (ex: CLBLM_L_INTER): They either correspond to buffers that are always on (i.e. 1:1 connections such as `CLBLL_L.CLBLL_L_AQ->CLBLL_LOGIC_OUTS0`), or they correspond to permutations of LUT input signals, which is handled by changing the LUT init value accordingly, or they are used to "connect" two signals that are driven by the same signal from within the CLB.
 
-The bit switchbox in an INT tile also contains a few 1:1 connections that are in fact always present and have no corresponding configuration bits.
+FIXME: Check the above is true.
 
-Regular PIPs
-------------
+The bit switchbox in an :term:`INT`s tile also contains a few 1:1 connections that are in fact always present and have no corresponding configuration bits.
 
-Regular PIPs correspond to a bit pattern that is present in the bit stream when the PIP is used in the current design. There is a block of up to 10-ish bits for each destination signal. For each configuration (i.e. source net that can drive the destination) there is a pair of bits that is set.
+Regular :term:`PIP`s
+--------------------
 
-For example, when the bits 05_57 and 11_56 are set then SR1END3->SE2BEG3 is enabled, but when 08_56 and 11_56 are set then ER1END3->SE2BEG3 is enabled (in an INT_L tile paired with a CLBLL_L tile). A configuration in which all three bits are set is invalid. See `segbits_int_[lr].db` for a complete list of bit pattern for configuring PIPs.
+Regular :term:`PIP`s correspond to a bit pattern that is present in the bit stream when the PIP is used in the current design. There is a block of up to 10-ish bits for each destination signal. For each configuration (i.e. source net that can drive the destination) there is a pair of bits that is set.
+
+FIXME: Check if the above is true for PIPs outside of the INT switch box.
+
+For example, when the bits 05_57 and 11_56 are set then SR1END3->SE2BEG3 is enabled, but when 08_56 and 11_56 are set then ER1END3->SE2BEG3 is enabled (in an :term:`INT_L`s tile paired with a CLBLL_L tile). A configuration in which all three bits are set is invalid. See `segbits_int_[lr].db` for a complete list of bit pattern for configuring :term:`PIP`s.
 
 VCC Drivers
 -----------
 
-The default state for a net is to be driven high. The PIPs that drive a net from `VCC_WIRE` correspond to the "empty configuration" with no bits set.
+The default state for a net is to be driven high. The :term:`PIP`s that drive a net from `VCC_WIRE` correspond to the "empty configuration" with no bits set.
 
-Bidirectional PIPs
-------------------
+Bidirectional :term:`PIP`s
+--------------------------
 
-Bidirectional PIPs are used to stitch together long traces (LV*, LVB*). In case of bidirectional PIPs there are two different configuration patterns, one for each direction.
+Bidirectional :term:`PIP`s are used to stitch together long traces (LV*, LVB*). In case of bidirectional :term:`PIP`s there are two different configuration patterns, one for each direction.

--- a/docs/architecture/interconnect.rst
+++ b/docs/architecture/interconnect.rst
@@ -1,0 +1,26 @@
+Interconnect PIPs
+=================
+
+Fake PIPs
+---------
+
+Some PIPs are not "real", in the sense that no bit pattern in the bit-stream correspond to the PIP being used. This is the case for all the PIPs in the switchbox in a CLB tile (ex: CLBLM_L_INTER): They either correspond to buffers that are always on (i.e. 1:1 connections such as `CLBLL_L.CLBLL_L_AQ->CLBLL_LOGIC_OUTS0`), or they correspond to permutations of LUT input signals, which is handled by changing the LUT init value accordingly, or they are used to "connect" two signals that are driven by the same signal from within the CLB.
+
+The bit switchbox in an INT tile also contains a few 1:1 connections that are in fact always present and have no corresponding configuration bits.
+
+Regular PIPs
+------------
+
+Regular PIPs correspond to a bit pattern that is present in the bit stream when the PIP is used in the current design. There is a block of up to 10-ish bits for each destination signal. For each configuration (i.e. source net that can drive the destination) there is a pair of bits that is set.
+
+For example, when the bits 05_57 and 11_56 are set then SR1END3->SE2BEG3 is enabled, but when 08_56 and 11_56 are set then ER1END3->SE2BEG3 is enabled (in an INT_L tile paired with a CLBLL_L tile). A configuration in which all three bits are set is invalid. See `segbits_int_[lr].db` for a complete list of bit pattern for configuring PIPs.
+
+VCC Drivers
+-----------
+
+The default state for a net is to be driven high. The PIPs that drive a net from `VCC_WIRE` correspond to the "empty configuration" with no bits set.
+
+Bidirectional PIPs
+------------------
+
+Bidirectional PIPs are used to stitch together long traces (LV*, LVB*). In case of bidirectional PIPs there are two different configuration patterns, one for each direction.

--- a/docs/architecture/reference.rst
+++ b/docs/architecture/reference.rst
@@ -1,0 +1,75 @@
+References
+==========
+
+Xilinx documents one should be familiar with:
+---------------------------------------------
+
+### UG470: 7 Series FPGAs Configuration User Guide
+
+https://www.xilinx.com/support/documentation/user_guides/ug470_7Series_Config.pdf
+
+*Chapter 5: Configuration Details* contains a good description of the overall
+bit-stream format. (See section "Bitstream Composition" and following.)
+
+### UG912: Vivado Design Suite Properties Reference Guide
+
+http://www.xilinx.com/support/documentation/sw_manuals/xilinx2017_3/ug912-vivado-properties.pdf
+
+Contains an excellent description of the in-memory data structures and
+associated properties Vivado uses to describe the design and the chip. The TCL
+interface provides a convenient interface to access this information.
+
+### UG903: Vivado Design Suite User Guide: Using Constraints
+
+http://www.xilinx.com/support/documentation/sw_manuals/xilinx2017_3/ug903-vivado-using-constraints.pdf
+
+The fuzzers generate designs (HDL + Constraints) that use many physical
+contraints constraints (placement and routing) to produce bit-streams with
+exactly the desired features. It helps to learn about the available constraints
+before starting to write fuzzers.
+
+### UG901: Vivado Design Suite User Guide: Synthesis
+
+http://www.xilinx.com/support/documentation/sw_manuals/xilinx2017_3/ug901-vivado-synthesis.pdf
+
+*Chapter 2: Synthesis Attributes* contains an overview of the Verilog
+attributes that can be used to control Vivado Synthesis. Many of them
+are useful for writing fuzzer designs. There is some natural overlap
+with UG903.
+
+### UG909: Vivado Design Suite User Guide: Partial Reconfiguration
+
+https://www.xilinx.com/support/documentation/sw_manuals/xilinx2017_3/ug909-vivado-partial-reconfiguration.pdf
+
+Among other things this UG contains some valuable information on how to constrain a design in a way so that the items inside a pblock are strictly separate from the items outside that pblock.
+
+### UG474: 7 Series FPGAs Configurable Logic Block
+
+https://www.xilinx.com/support/documentation/user_guides/ug474_7Series_CLB.pdf
+
+Describes the capabilities of a CLB, the most important non-interconnect resource of a Xilinx FPGA.
+
+Other documentation that might be of use:
+-----------------------------------------
+
+Doc of .bit container file format:
+http://www.pldtool.com/pdf/fmt_xilinxbit.pdf
+
+Open-Source Bitstream Generation for FPGAs, Ritesh K Soni, Master Thesis:
+https://vtechworks.lib.vt.edu/bitstream/handle/10919/51836/Soni_RK_T_2013.pdf
+
+VTR-to-Bitstream, Eddie Hung:
+https://eddiehung.github.io/vtb.html
+
+From the bitstream to the netlist, Jean-Baptiste Note and Éric Rannaud:
+http://www.fabienm.eu/flf/wp-content/uploads/2014/11/Note2008.pdf
+
+Wolfgang Spraul's Spartan-6 (xc6slx9) project:
+https://github.com/Wolfgang-Spraul/fpgatools
+
+Marek Vasut's Typhoon Cyclone IV project:
+http://git.bfuser.eu/?p=marex/typhoon.git
+
+XDL generator/imported for Vivado:
+https://github.com/byuccl/tincr
+

--- a/docs/format/db.rst
+++ b/docs/format/db.rst
@@ -19,13 +19,15 @@ Bit positions within a segment are written using the following notation: A two d
 
 The first number indicates the frame address relative to the base frame address for the segment and ranges from `00` to `35` for Atrix-7 CLB segments.
 
-The second number indicates the bit position with
+The second number indicates the bit position width.
+
+FIXME: Expand this section. We've had a couple questions around this, probably good to get a complete description of this that we can point people too. This is probably a good place to talk about tile grid and how it applies to segbit.
 
 
 segbits_*.db
 ------------
 
-Tag files document the meaning of individual configuration bits or bit pattern. They contain one line for each pattern. The first word (sequence of non-whitespace characters) in that line is the *configuration tag*, the remaining words in the line is the list of bits for that pattern. A bit prefixed with a `!` marks a bit that must be cleared, a bit bit not prefixed with a `!` marks a bit that must be set.
+Tag files document the meaning of individual configuration bits or bit pattern. They contain one line for each pattern. The first word (sequence of non-whitespace characters) in that line is the *configuration tag*, the remaining words in the line is the list of bits for that pattern. A bit prefixed with a `!` marks a bit that must be cleared, a bit not prefixed with a `!` marks a bit that must be set.
 
 No configuration tag may include the bit pattern for another tag as subset. If it does then this is an indicator that there is an incorrect entry in the database. Usually this either means that a tag has additional bits in their pattern that should not be there, or that `!<bit>` entries are missing for one or more tags.
 
@@ -71,14 +73,16 @@ Related tools:
    * Ex: CLB is solved by first solving LUT bits, and then solving FF bits
 
 
-Interconnect PIP Tags
-^^^^^^^^^^^^^^^^^^^^^
+Interconnect :term:`PIP` Tags
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Tags for interconnect PIPs are stored in the `segbits_int_l.db` and `segbits_int_r.db` database files. For example, look at `segbits_int_l.db` for the bits that configure the `INT_L` tile in a `CLBLL_L` or `CLBLM_L` segment.
+Tags for interconnect :term:`PIP`s are stored in the `segbits_int_l.db` and `segbits_int_r.db` database files.
 
-Tags that enable interconnect PIPs have the following syntax: `<tile_type>.<destination_wire>.<source_wire>`.
+Tags that enable interconnect :term:`PIP`s have the following syntax: `<tile_type>.<destination_wire>.<source_wire>`.
 
 The `<tile_type>` may be `INT_L` or `INT_R`. The destination and source wires are wire names in that tile type. For example, consider the following entry in `segbits_int_l.db`: `INT_L.NL1BEG1.NN6END2 07_32 12_33`
+
+FIXME: This is probably a good place to reference tileconn as the documentation that explains how wires are connected outside of switchboxes (which is what pips document).
 
 This means that the bits `07_32` and `12_33` must be set in the segment to drive the value from the wire `NN6END2` to the wire `NL1BEG1`.
 
@@ -92,7 +96,7 @@ Tags for CLB tiles use a dot-separated hierarchy for their tag names. For exampl
 ppips_*.db
 ----------
 
-Pseudo PIPs are PIPs in the Vivado tool, but do not have actual bit pattern. The `ppips_*.db` files contain information on pseudo-PIPs. Those files contain one entry per pseudo-PIP, each with one of the following three tags: `always`, `default` or `hint`. The tag `always` is used for pseudo-PIPs that are actually always-on, i.e. that are permanent connections between two wires. The tag `default` is used for pseudo-PIPs that represent the default behavior if no other driver has been configured for the destination net (all `default` pseudo-PIPs connect to the `VCC_WIRE` net). And the tag `hint` is used for PIPs that are used by Vivado to tell the router that two logic slice outputs drive the same value, i.e. behave like they are connected as far as the routing process is concerned.
+Pseudo :term:`PIP`s are :term:`PIP`s in the Vivado tool, but do not have actual bit pattern. The `ppips_*.db` files contain information on pseudo-:term:`PIP`s. Those files contain one entry per pseudo-PIP, each with one of the following three tags: `always`, `default` or `hint`. The tag `always` is used for pseudo-:term:`PIP`s that are actually always-on, i.e. that are permanent connections between two wires. The tag `default` is used for pseudo-:term:`PIP`s that represent the default behavior if no other driver has been configured for the destination net (all `default` pseudo-:term:`PIP`s connect to the `VCC_WIRE` net). And the tag `hint` is used for :term:`PIP`s that are used by Vivado to tell the router that two logic slice outputs drive the same value, i.e. behave like they are connected as far as the routing process is concerned.
 
 mask_*.db
 ---------
@@ -131,6 +135,9 @@ So in summary:
 * Frame word bit #: 5
 
 So, with this in mind, we have frame base address 0x00020500 and word # 2. This maps to tilegrid.json entry SEG_CLBLL_L_X12Y101 (has "baseaddr": ["0x00020600", 2]). This also yields "type": "clbll_l" meaning we are configuring a CLBLL_L.
+
+FIXME: This example is out of date with the new tilegrid format, should update it.
+
 
 Looking at segbits_clbll_l.db, we need to look up the bit at segment column 11, offset at bit 5. However, this is not present, so we fall back to segbits_int_l.db. This yields a few entries related to EL1BEG (ex: INT_L.EL1BEG_N3.EL1END0 11_05 13_05).
 

--- a/docs/format/tile.rst
+++ b/docs/format/tile.rst
@@ -16,6 +16,15 @@ General notes:
 tilegrid.json
 -------------
 
+The file `tilegrid.json` contains lists of all tiles in the ROI and the configuration segments formed by those tiles. It also documents the membership relationship of tiles and segments.
+
+For each segment this contains the configuration frame base address, and the word offset within the frames, as well as the number of frames for the segment and number of occupied words in each frame.
+
+For each tile this file contains the tile type, grid X/Y coordinates for the tile, and sites (slices) within the tile.
+
+Note that pairs of INT-tiles and non-INT-tiles form a segment. The same type-name (e.g. `CLBLL_R` is used for the non-INT tile within the segment, and the segment itself). So for example, a `CLBLL_R` segment contains a `CLBLL_R` tile and an `INT_R` tile.
+
+
 This section assumes you are already familiar with the 7 series bitstream format.
 
 This file contains two elements:
@@ -100,6 +109,8 @@ Interpreted as:
 
 tileconn.json
 -------------
+
+The file `tileconn.json` contains the information how the wires of neighboring tiles are connected to each other. It contains one entry for each pair of tile types, each containing a list of pairs of wires that belong to the same node.
 
 This file documents how adjacent tile pairs are connected.
 No directionality is given.

--- a/docs/format/tile.rst
+++ b/docs/format/tile.rst
@@ -16,14 +16,13 @@ General notes:
 tilegrid.json
 -------------
 
-The file `tilegrid.json` contains lists of all tiles in the ROI and the configuration segments formed by those tiles. It also documents the membership relationship of tiles and segments.
+The file `tilegrid.json` contains lists of all tiles in the device and the configuration segments formed by those tiles. It also documents the membership relationship of tiles and segments.
 
 For each segment this contains the configuration frame base address, and the word offset within the frames, as well as the number of frames for the segment and number of occupied words in each frame.
 
+FIXME: We should cross link to how to use the base address and word offset.
+
 For each tile this file contains the tile type, grid X/Y coordinates for the tile, and sites (slices) within the tile.
-
-Note that pairs of INT-tiles and non-INT-tiles form a segment. The same type-name (e.g. `CLBLL_R` is used for the non-INT tile within the segment, and the segment itself). So for example, a `CLBLL_R` segment contains a `CLBLL_R` tile and an `INT_R` tile.
-
 
 This section assumes you are already familiar with the 7 series bitstream format.
 
@@ -111,6 +110,8 @@ tileconn.json
 -------------
 
 The file `tileconn.json` contains the information how the wires of neighboring tiles are connected to each other. It contains one entry for each pair of tile types, each containing a list of pairs of wires that belong to the same node.
+
+FIXME: This is a good place to add the tile wire, pip, site pin diagram.
 
 This file documents how adjacent tile pairs are connected.
 No directionality is given.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,8 +20,10 @@ to develop a free and open Verilog to bitstream toolchain for these devices.
    architecture/overview
    architecture/configuration
    architecture/bitstream_format
+   architecture/interconnect
    architecture/dram_configuration
    architecture/glossary
+   architecture/reference
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Results can be found at https://mithro-prjxray.readthedocs.io/en/latest/

Fixes https://github.com/SymbiFlow/prjxray/issues/499

 - [x] [Interconnect PIPs](https://github.com/SymbiFlow/prjxray/wiki/Interconnect-PIPs) imported to [XILINX 7-SERIES ARCHITECTURE - Interconnect](https://mithro-prjxray.readthedocs.io/en/latest/architecture/interconnect.html)
 - [x] [References](https://github.com/SymbiFlow/prjxray/wiki/References) imported to [XILINX 7-SERIES ARCHITECTURE - References](https://mithro-prjxray.readthedocs.io/en/latest/architecture/reference.html)
 - [x] [DB Files stuff](https://github.com/SymbiFlow/prjxray/wiki/Database-Files) imported to [Output Format Files - .db](https://mithro-prjxray.readthedocs.io/en/latest/format/db.html) and [Output Format Files - .json](https://mithro-prjxray.readthedocs.io/en/latest/format/tile.html)

Need to clean up the database files section as segment stuff is probably wrong?