### PR TITLE
fuzzers: Disable retries by default.

### DIFF
--- a/fuzzers/run_fuzzer.py
+++ b/fuzzers/run_fuzzer.py
@@ -346,7 +346,7 @@ def main(argv):
     parser.add_argument(
         "--retries",
         type=int,
-        default=2,
+        default=0,
         help="Retry a failed fuzzer n times.",
     )
     args = parser.parse_args()
@@ -369,6 +369,7 @@ def main(argv):
     assert os.path.exists(fuzzer_logdir)
 
     exit_code = -1
+    args.retries += 1
     for retry_count in range(0, args.retries):
         logger.log('Running fuzzer attempt: {}', [retry_count])
         exit_code = run_fuzzer(


### PR DESCRIPTION
Retries can be re-enabled when #635 is fixed.

Currently the retries are just causing CI to take a long time.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>