### PR TITLE
docs: Trying to fix readthedocs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,8 @@
 # Minimal makefile for Sphinx documentation
 #
 
+MAKEDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
@@ -20,8 +22,8 @@ livehtml:
 
 # Update fuzzer / minitest markdown links.
 fuzzers-links:
-	@cd db_dev_process/fuzzers; rm -f *.md
-	@cd db_dev_process/fuzzers; \
+	@cd $(MAKEDIR)/db_dev_process/fuzzers && rm -f *.md
+	@cd $(MAKEDIR)/db_dev_process/fuzzers && \
 		for i in ../../../fuzzers/*; do \
 			n=$$(basename $$i | sed -e's/^[0-9][0-9][0-9]-//'); \
 			if [ ! -d $$i ]; then \
@@ -39,8 +41,8 @@ fuzzers-links:
 		done
 
 minitests-links:
-	@cd db_dev_process/minitests; rm -f *.md
-	@cd db_dev_process/minitests; \
+	@cd  $(MAKEDIR)/db_dev_process/minitests && rm -f *.md
+	@cd  $(MAKEDIR)/db_dev_process/minitests && \
 		for i in ../../../minitests/*; do \
 			n=$$(basename $$i | sed -e's/^[0-9][0-9][0-9]-//'); \
 			if [ ! -d $$i ]; then \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,19 +74,12 @@ if not on_rtd:
         "conf_py_path": "/doc/",
     }
 else:
+    docs_dir = os.path.abspath(os.path.dirname(__file__))
+    print("Docs dir is:", docs_dir)
     import subprocess
-    subprocess.call(
-        'git fetch origin --unshallow',
-        cwd=os.path.abspath(os.path.dirname(__file__)),
-        shell=True)
-    subprocess.check_call(
-        'git fetch origin --tags',
-        cwd=os.path.abspath(os.path.dirname(__file__)),
-        shell=True)
-    subprocess.check_call(
-        'make links',
-        cwd=os.path.abspath(os.path.dirname(__file__)),
-        shell=True)
+    subprocess.call('git fetch origin --unshallow', cwd=docs_dir, shell=True)
+    subprocess.check_call('git fetch origin --tags', cwd=docs_dir, shell=True)
+    subprocess.check_call('make links', cwd=docs_dir, shell=True)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
```
Running Sphinx v1.8.5
/bin/sh: 1: cd: can't cd to db_dev_process/fuzzers
/bin/sh: 1: cd: can't cd to db_dev_process/fuzzers
Linking ../../../minitests/clb-bused/README.md
Missing ../../../minitests/clb-carry_cin_cyinit/README.md
Missing ../../../minitests/clb-configs/README.md
Linking ../../../minitests/clb-muxf8/README.md
Missing ../../../minitests/clkbuf/README.md
```