### PR TITLE
Resolve missing CLK_REBUF PIPs bits for Zynq

### DIFF
--- a/fuzzers/043-clk-rebuf-pips/Makefile
+++ b/fuzzers/043-clk-rebuf-pips/Makefile
@@ -1,4 +1,4 @@
-N ?= 25
+N ?= 50
 
 include ../fuzzer.mk
 


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>
In #746  we are still missing few BUFG_REBUF PIPs calcualted in ``043-clk-rebuf-pips``.
To be precise these four PIPs are calculated for Artix, but are not for Zynq:
<pre>
CLK_BUFG_REBUF.CLK_BUFG_REBUF_R_CK_GCLK0_TOP.CLK_BUFG_REBUF_R_CK_GCLK0_BOT 27_13
CLK_BUFG_REBUF.CLK_BUFG_REBUF_R_CK_GCLK16_TOP.CLK_BUFG_REBUF_R_CK_GCLK16_BOT 27_12
CLK_BUFG_REBUF.CLK_BUFG_REBUF_R_CK_GCLK19_TOP.CLK_BUFG_REBUF_R_CK_GCLK19_BOT 27_60
CLK_BUFG_REBUF.CLK_BUFG_REBUF_R_CK_GCLK21_BOT.CLK_BUFG_REBUF_R_CK_GCLK21_TOP 27_94
</pre>
The dbfixup.py script removed these entries because they had 2 candidates while it was clear the features have only one bit.
Increasing the number of specimen in the fuzzer fixed this problem. The fuzzer is rather quick so there is no need to distinguish between Zynq and other architectures.