### PR TITLE
Fix bit collision caused by unstable 018-bram fuzzer

### DIFF
--- a/fuzzers/018-clb-ram/Makefile
+++ b/fuzzers/018-clb-ram/Makefile
@@ -1,4 +1,4 @@
-N := 2
+N := 4
 SLICEL ?= N
 include ../clb.mk
 


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>

In one of the CI runs for Artix7 (https://source.cloud.google.com/results/invocations/dac25fec-f8e0-43b4-bbf1-07b04e6cb593/targets/foss-fpga-tools%2Fprjxray%2Fpresubmit%2Fdatabase%2Fartix7/log)
I found the following conflict during db-check:
<pre>
00020594_089_23: had CLBLM_R_X11Y144.CLBLM_R.SLICEM_X0.WA8USED, got INT_R_X11Y144.INT_R.BYP_ALT4.GFAN0
</pre>
It turned out that the 018-bram fuzzer produces extra 20_23 bit for WA8USED - I could reproduce it locally.
Since the fuzzer runs very quickly (~1minute) I simply increased the specimen count. After this change I ran the fuzzer for 50 times and the result was correct.