### PR TITLE
kokoro: Pack failing test cases instead of vivado logs

### DIFF
--- a/.github/kokoro/continuous-db-artix7.cfg
+++ b/.github/kokoro/continuous-db-artix7.cfg
@@ -12,7 +12,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"

--- a/.github/kokoro/continuous-db-kintex7.cfg
+++ b/.github/kokoro/continuous-db-kintex7.cfg
@@ -12,7 +12,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"

--- a/.github/kokoro/continuous-db-zynq7.cfg
+++ b/.github/kokoro/continuous-db-zynq7.cfg
@@ -12,7 +12,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"

--- a/.github/kokoro/kokoro-cfg.py
+++ b/.github/kokoro/kokoro-cfg.py
@@ -15,7 +15,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"

--- a/.github/kokoro/presubmit-db-artix7.cfg
+++ b/.github/kokoro/presubmit-db-artix7.cfg
@@ -12,7 +12,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"

--- a/.github/kokoro/presubmit-db-kintex7.cfg
+++ b/.github/kokoro/presubmit-db-kintex7.cfg
@@ -12,7 +12,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"

--- a/.github/kokoro/presubmit-db-zynq7.cfg
+++ b/.github/kokoro/presubmit-db-zynq7.cfg
@@ -12,7 +12,7 @@ action {
     regex: "**/diff.patch"
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
-    regex: "**/fuzzers/vivado.tgz"
+    regex: "**/fuzzers/*.tgz"
     # Whole directories
     # regex: "**/build/**" - Currently kokoro dies on number of artifacts.
     regex: "**/build/*.log"


### PR DESCRIPTION
Signed-off-by: Tomasz Michalak <tmichalak@antmicro.com>

When analyzing the root cause of a failing fuzzer we just need its vivado logs.
Therefore there is no need to collect all of them.
What is missing though is often the contents of the build directory.
Collecting it for all fuzzers would kill the CI.
This PR implements the creation of an tgz archive with only the failing test cases.