### PR TITLE
053-pip-ctrlin: Fall back to todos bigger than specified number of lines

### DIFF
--- a/fuzzers/pip_loop.mk
+++ b/fuzzers/pip_loop.mk
@@ -22,6 +22,7 @@ SPECIMENS := $(addprefix build/$(ITER)/specimen_,$(shell seq -f '%03.0f' $(N)))
 SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
 # Individual fuzzer directory, such as ~/prjxray/fuzzers/010-lutinit
 export FUZDIR=$(shell pwd)
+export ITER
 
 all: database
 


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>

This PR fixes #843
The origin of the problem is the same as in #838

There are two solution variants:

1. Move the solution of the CTRL*.GFAN01 bits from the 053-pip-ctrlin fuzzer to a new dedicated fuzzer (059-pip-ctrlin-gfan) (https://github.com/antmicro/prjxray/tree/prjxray_stabilization_053_pip_ctrlin_separation). Validated the solution by running both fuzzers for around 30 times without any timeout.
2. Implement the same solution as for #838. This is the preferred solution as it doesn't required adding a new fuzzer to the list.