### PR TITLE
Pushing bits for IOI3 to the DB also for TBYTESRC and TBYTETERM tiles

### DIFF
--- a/fuzzers/035a-iob-idelay/Makefile
+++ b/fuzzers/035a-iob-idelay/Makefile
@@ -12,9 +12,17 @@ build/segbits_xiob33.db: build/segbits_xiob33.rdb
 
 pushdb:
 	${XRAY_MERGEDB} lioi3 build/segbits_xiob33.db
+	${XRAY_MERGEDB} lioi3_tbytesrc build/segbits_xiob33.db
+	${XRAY_MERGEDB} lioi3_tbyteterm build/segbits_xiob33.db
 	${XRAY_MERGEDB} rioi3 build/segbits_xiob33.db
+	${XRAY_MERGEDB} rioi3_tbytesrc build/segbits_xiob33.db
+	${XRAY_MERGEDB} rioi3_tbyteterm build/segbits_xiob33.db
 	${XRAY_MERGEDB} mask_lioi3 build/mask_xiob33.db
+	${XRAY_MERGEDB} mask_lioi3_tbytesrc build/mask_xiob33.db
+	${XRAY_MERGEDB} mask_lioi3_tbyteterm build/mask_xiob33.db
 	${XRAY_MERGEDB} mask_rioi3 build/mask_xiob33.db
+	${XRAY_MERGEDB} mask_rioi3_tbytesrc build/mask_xiob33.db
+	${XRAY_MERGEDB} mask_rioi3_tbyteterm build/mask_xiob33.db
 
 .PHONY: database pushdb
 

--- a/utils/mergedb.sh
+++ b/utils/mergedb.sh
@@ -117,8 +117,20 @@ case "$1" in
 	lioi3)
 		sed < "$2" > "$tmp1" -e 's/^IOI3\./LIOI3./' ;;
 
+	lioi3_tbytesrc)
+		sed < "$2" > "$tmp1" -e 's/^IOI3\./LIOI3_TBYTESRC./' ;;
+
+	lioi3_tbyteterm)
+		sed < "$2" > "$tmp1" -e 's/^IOI3\./LIOI3_TBYTETERM./' ;;
+
 	rioi3)
 		sed < "$2" > "$tmp1" -e 's/^IOI3\./RIOI3./' ;;
+
+	rioi3_tbytesrc)
+		sed < "$2" > "$tmp1" -e 's/^IOI3\./RIOI3_TBYTESRC./' ;;
+
+	rioi3_tbyteterm)
+		sed < "$2" > "$tmp1" -e 's/^IOI3\./RIOI3_TBYTETERM./' ;;
 
 	cmt_top_r_upper_t)
 		sed < "$2" > "$tmp1" -e 's/^CMT_UPPER_T\./CMT_TOP_R_UPPER_T./' ;;


### PR DESCRIPTION
With this PR IDELAY bits solved for LIOI3 and RIOI3 tiles are pushed to the DB for:
- LIOI3_TBYTESRC
- LIOI3_TBYTETERM
- RIOI3_TBYTESRC
- RIOI3_TBYTETERM