### PR TITLE
007-timing: added missing aliases for bram timing

### DIFF
--- a/fuzzers/007-timing/bel/pin_alias_map.json
+++ b/fuzzers/007-timing/bel/pin_alias_map.json
@@ -12,6 +12,22 @@
          }
     },
     "rambfifo36e1" : {
+         "REGCEAREGCEL" : {
+             "names" : ["regceal"],
+             "is_property_related" : false
+         },
+         "REGCEAREGCEU" : {
+             "names" : ["regceau"],
+             "is_property_related" : false
+         },
+         "RSTREGARSTREGL" : {
+             "names" : ["rstregal"],
+             "is_property_related" : false
+         },
+         "RSTREGARSTREGU" : {
+             "names" : ["rstregau"],
+             "is_property_related" : false
+         },
          "RSTRAMARSTRAMLRST" : {
              "names" : ["rstramarstl"],
              "is_property_related" : false
@@ -54,6 +70,22 @@
          },
          "DOPBDOP0" : {
              "names" : ["dopbdopl", "dopbdopu"],
+             "is_property_related" : false
+         },
+         "DIADI0" : {
+             "names" : ["diadil", "diadiu"],
+             "is_property_related" : false
+         },
+         "DIBDI0" : {
+             "names" : ["dibdil", "dibdiu"],
+             "is_property_related" : false
+         },
+         "DIPADIP0" : {
+             "names" : ["dipadipl", "dipadipu"],
+             "is_property_related" : false
+         },
+         "DIPBDIP0" : {
+             "names" : ["dipbdipl", "dipbdipu"],
              "is_property_related" : false
          }
     }


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to add missing aliases to the `pin_alias_map.json`. The reason is that some timing definitions were missing in the bram sdf files because some pins/ports were skipped as the `tim2json.py` was not able to find the timing relative to those pins/ports