### PR TITLE
Resolve missing IOB bits for Zynq

### DIFF
--- a/fuzzers/030-iob/Makefile
+++ b/fuzzers/030-iob/Makefile
@@ -12,9 +12,11 @@ build/segbits_xiob33.db: build/segbits_xiob33.rdb process_rdb.py bits.dbf
 	${XRAY_MASKMERGE} build/mask_xiob33.db $$(find -name segdata_liob33.txt) $$(find -name segdata_riob33.txt)
 
 pushdb:
+ifneq (${XRAY_DATABASE}, zynq7)
 	${XRAY_MERGEDB} liob33 build/segbits_xiob33.db
-	${XRAY_MERGEDB} riob33 build/segbits_xiob33.db
 	${XRAY_MERGEDB} mask_liob33 build/mask_xiob33.db
+endif
+	${XRAY_MERGEDB} riob33 build/segbits_xiob33.db
 	${XRAY_MERGEDB} mask_riob33 build/mask_xiob33.db
 
 .PHONY: database pushdb

--- a/fuzzers/030-iob/generate.py
+++ b/fuzzers/030-iob/generate.py
@@ -26,6 +26,8 @@ def skip_broken_tiles(d):
     """
     if os.getenv('XRAY_DATABASE') == 'artix7' and d['tile'] == 'LIOB33_X0Y43':
         return True
+    if os.getenv('XRAY_DATABASE') == 'zynq7' and d['tile'] == 'RIOB33_X31Y43':
+        return True
 
     return False
 


### PR DESCRIPTION
This PR solves issue #820.
In #746 we have several bits missing, some of them belong to the IOB tiles.
Those bits were resolved correctly for Artix, hence it had to be analyzed why this doesn't happen for Zynq.
Turned out that alike Artix there seems to be a broken tile that has the bits which are being solved always on.
After this fix the IOB related bits are no longer unknown in the roi harness for zynq.
Also in this PR a small change in the pushdb target was introduced to avoid creating a segbits_liob.db in the database since there are no IOB on the left hand side in Zynq7.