### PR TITLE
Add ROI harness for the X1Y0 clock region

### DIFF
--- a/minitests/roi_harness/basys3-x1y0-common.sh
+++ b/minitests/roi_harness/basys3-x1y0-common.sh
@@ -1,0 +1,43 @@
+# XC7A35T-1CPG236C
+export XRAY_PART=xc7a35tcpg236-1
+if [ -z "$XRAY_PINCFG" ]; then
+	echo "XRAY_PINCFG not set"
+	return 1
+fi
+if [ -z "$XRAY_DIN_N_LARGE" ]; then
+	echo "XRAY_DIN_N_LARGE not set"
+	return 1
+fi
+if [ -z "$XRAY_DOUT_N_LARGE" ]; then
+	echo "XRAY_DOUT_N_LARGE not set"
+	return 1
+fi
+
+# For generating DB
+export XRAY_PIN_00="V2"
+export XRAY_PIN_01="W2"
+export XRAY_PIN_02="V3"
+export XRAY_PIN_03="W3"
+
+# ROI is in the top left
+export XRAY_ROI_LARGE=SLICE_X36Y0:SLICE_X65Y49
+
+# HCLK Tile
+export XRAY_ROI_HCLK="CLK_HROW_BOT_R_X60Y26/CLK_HROW_CK_BUFHCLK_R0"
+
+# PITCH
+export XRAY_PITCH=2
+
+# INT_L/R for DOUT and DIN
+export XRAY_ROI_DIN_INT_L_X="0"
+export XRAY_ROI_DIN_INT_R_X="25"
+export XRAY_ROI_DOUT_INT_L_X="2"
+export XRAY_ROI_DOUT_INT_R_X="23"
+
+# PIPS for DOUT and DIN
+export XRAY_ROI_DIN_LPIP="EE2BEG2"
+export XRAY_ROI_DIN_RPIP="WW2BEG1"
+export XRAY_ROI_DOUT_LPIP="SW6BEG0"
+export XRAY_ROI_DOUT_RPIP="LH12"
+
+source $XRAY_DIR/utils/environment.sh

--- a/minitests/roi_harness/basys3-x1y0-fixed.xdc
+++ b/minitests/roi_harness/basys3-x1y0-fixed.xdc
@@ -1,0 +1,49 @@
+# assign pins
+set_property -dict {PACKAGE_PIN V2 IOSTANDARD LVCMOS33} [get_ports {din[0]}]
+set_property -dict {PACKAGE_PIN W2 IOSTANDARD LVCMOS33} [get_ports {din[1]}]
+set_property -dict {PACKAGE_PIN V3 IOSTANDARD LVCMOS33} [get_ports {dout[0]}]
+set_property -dict {PACKAGE_PIN W3 IOSTANDARD LVCMOS33} [get_ports {dout[1]}]
+set_property -dict {PACKAGE_PIN W5 IOSTANDARD LVCMOS33} [get_ports {clk}]
+
+# create roi pblock
+create_pblock roi
+add_cells_to_pblock [get_pblocks roi] [get_cells -quiet [list roi]]
+resize_pblock [get_pblocks roi] -add {SLICE_X36Y0:SLICE_X65Y49}
+set_property CONTAIN_ROUTING 1 [get_pblocks roi]
+set_property EXCLUDE_PLACEMENT 1 [get_pblocks roi]
+
+# other stuff
+set_property DONT_TOUCH true [get_cells roi]
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+
+# fix LUT locations
+
+## ins
+set_property BEL A6LUT [get_cells {roi/ins[0].lut}]
+set_property LOC SLICE_X64Y40 [get_cells {roi/ins[0].lut}]
+set_property BEL A6LUT [get_cells {roi/ins[1].lut}]
+set_property LOC SLICE_X64Y39 [get_cells {roi/ins[1].lut}]
+
+## outs
+set_property BEL A6LUT [get_cells {roi/outs[0].lut}]
+set_property LOC SLICE_X64Y38 [get_cells {roi/outs[0].lut}]
+set_property BEL A6LUT [get_cells {roi/outs[1].lut}]
+set_property LOC SLICE_X64Y37 [get_cells {roi/outs[1].lut}]
+
+## clk
+set_property BEL AFF [get_cells {roi/clk_reg_reg}]
+set_property LOC SLICE_X36Y24 [get_cells {roi/clk_reg_reg}]
+
+
+# fix routes
+set_property FIXED_ROUTE { { IOB_IBUF0 RIOI_I0 RIOI_ILOGIC0_D IOI_ILOGIC0_O IOI_LOGIC_OUTS18_1 INT_INTERFACE_LOGIC_OUTS18 WL1BEG_N3 NW2BEG0 IMUX7 CLBLM_M_A1 }  } [get_nets {din_IBUF[0]}]
+set_property FIXED_ROUTE { { IOB_IBUF1 RIOI_I1 RIOI_ILOGIC1_D IOI_ILOGIC1_O IOI_LOGIC_OUTS18_0 INT_INTERFACE_LOGIC_OUTS18 WL1BEG_N3 NW2BEG0 IMUX7 CLBLM_M_A1 }  } [get_nets {din_IBUF[1]}]
+
+set_property FIXED_ROUTE { { CLBLM_M_A CLBLM_LOGIC_OUTS12 EE2BEG0 BYP_ALT0 BYP_BOUNCE0 IMUX34 IOI_OLOGIC0_D1 RIOI_OLOGIC0_OQ RIOI_O0 }  } [get_nets {roi/dout[0]}]
+set_property FIXED_ROUTE { { CLBLM_M_A CLBLM_LOGIC_OUTS12 EE2BEG0 BYP_ALT0 BYP_BOUNCE0 IMUX34 IOI_OLOGIC1_D1 RIOI_OLOGIC1_OQ RIOI_O1 }  } [get_nets {roi/dout[1]}]
+
+set_property FIXED_ROUTE {} [get_nets roi/<const0>]
+
+# revert back to original instance
+current_instance -quiet

--- a/minitests/roi_harness/basys3-x1y0-swbut.sh
+++ b/minitests/roi_harness/basys3-x1y0-swbut.sh
@@ -1,0 +1,8 @@
+# XC7A35T-1CPG236C
+export XRAY_PINCFG=BASYS3-X1Y0-SWBUT
+export XRAY_DIN_N_LARGE=2
+export XRAY_DOUT_N_LARGE=2
+export HARNESS_DIR=$XRAY_DIR/database/artix7/harness/basys3/x1y0-swbut/
+export XRAY_FIXED_XDC=../basys3-x1y0-fixed.xdc
+
+source $XRAY_DIR/minitests/roi_harness/basys3-x1y0-common.sh

--- a/minitests/roi_harness/runme.tcl
+++ b/minitests/roi_harness/runme.tcl
@@ -249,6 +249,26 @@ if {$part eq "xc7a50tfgg484-1"} {
             set pin [lindex $outs $i]
             set net2pin(dout[$i]) $pin
         }
+    } elseif {$pincfg eq "BASYS3-X1Y0-SWBUT"} {
+        # Slide switches
+        set ins "V2 W2"
+        set outs "V3 W3"
+
+        # 100 MHz CLK onboard
+        set pin "W5"
+        set net2pin(clk) $pin
+
+        # DIN
+        for {set i 0} {$i < $DIN_N} {incr i} {
+            set pin [lindex $ins $i]
+            set net2pin(din[$i]) $pin
+        }
+
+        # DOUT
+        for {set i 0} {$i < $DOUT_N} {incr i} {
+            set pin [lindex $outs $i]
+            set net2pin(dout[$i]) $pin
+        }
     } else {
         error "Unsupported config $pincfg"
     }


### PR DESCRIPTION
This adds a simple harness in the X1Y0 clock region (bottom right) where two inputs and two outputs are connected to the closest corresponding LUT.

This is helpful to understand IO.

- tested with roi_inv.v on hardware

![Screenshot from 2019-07-24 17-17-58](https://user-images.githubusercontent.com/1069462/61836879-2644fb00-ae37-11e9-936a-f36745e82bc4.png)
