### PR TITLE
Add stepdown feature to HCLK_IOI.

### DIFF
--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -89,7 +89,7 @@ def run(fn_in, fn_out, verbose=False):
         ("clk_hrow/build/segbits_tilegrid.tdb", 30, 18),
         ("clk_bufg/build/segbits_tilegrid.tdb", 30, 8),
         ("hclk_cmt/build/segbits_tilegrid.tdb", 30, 10),
-        ("hclk_ioi/build/segbits_tilegrid.tdb", 42, 10),
+        ("hclk_ioi/build/segbits_tilegrid.tdb", 42, 1),
         ("clb_int/build/segbits_tilegrid.tdb", int_frames, int_words),
         ("iob_int/build/segbits_tilegrid.tdb", int_frames, int_words),
         ("bram_int/build/segbits_tilegrid.tdb", int_frames, int_words),

--- a/fuzzers/005-tilegrid/hclk_ioi/Makefile
+++ b/fuzzers/005-tilegrid/hclk_ioi/Makefile
@@ -1,4 +1,4 @@
 N ?= 5
-GENERATE_ARGS?="--oneval 1 --design params.csv --dword 5 --dframe 21"
+GENERATE_ARGS?="--oneval 1 --design params.csv --dword 0 --dframe 21"
 include ../fuzzaddr/common.mk
 

--- a/fuzzers/030-iob/Makefile
+++ b/fuzzers/030-iob/Makefile
@@ -17,7 +17,7 @@ build/segbits_xiob33.db: build/segbits_xiob33.rdb process_rdb.py bits.dbf
 	${XRAY_MASKMERGE} build/mask_xiob33.db $$(find -name segdata_liob33.txt) $$(find -name segdata_riob33.txt)
 
 build/segbits_hclk_ioi3.rdb: $(SPECIMENS_OK)
-	${XRAY_SEGMATCH} -o build/segbits_hclk_ioi3.rdb $$(find -name segdata_hclk_ioi3.txt)
+	${XRAY_SEGMATCH} -c 4 -o build/segbits_hclk_ioi3.rdb $$(find -name segdata_hclk_ioi3.txt)
 
 build/segbits_hclk_ioi3.db: build/segbits_hclk_ioi3.rdb
 	${XRAY_DBFIXUP} --db-root build --zero-db hclk_bits.dbf --seg-fn-in build/segbits_hclk_ioi3.rdb --seg-fn-out $@

--- a/fuzzers/030-iob/Makefile
+++ b/fuzzers/030-iob/Makefile
@@ -2,7 +2,7 @@ N := 50
 SPECIMENS_DEPS := build/iobanks.txt
 include ../fuzzer.mk
 
-database: build/segbits_xiob33.db
+database: build/segbits_xiob33.db build/segbits_hclk_ioi3.db
 
 build/iobanks.txt: write_io_banks.tcl
 	mkdir -p build
@@ -16,6 +16,12 @@ build/segbits_xiob33.db: build/segbits_xiob33.rdb process_rdb.py bits.dbf
 	${XRAY_DBFIXUP} --db-root build --zero-db bits.dbf --seg-fn-in build/segbits_xiob33_processed.rdb --seg-fn-out $@
 	${XRAY_MASKMERGE} build/mask_xiob33.db $$(find -name segdata_liob33.txt) $$(find -name segdata_riob33.txt)
 
+build/segbits_hclk_ioi3.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} -o build/segbits_hclk_ioi3.rdb $$(find -name segdata_hclk_ioi3.txt)
+
+build/segbits_hclk_ioi3.db: build/segbits_hclk_ioi3.rdb
+	${XRAY_DBFIXUP} --db-root build --zero-db hclk_bits.dbf --seg-fn-in build/segbits_hclk_ioi3.rdb --seg-fn-out $@
+
 pushdb:
 ifneq (${XRAY_DATABASE}, zynq7)
 	${XRAY_MERGEDB} liob33 build/segbits_xiob33.db
@@ -23,6 +29,8 @@ ifneq (${XRAY_DATABASE}, zynq7)
 endif
 	${XRAY_MERGEDB} riob33 build/segbits_xiob33.db
 	${XRAY_MERGEDB} mask_riob33 build/mask_xiob33.db
+
+	${XRAY_MERGEDB} hclk_ioi3 build/segbits_hclk_ioi3.db
 
 .PHONY: database pushdb
 

--- a/fuzzers/030-iob/top.py
+++ b/fuzzers/030-iob/top.py
@@ -100,7 +100,7 @@ def run():
     }
 
     with open(os.path.join(os.getenv('FUZDIR'), 'build', 'iobanks.txt')) as f:
-        iobanks = [int(l.strip()) for l in f]
+        iobanks = [int(l.strip().split(',')[1]) for l in f]
 
     params['iobanks'] = iobanks
 

--- a/fuzzers/030-iob/write_io_banks.tcl
+++ b/fuzzers/030-iob/write_io_banks.tcl
@@ -3,6 +3,17 @@ set_property design_mode PinPlanning [current_fileset]
 open_io_design -name io_1
 set fp [open "iobanks.txt" "w"]
 foreach iobank [get_iobanks] {
-    puts $fp $iobank
+    foreach site [get_sites -of $iobank] {
+        puts $fp "$site,$iobank"
+    }
+}
+close $fp
+
+set fp [open "cmt_regions.csv" "w"]
+foreach site_type { IOB33M IOB33S IDELAYCTRL} {
+    foreach site [get_sites -filter "SITE_TYPE == $site_type"] {
+        set tile [get_tiles -of $site]
+        puts $fp "$site,$tile,[get_property CLOCK_REGION $site]"
+    }
 }
 close $fp


### PR DESCRIPTION
 - Also narrow HCLK_IOI tilegrid size to avoid coupling into [RL]IOI3.

Builds on #986

This solves remaining HCLK_IOI3 bits.