### PR TITLE
ISERDES FASM feature improvements

### DIFF
--- a/fuzzers/035-iob-ilogic/generate.py
+++ b/fuzzers/035-iob-ilogic/generate.py
@@ -24,7 +24,7 @@ def handle_data_width(segmk, d):
 
     for opt in [2, 3, 4, 5, 6, 7, 8, 10, 14]:
         segmk.add_site_tag(
-            d['site'], 'ISERDES.DATA_WIDTH.{}'.format(opt),
+            d['site'], 'ISERDES.DATA_WIDTH.W{}'.format(opt),
             d['DATA_WIDTH'] == opt)
 
 
@@ -159,34 +159,34 @@ def main():
                             verilog.unquote(d['DDR_CLK_EDGE']) == opt)
 
             if d['iddr_mux_config'] == 'direct':
-                segmk.add_site_tag(site, 'IFFDELMUXE3.0', 0)
-                segmk.add_site_tag(site, 'IFFDELMUXE3.1', 1)
-                segmk.add_site_tag(site, 'IFFDELMUXE3.2', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P0', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P1', 1)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P2', 0)
             elif d['iddr_mux_config'] == 'idelay':
-                segmk.add_site_tag(site, 'IFFDELMUXE3.0', 1)
-                segmk.add_site_tag(site, 'IFFDELMUXE3.1', 0)
-                segmk.add_site_tag(site, 'IFFDELMUXE3.2', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P0', 1)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P1', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P2', 0)
             elif d['iddr_mux_config'] == 'none':
-                segmk.add_site_tag(site, 'IFFDELMUXE3.0', 0)
-                segmk.add_site_tag(site, 'IFFDELMUXE3.1', 0)
-                segmk.add_site_tag(site, 'IFFDELMUXE3.2', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P0', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P1', 0)
+                segmk.add_site_tag(site, 'IFFDELMUXE3.P2', 0)
             else:
                 assert False, d['mux_config']
 
             if d['mux_config'] == 'direct':
-                segmk.add_site_tag(site, 'IDELMUXE3.0', 0)
-                segmk.add_site_tag(site, 'IDELMUXE3.1', 1)
-                segmk.add_site_tag(site, 'IDELMUXE3.2', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P0', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P1', 1)
+                segmk.add_site_tag(site, 'IDELMUXE3.P2', 0)
 
             elif d['mux_config'] == 'idelay':
-                segmk.add_site_tag(site, 'IDELMUXE3.0', 1)
-                segmk.add_site_tag(site, 'IDELMUXE3.1', 0)
-                segmk.add_site_tag(site, 'IDELMUXE3.2', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P0', 1)
+                segmk.add_site_tag(site, 'IDELMUXE3.P1', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P2', 0)
 
             elif d['mux_config'] == 'none':
-                segmk.add_site_tag(site, 'IDELMUXE3.0', 0)
-                segmk.add_site_tag(site, 'IDELMUXE3.1', 0)
-                segmk.add_site_tag(site, 'IDELMUXE3.2', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P0', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P1', 0)
+                segmk.add_site_tag(site, 'IDELMUXE3.P2', 0)
             else:
                 assert False, d['mux_config']
 

--- a/fuzzers/035-iob-ilogic/generate.tcl
+++ b/fuzzers/035-iob-ilogic/generate.tcl
@@ -86,6 +86,7 @@ proc run {} {
     set_property CONFIG_VOLTAGE 3.3 [current_design]
     set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
     set_property IS_ENABLED 0 [get_drc_checks {REQP-79}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-105}]
     set_property IS_ENABLED 0 [get_drc_checks {PDRC-26}]
 
     write_checkpoint -force design_pre_place.dcp

--- a/fuzzers/035-iob-ilogic/top.py
+++ b/fuzzers/035-iob-ilogic/top.py
@@ -189,6 +189,13 @@ def use_iserdese2(p, luts, connects):
             'clk_BUFG2',
         ))
 
+    clkdiv = random.choice(('0', ))
+
+    if random.randint(0, 1):
+        clknet = '0'
+        clkbnet = '0'
+        oclknet = '0'
+
     print(
         '''
     (* KEEP, DONT_TOUCH, LOC = "{ilogic_loc}" *)
@@ -224,8 +231,9 @@ def use_iserdese2(p, luts, connects):
         .OCLK({oclknet}),
         .O({onet}),
         .Q1({q1net}),
-        .CLKDIV(0)
+        .CLKDIV({clkdiv})
     );'''.format(
+            clkdiv=clkdiv,
             clknet=clknet,
             clkbnet=clkbnet,
             oclknet=oclknet,


### PR DESCRIPTION
 - Add non-decimal prefixes to feature parts
 - Remove clocks in some samples to decouple ioi pips.