### PR TITLE
Generate db files with fuzzer name of origin

### DIFF
--- a/fuzzers/int_maketodo.py
+++ b/fuzzers/int_maketodo.py
@@ -58,7 +58,7 @@ def maketodo(
         with open(dbfile, "r") as f:
             # INT.BYP_ALT0.BYP_BOUNCE_N3_3 !22_07 !23_07 !25_07 21_07 24_07
             for line in f:
-                tag, _bits, mode = util.parse_db_line(line.strip())
+                tag, _bits, mode, _ = util.parse_db_line(line.strip())
                 # Only count resolved entries
                 if mode:
                     continue

--- a/utils/checkdb.py
+++ b/utils/checkdb.py
@@ -67,6 +67,9 @@ def parsedb_all(db_root, verbose=False):
 
     files = 0
     for bit_fn in glob.glob('%s/segbits_*.db' % db_root):
+        # Don't parse db files with fuzzer origin information
+        if "origin_info" in bit_fn:
+            continue
         verbose and print("Checking %s" % bit_fn)
         parsedb.run(bit_fn, fnout=None, strict=True, verbose=verbose)
         files += 1

--- a/utils/dbfixup.py
+++ b/utils/dbfixup.py
@@ -124,7 +124,7 @@ def add_zero_bits(fn_in, zero_db, clb_int=False, strict=True, verbose=False):
             if line == llast:
                 continue
 
-            tag, bits, mode = util.parse_db_line(line)
+            tag, bits, mode, _ = util.parse_db_line(line)
             # an enum that needs masking
             # check below asserts that a mask was actually applied
             if mode and mode != "<0 candidates>" and not strict:

--- a/utils/mergedb.py
+++ b/utils/mergedb.py
@@ -4,7 +4,7 @@ import os
 from prjxray import util
 
 
-def run(fn_ins, fn_out, strict=False, verbose=False):
+def run(fn_ins, fn_out, strict=False, track_origin=False, verbose=False):
     # tag to bits
     entries = {}
     # tag to (bits, line)
@@ -13,18 +13,21 @@ def run(fn_ins, fn_out, strict=False, verbose=False):
     bitss = dict()
 
     for fn_in in fn_ins:
-        for line, (tag, bits, mode) in util.parse_db_lines(fn_in):
+        for line, (tag, bits, mode, origin) in util.parse_db_lines(fn_in):
             line = line.strip()
             assert mode is not None or mode != "always", "strict: got ill defined line: %s" % (
                 line, )
 
             if tag in tags:
-                orig_bits, orig_line = tags[tag]
+                orig_bits, orig_line, orig_origin = tags[tag]
                 if orig_bits != bits:
                     print("WARNING: got duplicate tag %s" % (tag, ))
                     print("  Orig line: %s" % orig_line)
                     print("  New line : %s" % line)
                     assert not strict, "strict: got duplicate tag"
+                origin = os.path.basename(os.getcwd())
+                if track_origin and orig_origin != origin:
+                    origin = orig_origin + "," + origin
             if bits in bitss:
                 orig_tag, orig_line = bitss[bits]
                 if orig_tag != tag:
@@ -33,12 +36,14 @@ def run(fn_ins, fn_out, strict=False, verbose=False):
                     print("  New line : %s" % line)
                     assert not strict, "strict: got duplicate bits"
 
-            entries[tag] = bits
-            tags[tag] = (bits, line)
+            if track_origin and origin is None:
+                origin = os.path.basename(os.getcwd())
+            entries[tag] = (bits, origin)
+            tags[tag] = (bits, line, origin)
             if bits != None:
                 bitss[bits] = (tag, line)
 
-    util.write_db_lines(fn_out, entries)
+    util.write_db_lines(fn_out, entries, track_origin)
 
 
 def main():
@@ -48,6 +53,7 @@ def main():
 
     util.db_root_arg(parser)
     parser.add_argument('--verbose', action='store_true', help='')
+    parser.add_argument('--track_origin', action='store_true', help='')
     parser.add_argument('--out', help='')
     parser.add_argument('ins', nargs='+', help='Last takes precedence')
     args = parser.parse_args()
@@ -56,6 +62,7 @@ def main():
         args.ins,
         args.out,
         strict=int(os.getenv("MERGEDB_STRICT", "1")),
+        track_origin=args.track_origin,
         verbose=args.verbose)
 
 

--- a/utils/mergedb.sh
+++ b/utils/mergedb.sh
@@ -131,6 +131,13 @@ if $ismask ; then
 else
     # tmp1 must be placed second to take precedence over old bad entries
     python3 ${XRAY_DIR}/utils/mergedb.py --out "$tmp2" "$db" "$tmp1"
+    if ! $ismask ; then
+	db_origin=$XRAY_DATABASE_DIR/$XRAY_DATABASE/segbits_$1.origin_info.db
+        if [ ! -f $db_origin ] ; then
+            touch "$db_origin"
+        fi
+        python3 ${XRAY_DIR}/utils/mergedb.py --out "$db_origin" "$db_origin" "$tmp1" --track_origin
+    fi
 fi
 # Check aggregate db for consistency and make canonical
 ${XRAY_PARSEDB} --strict "$tmp2" "$db"

--- a/utils/parsedb.py
+++ b/utils/parsedb.py
@@ -15,7 +15,7 @@ def run(fnin, fnout=None, strict=False, verbose=False):
         # TODO: figure out what to do with masks
         if line.startswith("bit "):
             continue
-        tag, bits, mode = util.parse_db_line(line)
+        tag, bits, mode, _ = util.parse_db_line(line)
         if strict:
             if mode != "always":
                 assert not mode, "strict: got ill defined line: %s" % (line, )

--- a/utils/sort_db.py
+++ b/utils/sort_db.py
@@ -339,6 +339,9 @@ def main(argv):
     for n in sorted(os.listdir()):
         if not os.path.isfile(n):
             continue
+        # Leave db files with fuzzer of origin untouched
+        if "origin_info" in n:
+            continue
 
         base, ext = os.path.splitext(n)
 


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>

Overview:
This PR implements a mechanism to track which fuzzer generated a specific solution described in #816.
Its main purpose is to track which fuzzer is responsible for solving the bits for a given feature.
This piece of information is very useful when debugging db-check failures.

Implementation:
The changes have been added to the mergedb (shell script and python script) which is called in every fuzzer by the pushdb target.

Functionality:
The fuzzer produces or updates additonal db files which apart from the bits for a particular feature also contain the information which fuzzer/fuzzers solved it. The files which are names ``segbits_*.origin_info.db`` are kept next to the regular ``segbits_*.db`` files.

An example with the content of a ``origin_info`` files:
<pre>
INT_R.BYP_ALT6.GFAN1 origin:054-pip-fan-alt !22_55 !23_55 !25_55 20_55 24_55
</pre>
If there are more fuzzers which calculate the solution for a particular tag we have the origin names comma separated:
<pre>
INT_R.BYP_ALT6.LOGIC_OUTS17 origin:051-pip-imuxlout-bypalts,050-pip-seed !22_55 !23_55 !24_55 20_55 25_55
</pre>