### PR TITLE
Make build scripts of 007 explicitly use python3

### DIFF
--- a/fuzzers/007-timing/bel/Makefile
+++ b/fuzzers/007-timing/bel/Makefile
@@ -10,14 +10,14 @@ build/bel_timings.json: build/bel_timings.txt
 	python3 tim2json.py --timings=build/bel_timings.txt --json=build/bel_timings.json --properties=build/bel_properties.txt --propertiesmap=properties_map.json --belpins=build/bel_pins.txt --sitepins=build/tile_pins.txt --debug true
 
 build/sdf: build/bel_timings.json
-	python ${XRAY_UTILS_DIR}/makesdf.py --json=${PWD}/build/bel_timings.json --sdf=${PWD}/build
+	python3 ${XRAY_UTILS_DIR}/makesdf.py --json=${PWD}/build/bel_timings.json --sdf=${PWD}/build
 
 cleandb:
 	rm -rf ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/timings
 
 mergesdfs: build/sdf
-	python ${XRAY_UTILS_DIR}/sdfmerge.py --sdfs build/CLBLL_L.sdf build/CLBLL_R.sdf build/CLBLM_L.sdf build/CLBLM_R.sdf --site SLICEM --out build/slicem.sdf
-	python ${XRAY_UTILS_DIR}/sdfmerge.py --sdfs build/CLBLL_L.sdf build/CLBLL_R.sdf build/CLBLM_L.sdf build/CLBLM_R.sdf --site SLICEL --out build/slicel.sdf
+	python3 ${XRAY_UTILS_DIR}/sdfmerge.py --sdfs build/CLBLL_L.sdf build/CLBLL_R.sdf build/CLBLM_L.sdf build/CLBLM_R.sdf --site SLICEM --out build/slicem.sdf
+	python3 ${XRAY_UTILS_DIR}/sdfmerge.py --sdfs build/CLBLL_L.sdf build/CLBLL_R.sdf build/CLBLM_L.sdf build/CLBLM_R.sdf --site SLICEL --out build/slicel.sdf
 
 pushdb: mergesdfs
 	mkdir -p ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/timings

--- a/fuzzers/007-timing/projects/placelut/generate.sh
+++ b/fuzzers/007-timing/projects/placelut/generate.sh
@@ -5,7 +5,7 @@ set -ex
 source ${XRAY_GENHEADER}
 TIMFUZ_DIR=$XRAY_DIR/fuzzers/007-timing
 
-python ../generate.py --sdx 4 --sdy 4  >top.v
+python3 ../generate.py --sdx 4 --sdy 4  >top.v
 ${XRAY_VIVADO} -mode batch -source ../generate.tcl
 python3 $TIMFUZ_DIR/timing_txt2csv.py --speed-json $TIMFUZ_DIR/speed/build/speed.json --out timing4.csv timing4.txt
 

--- a/fuzzers/007-timing/projects/placelut_fb/generate.sh
+++ b/fuzzers/007-timing/projects/placelut_fb/generate.sh
@@ -3,7 +3,7 @@
 set -ex
 source ../generate.sh
 
-python ../generate.py --sdx 4 --sdy 4  >top.v
+python3 ../generate.py --sdx 4 --sdy 4  >top.v
 ${XRAY_VIVADO} -mode batch -source ../generate.tcl
 timing_txt2csv
 

--- a/fuzzers/007-timing/projects/placelut_ff_fb/generate.sh
+++ b/fuzzers/007-timing/projects/placelut_ff_fb/generate.sh
@@ -3,7 +3,7 @@
 set -ex
 source ../generate.sh
 
-python ../generate.py --sdx 4 --sdy 4  >top.v
+python3 ../generate.py --sdx 4 --sdy 4  >top.v
 ${XRAY_VIVADO} -mode batch -source ../generate.tcl
 timing_txt2csv
 

--- a/fuzzers/007-timing/speed/Makefile
+++ b/fuzzers/007-timing/speed/Makefile
@@ -5,7 +5,7 @@ build/node.txt: speed_json.py generate.tcl
 	cd build && ${XRAY_VIVADO} -mode batch -source ../generate.tcl
 
 build/speed.json: build/node.txt
-	cd build && python ../speed_json.py speed_model.txt node.txt speed.json
+	cd build && python3 ../speed_json.py speed_model.txt node.txt speed.json
 
 clean:
 	rm -rf build


### PR DESCRIPTION
Added explicit call to python3 for all related scripts in fuzzer 007. This fixes making local builds when the system default Python is not set as Python3.