### PR TITLE
IOB frame count is 40 not 42.

### DIFF
--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -76,7 +76,7 @@ def run(fn_in, fn_out, verbose=False):
     # FIXME: generate words from pitch
     int_frames, int_words = localutil.get_int_params()
     tdb_fns = [
-        ("iob/build/segbits_tilegrid.tdb", 42, 4),
+        ("iob/build/segbits_tilegrid.tdb", 40, 4),
         ("mmcm/build/segbits_tilegrid.tdb", 30, 101),
         ("pll/build/segbits_tilegrid.tdb", 30, 101),
         ("monitor/build/segbits_tilegrid.tdb", 30, 101),


### PR DESCRIPTION
Because IOB's live at the top of CLB_IO_CLK frame, the maximum on artix7
should be a base address of 0x004015A7, which from a base address of
0x00401580 is 40 frames.