### PR TITLE
036-iob-ologic: Solve bits for DATA_RATE_OQ

### DIFF
--- a/fuzzers/036-iob-ologic/generate.py
+++ b/fuzzers/036-iob-ologic/generate.py
@@ -18,16 +18,6 @@ def handle_data_width(segmk, d):
             d['DATA_WIDTH'] == opt)
 
 
-def handle_data_rate(segmk, d):
-    if 'DATA_WIDTH' not in d:
-        return
-
-    for opt in ['SDR', 'DDR']:
-        segmk.add_site_tag(
-            d['site'], 'OSERDESE.DATA_RATE.{}'.format(opt),
-            verilog.unquote(d['DATA_RATE_OQ']) == opt)
-
-
 def main():
     print("Loading tags")
     segmk = Segmaker("design.bits")
@@ -39,7 +29,6 @@ def main():
             site = d['site']
 
             handle_data_width(segmk, d)
-            handle_data_rate(segmk, d)
 
             if d['use_oserdese2']:
                 if 'SRTYPE' in d:


### PR DESCRIPTION
DATA_RATE and DATA_RATE_OQ tags were generated from the same parameter which resulted in the solution being the same bit. This led to dbfixup rejecting the solution, hence the bits never made it to the final segbits.