### PR TITLE
Minitests for SRLs

### DIFF
--- a/minitests/srl/Makefile
+++ b/minitests/srl/Makefile
@@ -52,6 +52,9 @@ endif
         $< >$@ \
         || (rm -f $@ && exit 1)
 
+%.unique.fasm: %.fasm
+	@sort -u $< >$@
+
 %.bits: %.bit
 	$(XRAY_BITREAD) -part_file $(XRAY_DIR)/database/artix7/$(PART).yaml -o $@ -z -y $<
 

--- a/minitests/srl/Makefile
+++ b/minitests/srl/Makefile
@@ -1,0 +1,45 @@
+YOSYS = $(XRAY_DIR)/third_party/yosys/yosys
+PART = xc7a35tcsg324-1
+BIT2FASM_ARGS = --part "$(XRAY_DIR)/database/artix7/$(PART)" --verbose
+
+VERILOG_FILES = $(wildcard *.v)
+FASM_TARGETS = $(VERILOG_FILES:.v=.fasm)
+SEGPRINT_TARGETS = $(VERILOG_FILES:.v=.segprint.log)
+
+all: $(FASM_TARGETS) $(SEGPRINT_TARGETS)
+
+clean:
+	@find . -name "build.*" | xargs rm -rf
+	@rm -f *.edif
+	@rm -f *.bit
+	@rm -f *.bin
+	@rm -f *.bits
+	@rm -f *.fasm
+	@rm -f *.log
+	@rm -f *.dcp
+
+.PHONY: all clean
+
+$(YOSYS):
+	cd $(XRAY_DIR)/third_party/yosys && make config-gcc && make -j$(shell nproc)
+
+%.edif: %.v $(YOSYS)
+	$(YOSYS) -p "read_verilog $< ; synth_xilinx -flatten -nosrl -edif $@"  -l $@.log
+
+%.bit: %.edif par.tcl
+	mkdir -p build.$(basename $@)
+	cd build.$(basename $@) && env PROJECT_NAME=$(basename $@) $(XRAY_VIVADO) -mode batch -source ../par.tcl -nojournal -log ../$@.log
+	rm -rf *.backup.log
+
+%.fasm: %.bit
+	PYTHONPATH="$(XRAY_DIR):$(XRAY_DIR)/utils:$(XRAY_DIR)/third_party/fasm" \
+    PATH="$(XRAY_DIR)/build/tools:$(PATH)" \
+    $(XRAY_BIT2FASM) $(BIT2FASM_ARGS) \
+        $< >$@ \
+        || (rm -f $@ && exit 1)
+
+%.bits: %.bit
+	$(XRAY_BITREAD) -part_file $(XRAY_DIR)/database/artix7/$(PART).yaml -o $@ -z -y $<
+
+%.segprint.log: %.bits
+	$(XRAY_SEGPRINT) -z -D -b $< > $@

--- a/minitests/srl/Makefile
+++ b/minitests/srl/Makefile
@@ -30,7 +30,7 @@ $(YOSYS):
 
 ifeq ($(SYNTH), yosys)
 %.edif: %.v $(YOSYS)
-	$(YOSYS) -p "read_verilog $< ; synth_xilinx -flatten -nosrl -edif $@"  -l $@.log
+	$(YOSYS) -p "read_verilog $< ; synth_xilinx -flatten -nosrl; write_edif -pvector bra -attrprop $@"  -l $@.log
 
 else ifeq ($(SYNTH), vivado)
 %.edif: %.v $(YOSYS)

--- a/minitests/srl/Makefile
+++ b/minitests/srl/Makefile
@@ -1,3 +1,4 @@
+SYNTH ?= vivado
 YOSYS = $(XRAY_DIR)/third_party/yosys/yosys
 PART = xc7a35tcsg324-1
 BIT2FASM_ARGS = --part "$(XRAY_DIR)/database/artix7/$(PART)" --verbose
@@ -9,7 +10,8 @@ SEGPRINT_TARGETS = $(VERILOG_FILES:.v=.segprint.log)
 all: $(FASM_TARGETS) $(SEGPRINT_TARGETS)
 
 clean:
-	@find . -name "build.*" | xargs rm -rf
+	@find . -name "build-par.*" | xargs rm -rf
+	@find . -name "build-syn.*" | xargs rm -rf
 	@rm -f *.edif
 	@rm -f *.bit
 	@rm -f *.bin
@@ -18,17 +20,29 @@ clean:
 	@rm -f *.log
 	@rm -f *.dcp
 
-.PHONY: all clean
+help:
+	@echo "Usage: make all [SYNTH=<vivado/yosys>]"
+
+.PHONY: all clean help
 
 $(YOSYS):
 	cd $(XRAY_DIR)/third_party/yosys && make config-gcc && make -j$(shell nproc)
 
+ifeq ($(SYNTH), yosys)
 %.edif: %.v $(YOSYS)
 	$(YOSYS) -p "read_verilog $< ; synth_xilinx -flatten -nosrl -edif $@"  -l $@.log
 
+else ifeq ($(SYNTH), vivado)
+%.edif: %.v $(YOSYS)
+	mkdir -p build-syn.$(basename $@)
+	cd build-syn.$(basename $@) && env PROJECT_NAME=$(basename $@) $(XRAY_VIVADO) -mode batch -source ../syn.tcl -nojournal -log ../$@.log
+	rm -rf *.backup.log
+
+endif
+
 %.bit: %.edif par.tcl
-	mkdir -p build.$(basename $@)
-	cd build.$(basename $@) && env PROJECT_NAME=$(basename $@) $(XRAY_VIVADO) -mode batch -source ../par.tcl -nojournal -log ../$@.log
+	mkdir -p build-par.$(basename $@)
+	cd build-par.$(basename $@) && env PROJECT_NAME=$(basename $@) $(XRAY_VIVADO) -mode batch -source ../par.tcl -nojournal -log ../$@.log
 	rm -rf *.backup.log
 
 %.fasm: %.bit

--- a/minitests/srl/README.md
+++ b/minitests/srl/README.md
@@ -1,0 +1,5 @@
+# Minitests for SRLs
+
+This is a minitest for various SRL configurations.
+
+Uses Yosys to generate EDIF which is then P&R'd by Vivado. The makefile also invokes bit2fasm and segprint

--- a/minitests/srl/par.tcl
+++ b/minitests/srl/par.tcl
@@ -1,0 +1,36 @@
+create_project -force -name $env(PROJECT_NAME) -part xc7a35ticsg324-1L
+
+#read_xdc ../top.xdc
+read_edif ../$env(PROJECT_NAME).edif
+
+link_design -part xc7a35ticsg324-1L
+
+report_timing_summary -file top_timing_synth.rpt
+report_utilization -hierarchical -file top_utilization_hierarchical_synth.rpt
+report_utilization -file top_utilization_synth.rpt
+
+opt_design
+place_design
+
+report_utilization -hierarchical -file top_utilization_hierarchical_place.rpt
+report_utilization -file top_utilization_place.rpt
+report_io -file top_io.rpt
+report_control_sets -verbose -file top_control_sets.rpt
+report_clock_utilization -file top_clock_utilization.rpt
+
+route_design
+#phys_opt_design
+
+report_timing_summary -no_header -no_detailed_paths
+
+write_checkpoint -force ../$env(PROJECT_NAME).dcp
+
+set_property SEVERITY {Warning} [get_drc_checks UCIO-1]
+set_property SEVERITY {Warning} [get_drc_checks NSTD-1]
+
+report_route_status -file top_route_status.rpt
+report_drc -file top_drc.rpt
+report_timing_summary -datasheet -max_paths 10 -file top_timing.rpt
+report_power -file top_power.rpt
+
+write_bitstream -force ../$env(PROJECT_NAME).bit

--- a/minitests/srl/srl32_init.v
+++ b/minitests/srl/srl32_init.v
@@ -1,0 +1,25 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire Q
+);
+
+  (* LOC="SLICE_X2Y0", BEL="A6LUT"  *)
+  SRLC32E #
+  (
+  .INIT(32'hF0F01030)
+  )
+  srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q)
+  );
+
+endmodule

--- a/minitests/srl/srl32_x1.v
+++ b/minitests/srl/srl32_x1.v
@@ -1,0 +1,21 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire Q
+);
+
+  (* LOC="SLICE_X2Y0", BEL="A6LUT"  *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q)
+  );
+
+endmodule

--- a/minitests/srl/srl32_x1_and_lut6_x3.v
+++ b/minitests/srl/srl32_x1_and_lut6_x3.v
@@ -1,0 +1,62 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [5:0] I,
+input  wire [4:0] A,
+output wire [3:0] Q
+);
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="A6LUT" *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[0])
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="B6LUT" *)
+  LUT6 lut_b
+  (
+  .I0     (I[0]),
+  .I1     (I[1]),
+  .I2     (I[2]),
+  .I3     (I[3]),
+  .I4     (I[4]),
+  .I5     (I[5]),
+  .O      (Q[1])
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="C6LUT" *)
+  LUT6 lut_c
+  (
+  .I0     (I[0]),
+  .I1     (I[1]),
+  .I2     (I[2]),
+  .I3     (I[3]),
+  .I4     (I[4]),
+  .I5     (I[5]),
+  .O      (Q[2])
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="D6LUT" *)
+  LUT6 lut_d
+  (
+  .I0     (I[0]),
+  .I1     (I[1]),
+  .I2     (I[2]),
+  .I3     (I[3]),
+  .I4     (I[4]),
+  .I5     (I[5]),
+  .O      (Q[3])
+  );
+
+endmodule

--- a/minitests/srl/srl32_x2.v
+++ b/minitests/srl/srl32_x2.v
@@ -1,0 +1,31 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire [1:0] Q
+);
+
+  (* LOC="SLICE_X2Y0", BEL="A6LUT"  *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[0])
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="B6LUT"  *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[1])
+  );
+
+endmodule

--- a/minitests/srl/srl32_x2_and_lut6_x2.v
+++ b/minitests/srl/srl32_x2_and_lut6_x2.v
@@ -1,0 +1,63 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [5:0] I,
+input  wire [4:0] A,
+output wire [3:0] Q
+);
+
+  wire srl_b_mc31;
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="A6LUT" *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (srl_b_mc31),
+  .A      (A),
+  .Q      (Q[0])
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="B6LUT" *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[1]),
+  .Q31    (srl_b_mc31)
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="C6LUT" *)
+  LUT6 lut_c
+  (
+  .I0     (I[0]),
+  .I1     (I[1]),
+  .I2     (I[2]),
+  .I3     (I[3]),
+  .I4     (I[4]),
+  .I5     (I[5]),
+  .O      (Q[2])
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="D6LUT" *)
+  LUT6 lut_d
+  (
+  .I0     (I[0]),
+  .I1     (I[1]),
+  .I2     (I[2]),
+  .I3     (I[3]),
+  .I4     (I[4]),
+  .I5     (I[5]),
+  .O      (Q[3])
+  );
+
+endmodule

--- a/minitests/srl/srl32_x2_chain.v
+++ b/minitests/srl/srl32_x2_chain.v
@@ -1,0 +1,33 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire Q
+);
+
+  wire  q31_d;
+
+  (* LOC="SLICE_X2Y0", BEL="D6LUT"  *)
+  SRLC32E srl_d
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q31    (q31_d)
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="C6LUT"  *)
+  SRLC32E srl_c
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (q31_d),
+  .A      (A),
+  .Q      (Q)
+  );
+
+endmodule

--- a/minitests/srl/srl32_x3.v
+++ b/minitests/srl/srl32_x3.v
@@ -1,0 +1,41 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire [2:0] Q
+);
+
+  (* LOC="SLICE_X2Y0", BEL="A6LUT"  *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[0])
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="B6LUT"  *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[1])
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="C6LUT"  *)
+  SRLC32E srl_c
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[2])
+  );
+
+endmodule

--- a/minitests/srl/srl32_x3_and_lut6_x1.v
+++ b/minitests/srl/srl32_x3_and_lut6_x1.v
@@ -1,0 +1,63 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [5:0] I,
+input  wire [4:0] A,
+output wire [3:0] Q
+);
+
+  wire srl_b_mc31;
+  wire srl_c_mc31;
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="A6LUT" *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (srl_b_mc31),
+  .A      (A),
+  .Q      (Q[0])
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="B6LUT" *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (srl_c_mc31),
+  .A      (A),
+  .Q      (Q[1]),
+  .Q31    (srl_b_mc31)
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="C6LUT" *)
+  SRLC32E srl_c
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[2]),
+  .Q31    (srl_c_mc31)
+  );
+
+  (* DONT_TOUCH="yes" *)
+  (* LOC="SLICE_X2Y0", BEL="D6LUT" *)
+  LUT6 lut_d
+  (
+  .I0     (I[0]),
+  .I1     (I[1]),
+  .I2     (I[2]),
+  .I3     (I[3]),
+  .I4     (I[4]),
+  .I5     (I[5]),
+  .O      (Q[3])
+  );
+
+endmodule

--- a/minitests/srl/srl32_x3_chain.v
+++ b/minitests/srl/srl32_x3_chain.v
@@ -1,0 +1,44 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire Q
+);
+
+  wire  q31_d;
+  wire  q31_c;
+
+  (* LOC="SLICE_X2Y0", BEL="D6LUT"  *)
+  SRLC32E srl_d
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q31    (q31_d)
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="C6LUT"  *)
+  SRLC32E srl_c
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (q31_d),
+  .A      (A),
+  .Q31    (q31_c)
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="B6LUT"  *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (q31_c),
+  .A      (A),
+  .Q      (Q)
+  );
+
+endmodule

--- a/minitests/srl/srl32_x4.v
+++ b/minitests/srl/srl32_x4.v
@@ -1,0 +1,51 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire [3:0] Q
+);
+
+  (* LOC="SLICE_X2Y0", BEL="A6LUT"  *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[0])
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="B6LUT"  *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[1])
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="C6LUT"  *)
+  SRLC32E srl_c
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[2])
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="D6LUT"  *)
+  SRLC32E srl_d
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q      (Q[3])
+  );
+
+endmodule

--- a/minitests/srl/srl32_x4_chain.v
+++ b/minitests/srl/srl32_x4_chain.v
@@ -1,0 +1,55 @@
+module top
+(
+(* clock_buffer_type = "NONE" *)
+input  wire CLK,
+input  wire CE,
+input  wire D,
+input  wire [4:0] A,
+output wire Q
+);
+
+  wire  q31_d;
+  wire  q31_c;
+  wire  q31_b;
+
+  (* LOC="SLICE_X2Y0", BEL="D6LUT"  *)
+  SRLC32E srl_d
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (D),
+  .A      (A),
+  .Q31    (q31_d)
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="C6LUT"  *)
+  SRLC32E srl_c
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (q31_d),
+  .A      (A),
+  .Q31    (q31_c)
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="B6LUT"  *)
+  SRLC32E srl_b
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (q31_c),
+  .A      (A),
+  .Q      (q31_b)
+  );
+
+  (* LOC="SLICE_X2Y0", BEL="A6LUT"  *)
+  SRLC32E srl_a
+  (
+  .CLK    (CLK),
+  .CE     (CE),
+  .D      (q31_b),
+  .A      (A),
+  .Q      (Q)
+  );
+
+endmodule

--- a/minitests/srl/syn.tcl
+++ b/minitests/srl/syn.tcl
@@ -1,0 +1,11 @@
+create_project -force -name $env(PROJECT_NAME) -part xc7a35ticsg324-1L
+
+read_verilog ../$env(PROJECT_NAME).v
+
+synth_design -top top
+
+report_timing_summary -file top_timing_synth.rpt
+report_utilization -hierarchical -file top_utilization_hierarchical_synth.rpt
+report_utilization -file top_utilization_synth.rpt
+
+write_edif -force ../$env(PROJECT_NAME).edif


### PR DESCRIPTION
This PR adds several minitests for SRL32 (for now). Helps to identify which FASM features and in which combination are required to make SRLs work.

Each design can be built using Yosys+Vivado flow. After a build `bit2fasm` and `segprint` scripts are invoked.