### PR TITLE
Correct class vs struct usage.

### DIFF
--- a/lib/include/prjxray/xilinx/xc7series/configuration_bus.h
+++ b/lib/include/prjxray/xilinx/xc7series/configuration_bus.h
@@ -42,7 +42,7 @@ class ConfigurationBus {
 	    FrameAddress address) const;
 
        private:
-	friend class YAML::convert<ConfigurationBus>;
+	friend struct YAML::convert<ConfigurationBus>;
 
 	std::map<unsigned int, ConfigurationColumn> configuration_columns_;
 };

--- a/lib/include/prjxray/xilinx/xc7series/configuration_column.h
+++ b/lib/include/prjxray/xilinx/xc7series/configuration_column.h
@@ -36,7 +36,7 @@ class ConfigurationColumn {
 	    FrameAddress address) const;
 
        private:
-	friend class YAML::convert<ConfigurationColumn>;
+	friend struct YAML::convert<ConfigurationColumn>;
 
 	unsigned int frame_count_;
 };

--- a/lib/include/prjxray/xilinx/xc7series/global_clock_region.h
+++ b/lib/include/prjxray/xilinx/xc7series/global_clock_region.h
@@ -45,7 +45,7 @@ class GlobalClockRegion {
 	    FrameAddress address) const;
 
        private:
-	friend class YAML::convert<GlobalClockRegion>;
+	friend struct YAML::convert<GlobalClockRegion>;
 
 	std::map<unsigned int, Row> rows_;
 };

--- a/lib/include/prjxray/xilinx/xc7series/part.h
+++ b/lib/include/prjxray/xilinx/xc7series/part.h
@@ -40,7 +40,7 @@ class Part {
 	    FrameAddress address) const;
 
        private:
-	friend class YAML::convert<Part>;
+	friend struct YAML::convert<Part>;
 
 	uint32_t idcode_;
 	GlobalClockRegion top_region_;

--- a/lib/include/prjxray/xilinx/xc7series/row.h
+++ b/lib/include/prjxray/xilinx/xc7series/row.h
@@ -41,7 +41,7 @@ class Row {
 	    FrameAddress address) const;
 
        private:
-	friend class YAML::convert<Row>;
+	friend struct YAML::convert<Row>;
 
 	std::map<BlockType, ConfigurationBus> configuration_buses_;
 };


### PR DESCRIPTION
yaml-lib defines convert as
```
template<T>
struct convert
```

Not as a ``class``.
