### PR TITLE
docs: Rename wrong make target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,7 @@ help:
 livehtml:
 	@$(SPHINXAUTOBUILD) -b html --ignore \*.swp --ignore \*~ $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
-.PHONY: help livereload Makefile
+.PHONY: help livehtml Makefile
 
 # Update fuzzer / minitest markdown links.
 fuzzers-links:


### PR DESCRIPTION
@mithro Please merge if you think it's indeed wrong.

Also I'm not sure I see the point of the "Makefile" target but it might be just my lack of skill with Makefiles...