### PR TITLE
fuzzers: 037: relax PIP filtering

### DIFF
--- a/fuzzers/037-iob-pips/ioi3_pip_list.tcl
+++ b/fuzzers/037-iob-pips/ioi3_pip_list.tcl
@@ -19,7 +19,10 @@ proc print_tile_pips {tile_type filename} {
                 continue
             }
 
-            if {[llength [get_nodes -uphill -of_objects [get_nodes -of_objects $dst]]] != 1} {
+            set dst_wire [regsub {.*/} $dst ""]
+            set dst_match [regexp {R?IOI_OLOGIC[01]_CLK(B)?(DIVF?B?)?} $dst_wire]
+
+            if {[llength [get_nodes -uphill -of_objects [get_nodes -of_objects $dst]]] != 1 || $dst_match} {
                 set pip_string "$tile_type.[regsub {.*/} $dst ""].[regsub {.*/} $src ""]"
                 if ![dict exists $pips $pip_string] {
                     puts $fp $pip_string


### PR DESCRIPTION
This PR solves a few more bits related to clk routing in IOI:

```
LIOI3.IOI_ILOGIC0_OCLK.IOI_OCLK_0 28_64
LIOI3.IOI_ILOGIC1_OCLK.IOI_OCLK_1 29_63
LIOI3.IOI_OLOGIC0_CLK.IOI_OCLK_0 31_90 31_92 
LIOI3.IOI_OLOGIC1_CLK.IOI_OCLK_1 30_35 30_37
```
and the same set for RIOI3