### PR TITLE
Add target to cleanup all piplists

### DIFF
--- a/.github/kokoro/db-full.sh
+++ b/.github/kokoro/db-full.sh
@@ -176,5 +176,6 @@ echo "----------------------------------------"
 	echo
 	echo "Cleaning up so CI doesn't save all the excess data."
 	make clean_fuzzers
+	make clean_piplists
 )
 echo "----------------------------------------"

--- a/fuzzers/050-pip-seed/Makefile
+++ b/fuzzers/050-pip-seed/Makefile
@@ -3,7 +3,7 @@ ifeq ($(QUICK),Y)
 N ?= 1
 SEGMATCH_FLAGS=
 else
-N ?= 48
+N ?= 60
 # Do relatively large batch to keep parallelism high
 # LCM between 12 (CPUs on my system) and 16, a common CPU count
 SEGMATCH_FLAGS=-m 15 -M 45

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -11,10 +11,13 @@ FUZZONLY=N
 BITONLY=N
 
 all:
-clean: clean_fuzzers clean_logs clean_locks
+clean: clean_fuzzers clean_piplists clean_logs clean_locks
 
 clean_locks:
 	rm -rf /tmp/segbits_*.db.lock
+
+clean_piplists:
+	rm -rf $(XRAY_FUZZERS_DIR)/piplist/build
 
 define fuzzer
 


### PR DESCRIPTION
It is possible for a PIP fuzzer to fail after reaching the defined iteration timeout due an incompatible piplist.
This happens when running all the fuzzers for one architecture and then running them for another architecture after just calling ``make clean`` in the ``fuzzers`` directory. The clean target doesn't clean the piplists which can cause problems during the execution of some pip fuzzers.
Namely, the ``todo`` file used in the pip fuzzer, which is generated based on the specific piplist generated for one architecture may not be compatible for another architecture which might not have the same pips.
The symptom is usually that the fuzzer which is set to finish within max 50 iterations, advances to a certain iteration, but later on performs all remaining iterations until 50 without being able to solve any of the remaining PIPs on the todo list, simply because the new architecture doesn't have those PIPs.

This PR adds an explicit clean_piplists target to the Makefile in the ``fuzzers`` directory and also uses that in kokoro's run script.
A separate target was used instead of adding the cleanup to the clean_fuzzers target to avoid forcing the piplist generation for each iteration that is used in pip_loop.mk. 
