### PR TITLE
Add make targets to build additional outputs from each database.

### DIFF
--- a/.github/kokoro/db-full.sh
+++ b/.github/kokoro/db-full.sh
@@ -76,6 +76,12 @@ echo "----------------------------------------"
 
 # Check the database
 #make checkdb-${XRAY_SETTINGS} || true
+# Generate extra files (additional part yaml's, harness, etc).
+set +e
+# Attempt to generate extras here, but don't check until after diff reporting.
+make db-extras-${XRAY_SETTINGS}
+EXTRAS_RET=$?
+set -e
 # Format the database
 make db-format-${XRAY_SETTINGS}
 # Update the database/Info.md file
@@ -142,6 +148,10 @@ echo "----------------------------------------"
 
 # Check the database and fail if it is broken.
 make db-check-${XRAY_SETTINGS}
+if [[ $EXTRAS_RET != 0 ]] ; then
+    echo "A failure occurred during extras generation."
+    exit $EXTRAS_RET
+fi
 
 # If we get here, then all the fuzzers completed fine. Hence we are
 # going to assume we don't want to keep all the build / logs / etc (as

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,35 @@ endef
 
 $(foreach DB,$(DATABASES),$(eval $(call database,$(DB))))
 
+.PHONY: db-extras-artix7 db-extras-kintex7 db-extras-zynq7
+
+db-extras-artix7:
+	+source minitests/roi_harness/basys3-swbut.sh && $(MAKE) -C fuzzers part_only
+	+source minitests/roi_harness/arty-uart.sh && $(MAKE) -C fuzzers part_only
+	+source minitests/roi_harness/basys3-swbut.sh && \
+		$(MAKE) -C minitests/roi_harness \
+			HARNESS_DIR=database/artix7/harness/basys3/swbut run
+	+source minitests/roi_harness/arty-uart.sh && \
+		$(MAKE) -C minitests/roi_harness \
+			HARNESS_DIR=database/artix7/harness/arty-a7/uart run
+	+source minitests/roi_harness/arty-pmod.sh && \
+		$(MAKE) -C minitests/roi_harness \
+			HARNESS_DIR=database/artix7/harness/arty-a7/pmod run
+	+source minitests/roi_harness/arty-swbut.sh && \
+		$(MAKE) -C minitests/roi_harness \
+			HARNESS_DIR=database/artix7/harness/arty-a7/swbut run
+
+db-extras-kintex7:
+	@true
+
+db-extras-zynq7:
+	+source minitests/roi_harness/zybo-swbut.sh && $(MAKE) -C fuzzers part_only
+	# TODO(#746): Zybo harness is missing some bits, disable automatic harness
+	# generation.
+	#+source minitests/roi_harness/zybo-swbut.sh && \
+	#	$(MAKE) -C minitests/roi_harness \
+	#		HARNESS_DIR=database/artix7/harness/zybo/swbut run
+
 db-check:
 	@true
 

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -111,4 +111,11 @@ $(eval $(call fuzzer,100-dsp-mskpat,005-tilegrid))
 quick:
 	$(MAKE) QUICK=Y
 
-.PHONY: all clean clean_fuzzers clean_logs quick
+# part_only runs the fuzzers required for supporting additional parts.
+# Note: In theory this includes 005-tilegrid, but there isn't support for
+# multiple tilegrid's per family at this time.
+part_only:
+	+$(MAKE) -C 001-part-yaml run
+	+$(MAKE) -C 075-pins run
+
+.PHONY: all clean clean_fuzzers clean_logs quick part_only

--- a/minitests/roi_harness/Makefile
+++ b/minitests/roi_harness/Makefile
@@ -20,5 +20,9 @@ copy: $(HARNESS_FILES)
 clean:
 	rm -rf $(BUILD_DIR) $(HARNESS_DIR)
 
-.PHONY: all clean copy
+run:
+	make clean
+	make copy
+
+.PHONY: all clean copy run
 


### PR DESCRIPTION
These targets are for:
 - Generating additional database outputs that are part, e.g. yaml files.
 - Generating harnesses

Fixes #708