### PR TITLE
segprint: drop empty sections with -z -D

### DIFF
--- a/utils/segprint.py
+++ b/utils/segprint.py
@@ -308,7 +308,8 @@ def handle_segment(
         segtags = set()
 
     # Found something to print?
-    keep = not omit_empty_segs or len(segbits) > 0 or len(segtags) > 0
+    keep = not omit_empty_segs or len(segbits) > 0 or (
+        len(segtags) > 0 and not decode_omit)
     if not keep:
         return
 


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>

Segprint proved very handy when working on tasks like #746
The spamming reported in #463 was annoying thought. This small fix addresses the problem.