### PR TITLE
056-pip-rem: Delete net and cell after unsuccessful routing attempt

### DIFF
--- a/fuzzers/056-pip-rem/generate.tcl
+++ b/fuzzers/056-pip-rem/generate.tcl
@@ -111,6 +111,8 @@ proc route_todo {} {
             # sometimes it gets stuck in specific orientations
             if {$tries >= 3} {
                 puts "WARNING: failed to route net after $tries tries"
+                remove_net $mynet
+                remove_cell $mylut
                 break
             }
         }

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -98,8 +98,7 @@ $(eval $(call fuzzer,052-pip-clkin,048-int-piplist))
 $(eval $(call fuzzer,053-pip-ctrlin,048-int-piplist))
 $(eval $(call fuzzer,054-pip-fan-alt,048-int-piplist))
 $(eval $(call fuzzer,055-pip-gnd,048-int-piplist))
-#Disable until all other fuzzer instabilities are fixed
-#$(eval $(call fuzzer,056-pip-rem,049-int-imux-gfan 050-pip-seed 051-pip-imuxlout-bypalts 052-pip-clkin 053-pip-ctrlin 054-pip-fan-alt 055-pip-gnd))
+$(eval $(call fuzzer,056-pip-rem,049-int-imux-gfan 050-pip-seed 051-pip-imuxlout-bypalts 052-pip-clkin 053-pip-ctrlin 054-pip-fan-alt 055-pip-gnd))
 #Disable the longest running fuzzer to speed up test iterations
 #$(eval $(call fuzzer,057-pip-bi,056-pip-rem))
 ifneq ($(QUICK),Y)


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>
This PR is aimed at solving the instability problem with 056-pip-rem fuzzer reported in issue #661.
In brief:
The fuzzer fails with the following error:
<pre>
mynet_28: try 3                                                                 
PIP Tile: INT_L_X20Y94, LUT tile: INT_R_X3Y77                                   
LUT site: SLICE_X5Y77                                                           
route_via mynet_28 INT_L_X20Y94/LOGIC_OUTS_L3 INT_L_X20Y94/WW2BEG3              
Routing net mynet_28:                                                           
  set route [find_routing_path -quiet -from CLBLM_R_X3Y77/CLBLM_L_A -to CLBLM_L_X20Y94/CLBLM_LOGIC_OUTS3]
  CLBLM_R_X3Y77/CLBLM_L_A -> CLBLM_L_X20Y94/CLBLM_LOGIC_OUTS3: no route found - assuming direct PIP
  set route [find_routing_path -quiet -from CLBLM_L_X20Y94/CLBLM_LOGIC_OUTS3 -to INT_L_X20Y94/WW2BEG3]
  CLBLM_L_X20Y94/CLBLM_LOGIC_OUTS3 -> INT_L_X20Y94/WW2BEG3: no route found - assuming direct PIP
  set route [find_routing_path -quiet -from INT_L_X20Y94/WW2BEG3 -to CLBLM_R_X3Y77/CLBLM_L_A6]
  INT_L_X20Y94/WW2BEG3 -> CLBLM_R_X3Y77/CLBLM_L_A6: INT_L_X20Y94/WW2BEG3 INT_L_X18Y94/SS6BEG3 INT_L_X6Y88/LH12 INT_L_X6Y88/LVB_L12 INT_L_X6Y76/WW4BEG2 INT_L_X2Y76/ER1BEG2 INT_R_X3Y76/NR1BEG2 INT_R_X3Y77/IMUX5 CLBLM_R_X3Y77/CLBLM_L_A6
  Failed to route net mynet_28, status UNROUTED, route: CLBLM_R_X3Y77/CLBLM_L_A CLBLM_L_X20Y94/CLBLM_LOGIC_OUTS3 INT_L_X20Y94/WW2BEG3 INT_L_X18Y94/SS6BEG3 INT_L_X6Y88/LH12 INT_L_X6Y88/LVB_L12 INT_L_X6Y76/WW4BEG2 INT_L_X2Y76/ER1BEG2 INT_R_X3Y76/NR1BEG2 INT_R_X3Y77/IMUX5 CLBLM_R_X3Y77/CLBLM_L_A6
WARNING: failed to route net                 

ERROR: [DRC PDIL-1] Invalid Site Configuration: Invalid configuration for site SLICE_X5Y77. Reason: Cannot replace net mynet_28 with net mynet_32 on bel pin A/A
, Cannot replace net mynet_28 with net mynet_32 on bel pin AUSED/0              
, Cannot replace net mynet_28 with net mynet_32 on bel pin AUSED/OUT            
, Site pin to site pin route-thru requires conflicting attribute string values for user logic element 'A6LUT in site 'SLICE_X5Y77'. Attribute 'EQN' is programmed to '2'h0' but needs a value of 'O6=A1' for the route-thru.
.                                                                               
ERROR: [DRC RTSTAT-5] Partial antennas: 1 net(s) have a partial antenna. The problem bus(es) and/or net(s) are mynet_28.
ERROR: [DRC RTSTAT-6] Partial route conflicts: 2 net(s) have a partial conflict. The problem bus(es) and/or net(s) are mynet_28, and mynet_32.
ERROR: [DRC RTSTAT-11] Invalid Site Programming: Invalid site programming for net mynet_28. The following site(s) are invalid: SLICE_X5Y77.
</pre>

The DRC is caused by two nets requiring a conflicting configuration of a site they are routed through. The conflict is usually between a net that previously failed to route and another successfully routed net.

In order to avoid the conflict the net and cell used during the unsuccessful routing attempt is deleted before the script continues to run.