### PR TITLE
WIP: Add bitstream tools for Spartan6

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,28 @@ add_library(libprjxray
 target_include_directories(libprjxray PUBLIC "include")
 target_link_libraries(libprjxray absl::optional absl::strings absl::span absl::time yaml-cpp)
 
+add_library(libsp6
+	database.cc
+	memory_mapped_file.cc
+	segbits_file_reader.cc
+	xilinx/spartan6/bitstream_reader.cc
+	xilinx/spartan6/bitstream_writer.cc
+	xilinx/spartan6/block_type.cc
+	xilinx/spartan6/configuration_bus.cc
+	xilinx/spartan6/configuration_column.cc
+	xilinx/spartan6/configuration_packet.cc
+	xilinx/spartan6/configuration_packetizer.cc
+	xilinx/spartan6/configuration_register.cc
+	xilinx/spartan6/frame_address.cc
+	xilinx/spartan6/global_clock_region.cc
+	xilinx/spartan6/part.cc
+	xilinx/spartan6/row.cc
+	xilinx/spartan6/frames.cc
+	xilinx/spartan6/utils.cc
+)
+target_include_directories(libsp6 PUBLIC "include")
+target_link_libraries(libsp6 absl::optional absl::strings absl::span absl::time yaml-cpp)
+
 if (PRJXRAY_BUILD_TESTING)
 	add_executable(big_endian_span_test big_endian_span_test.cc)
 	target_link_libraries(big_endian_span_test libprjxray gtest_main)
@@ -63,5 +85,24 @@ if (PRJXRAY_BUILD_TESTING)
 	target_link_libraries(xilinx_xc7series_test libprjxray gtest_main)
 	add_test(NAME xilinx_xc7series_test
 		 COMMAND xilinx_xc7series_test
+		 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test_data)
+
+	add_executable(xilinx_spartan6_test
+		xilinx/spartan6/bitstream_reader_test.cc
+		#xilinx/spartan6/bitstream_writer_test.cc
+		xilinx/spartan6/block_type_test.cc
+		xilinx/spartan6/configuration_bus_test.cc
+		xilinx/spartan6/configuration_column_test.cc
+		xilinx/spartan6/configuration_test.cc
+		xilinx/spartan6/configuration_packet_test.cc
+		#xilinx/spartan6/configuration_packetizer_test.cc
+		xilinx/spartan6/frame_address_test.cc
+		#xilinx/spartan6/global_clock_region_test.cc
+		xilinx/spartan6/part_test.cc
+		xilinx/spartan6/row_test.cc
+		xilinx/spartan6/frames_test.cc)
+	target_link_libraries(xilinx_spartan6_test libsp6 gtest_main)
+	add_test(NAME xilinx_spartan6_test
+		 COMMAND xilinx_spartan6_test
 		 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test_data)
 endif()

--- a/lib/include/prjxray/xilinx/spartan6/bitstream_reader.h
+++ b/lib/include/prjxray/xilinx/spartan6/bitstream_reader.h
@@ -1,0 +1,94 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_BITSTREAM_READER_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_BITSTREAM_READER_H
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include <absl/types/optional.h>
+#include <absl/types/span.h>
+
+#include <prjxray/big_endian_span.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class BitstreamReader {
+       public:
+	using value_type = ConfigurationPacket;
+
+	class iterator
+	    : public std::iterator<std::input_iterator_tag, value_type> {
+	       public:
+		iterator& operator++();
+
+		bool operator==(const iterator& other) const;
+		bool operator!=(const iterator& other) const;
+
+		const value_type& operator*() const;
+		const value_type* operator->() const;
+
+	       protected:
+		explicit iterator(absl::Span<uint32_t> words);
+
+	       private:
+		friend BitstreamReader;
+
+		ConfigurationPacket::ParseResult parse_result_;
+		absl::Span<uint32_t> words_;
+	};
+
+	// Construct a reader from a collection of 16-bit, big-endian words.
+	// Assumes that any sync word has already been removed.
+	BitstreamReader(std::vector<uint32_t>&& words);
+
+	// Construct a `BitstreamReader` from a Container of bytes.
+	// Any bytes preceding an initial sync word are ignored.
+	template <typename T>
+	static absl::optional<BitstreamReader> InitWithBytes(T bitstream);
+
+	const std::vector<uint32_t>& words() { return words_; };
+
+	// Returns an iterator that yields `ConfigurationPackets`
+	// as read from the bitstream.
+	iterator begin();
+	iterator end();
+
+       private:
+	static std::array<uint8_t, 4> kSyncWord;
+
+	std::vector<uint32_t> words_;
+};
+
+template <typename T>
+absl::optional<BitstreamReader> BitstreamReader::InitWithBytes(T bitstream) {
+	// If this is really a Xilinx 7-Series bitstream, there will be a sync
+	// word somewhere toward the beginning.
+	auto sync_pos = std::search(bitstream.begin(), bitstream.end(),
+	                            kSyncWord.begin(), kSyncWord.end());
+	if (sync_pos == bitstream.end()) {
+		return absl::optional<BitstreamReader>();
+	}
+	sync_pos += kSyncWord.size();
+
+	// Wrap the provided container in a span that strips off the preamble.
+	absl::Span<typename T::value_type> bitstream_span(bitstream);
+	auto config_packets =
+	    bitstream_span.subspan(sync_pos - bitstream.begin());
+
+	// Convert the bytes into 16-bit, big-endian words.
+	auto big_endian_reader = make_big_endian_span<uint16_t>(config_packets);
+	std::vector<uint32_t> words{big_endian_reader.begin(),
+	                            big_endian_reader.end()};
+
+	return BitstreamReader(std::move(words));
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_BITSTREAM_READER_H

--- a/lib/include/prjxray/xilinx/spartan6/bitstream_writer.h
+++ b/lib/include/prjxray/xilinx/spartan6/bitstream_writer.h
@@ -1,0 +1,113 @@
+/*
+ * Takes in a collection of ConfigurationPacket and writes them to specified
+ * file This includes the following: -Bus auto detection -Sync Word -FPGA
+ * configuration
+ */
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_BITSTREAM_WRITER_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_BITSTREAM_WRITER_H
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <absl/types/optional.h>
+#include <absl/types/span.h>
+
+#include <prjxray/big_endian_span.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class BitstreamWriter {
+       public:
+	typedef std::array<uint32_t, 10> header_t;
+	typedef std::vector<std::unique_ptr<ConfigurationPacket>> packets_t;
+	// Only defined if a packet exists
+	typedef absl::optional<absl::Span<const uint32_t>> op_data_t;
+	typedef absl::Span<const uint32_t>::iterator data_iterator_t;
+	using itr_value_type = uint32_t;
+
+	class packet_iterator
+	    : public std::iterator<std::input_iterator_tag, itr_value_type> {
+	       public:
+		packet_iterator& operator++();
+
+		bool operator==(const packet_iterator& other) const;
+		bool operator!=(const packet_iterator& other) const;
+
+		const itr_value_type operator*() const;
+		const itr_value_type operator->() const;
+
+		typedef enum {
+			STATE_HEADER = 1,
+			STATE_DATA = 2,
+			STATE_END = 3,
+		} state_t;
+
+	       protected:
+		explicit packet_iterator(const ConfigurationPacket* packet,
+		                         state_t state,
+		                         data_iterator_t itr_data);
+
+	       private:
+		friend iterator;
+		friend BitstreamWriter;
+
+		// Data iterators
+		// First over the fixed header, then the configuration data
+		state_t state_;
+		// Over packet.data()
+		data_iterator_t itr_data_;
+
+		const ConfigurationPacket* packet_;
+	};
+
+	using value_type = uint32_t;
+	class iterator
+	    : public std::iterator<std::input_iterator_tag, itr_value_type> {
+	       public:
+		iterator& operator++();
+
+		bool operator==(const iterator& other) const;
+		bool operator!=(const iterator& other) const;
+
+		const itr_value_type operator*() const;
+		const itr_value_type operator->() const;
+
+		packet_iterator packet_begin();
+		packet_iterator packet_end();
+
+	       protected:
+		explicit iterator(
+		    header_t::iterator itr_header,
+		    const packets_t& packets,
+		    packets_t::const_iterator itr_packets,
+		    absl::optional<packet_iterator> op_itr_packet);
+
+	       private:
+		friend BitstreamWriter;
+		// Data iterators
+		// First over the fixed header, then the configuration data
+		header_t::iterator itr_header_;
+		const packets_t& packets_;
+		packets_t::const_iterator itr_packets_;
+		absl::optional<packet_iterator> op_itr_packet_;
+	};
+
+	BitstreamWriter(const packets_t& packets);
+
+	iterator begin();
+	iterator end();
+
+       private:
+	static header_t header_;
+	const packets_t& packets_;
+};
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_BITSTREAM_WRITER_H

--- a/lib/include/prjxray/xilinx/spartan6/block_type.h
+++ b/lib/include/prjxray/xilinx/spartan6/block_type.h
@@ -1,0 +1,33 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_BLOCK_TYPE_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_BLOCK_TYPE_H_
+
+#include <ostream>
+
+#include <yaml-cpp/yaml.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+enum class BlockType : unsigned int {
+	CLB_IOI_CLK = 0x0,
+	BLOCK_RAM = 0x1,
+	IOB = 0x2,
+};
+
+std::ostream& operator<<(std::ostream& o, BlockType value);
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::BlockType> {
+	static Node encode(const prjxray::xilinx::spartan6::BlockType& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::BlockType& lhs);
+};
+}  // namespace YAML
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_BLOCK_TYPE_H_

--- a/lib/include/prjxray/xilinx/spartan6/command.h
+++ b/lib/include/prjxray/xilinx/spartan6/command.h
@@ -1,0 +1,34 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_COMMAND_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_COMMAND_H_
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+enum class Command : uint32_t {
+	NOP = 0x0,
+	WCFG = 0x1,
+	MFW = 0x2,
+	LFRM = 0x3,
+	RCFG = 0x4,
+	START = 0x5,
+	RCAP = 0x6,
+	RCRC = 0x7,
+	AGHIGH = 0x8,
+	SWITCH = 0x9,
+	GRESTORE = 0xA,
+	SHUTDOWN = 0xB,
+	GCAPTURE = 0xC,
+	DESYNC = 0xD,
+	IPROG = 0xF,
+	CRCC = 0x10,
+	LTIMER = 0x11,
+	BSPI_READ = 0x12,
+	FALL_EDGE = 0x13,
+};
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_COMMAND_H_

--- a/lib/include/prjxray/xilinx/spartan6/configuration.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration.h
@@ -1,0 +1,172 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_H_
+
+#include <map>
+
+#include <absl/types/span.h>
+#include <prjxray/bit_ops.h>
+#include <prjxray/xilinx/spartan6/bitstream_reader.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <prjxray/xilinx/spartan6/part.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class Configuration {
+       public:
+	using FrameMap = std::map<FrameAddress, absl::Span<const uint32_t>>;
+
+	template <typename Collection>
+	static absl::optional<Configuration> InitWithPackets(
+	    const Part& part,
+	    Collection& packets);
+
+	Configuration(const Part& part,
+	              std::map<FrameAddress, std::vector<uint32_t>>* frames)
+	    : part_(part) {
+		for (auto& frame : *frames) {
+			frames_[frame.first] =
+			    absl::Span<const uint32_t>(frame.second);
+		}
+	}
+
+	Configuration(const Part& part, const FrameMap& frames)
+	    : part_(part), frames_(std::move(frames)) {}
+
+	const Part& part() const { return part_; }
+	const FrameMap& frames() const { return frames_; }
+
+       private:
+	static constexpr int kWordsPerFrame = 65;
+
+	Part part_;
+	FrameMap frames_;
+};
+
+template <typename Collection>
+absl::optional<Configuration> Configuration::InitWithPackets(
+    const Part& part,
+    Collection& packets) {
+	// Registers that can be directly written to.
+	uint32_t command_register = 0;
+	uint32_t frame_address_register = 0;
+	uint32_t mask_register = 0;
+	__attribute__((unused)) uint32_t ctl1_register = 0;
+
+	// Internal state machine for writes.
+	bool start_new_write = false;
+	FrameAddress current_frame_address = 0;
+
+	Configuration::FrameMap frames;
+	for (auto packet : packets) {
+		if (packet.opcode() != ConfigurationPacket::Opcode::Write) {
+			continue;
+		}
+
+		switch (packet.address()) {
+			case ConfigurationRegister::MASK:
+				if (packet.data().size() < 1)
+					continue;
+				mask_register = packet.data()[0];
+				break;
+			case ConfigurationRegister::CTL:
+				if (packet.data().size() < 1)
+					continue;
+				ctl1_register =
+				    packet.data()[0] & mask_register;
+				break;
+			case ConfigurationRegister::CMD:
+				if (packet.data().size() < 1)
+					continue;
+				command_register = packet.data()[0];
+				// Writes to CMD trigger an immediate action. In
+				// the case of WCFG, that is just setting a flag
+				// for the next FDRI.
+				if (command_register == 0x1) {
+					start_new_write = true;
+				}
+				break;
+			case ConfigurationRegister::IDCODE: {
+				// This really should be a two-word write.
+				if (packet.data().size() < 2)
+					continue;
+
+				// If the IDCODE doesn't match our expected
+				// part, consider the bitstream invalid.
+				uint32_t idcode = (packet.data()[0] << 16) |
+				                  (packet.data()[1]);
+				if (idcode != part.idcode()) {
+					return {};
+				}
+				break;
+			}
+			// UG380 describes the frame addressing scheme where two
+			// words for FAR_MAJ update FAR_MAJ anda FAR_MIN -
+			// FAR_MAJ comes first
+			case ConfigurationRegister::FAR_MAJ: {
+				size_t packet_size = packet.data().size();
+				assert(packet_size < 3);
+				if (packet_size < 1) {
+					continue;
+				} else if (packet_size < 2) {
+					frame_address_register =
+					    (packet.data()[0] & 0xFFFF) << 16;
+				} else {
+					frame_address_register =
+					    ((packet.data()[0] & 0xFFFF)
+					     << 16) |
+					    (packet.data()[1] & 0xFFFF);
+				}
+				break;
+			}
+			case ConfigurationRegister::FAR_MIN:
+				// This really should be a one-word write.
+				if (packet.data().size() < 1)
+					continue;
+
+				frame_address_register |=
+				    packet.data()[0] & 0x3FF;
+
+				break;
+			case ConfigurationRegister::FDRI: {
+				if (start_new_write) {
+					current_frame_address =
+					    frame_address_register;
+					start_new_write = false;
+				}
+
+				// Spartan6 frames are 65-words long.  Writes
+				// to this register can be multiples of that to
+				// do auto-incrementing block writes.
+
+				for (size_t ii = 0; ii < packet.data().size();
+				     ii += kWordsPerFrame) {
+					frames[current_frame_address] =
+					    packet.data().subspan(
+					        ii, kWordsPerFrame);
+
+					auto next_address =
+					    part.GetNextFrameAddress(
+					        current_frame_address);
+					if (!next_address)
+						break;
+
+					current_frame_address = *next_address;
+				}
+				break;
+			}
+			default:
+				break;
+		}
+	}
+
+	return Configuration(part, frames);
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_H_

--- a/lib/include/prjxray/xilinx/spartan6/configuration_bus.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_bus.h
@@ -1,0 +1,91 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_BUS_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_BUS_H_
+
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <memory>
+
+#include <absl/types/optional.h>
+#include <prjxray/xilinx/spartan6/configuration_column.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <yaml-cpp/yaml.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+// ConfigurationBus represents a bus for sending frames to a specific BlockType
+// within a Row.  An instance of ConfigurationBus will contain one or more
+// ConfigurationColumns.
+class ConfigurationBus {
+       public:
+	ConfigurationBus() = default;
+
+	// Constructs a ConfigurationBus from iterators yielding
+	// FrameAddresses.  The frame address need not be contiguous or sorted
+	// but they must all have the same block type, row half, and row
+	// address components.
+	template <typename T>
+	ConfigurationBus(T first, T last);
+
+	// Returns true if the provided address falls into a valid segment of
+	// the address range on this bus.  Only the column and minor components
+	// of the address are considered as all other components are outside
+	// the scope of a bus.
+	bool IsValidFrameAddress(FrameAddress address) const;
+
+	// Returns the next valid address on the bus in numerically increasing
+	// order. If the next address would fall outside this bus, no object is
+	// returned.
+	absl::optional<FrameAddress> GetNextFrameAddress(
+	    FrameAddress address) const;
+
+       private:
+	friend struct YAML::convert<ConfigurationBus>;
+
+	std::map<unsigned int, ConfigurationColumn> configuration_columns_;
+};
+
+template <typename T>
+ConfigurationBus::ConfigurationBus(T first, T last) {
+	assert(
+	    std::all_of(first, last, [&](const typename T::value_type& addr) {
+		    return (addr.block_type() == first->block_type() &&
+		            addr.row() == first->row());
+	    }));
+
+	std::sort(first, last,
+	          [](const FrameAddress& lhs, const FrameAddress& rhs) {
+		          return lhs.column() < rhs.column();
+	          });
+
+	for (auto col_first = first; col_first != last;) {
+		auto col_last = std::upper_bound(
+		    col_first, last, col_first->column(),
+		    [](const unsigned int& lhs, const FrameAddress& rhs) {
+			    return lhs < rhs.column();
+		    });
+
+		configuration_columns_.emplace(
+		    col_first->column(),
+		    std::move(ConfigurationColumn(col_first, col_last)));
+		col_first = col_last;
+	}
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::ConfigurationBus> {
+	static Node encode(
+	    const prjxray::xilinx::spartan6::ConfigurationBus& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::ConfigurationBus& lhs);
+};
+}  // namespace YAML
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_BUS_H_

--- a/lib/include/prjxray/xilinx/spartan6/configuration_column.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_column.h
@@ -1,0 +1,75 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_COLUMN_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_COLUMN_H_
+
+#include <algorithm>
+#include <cassert>
+
+#include <absl/types/optional.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <yaml-cpp/yaml.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+// ConfigurationColumn represents an endpoint on a ConfigurationBus.
+class ConfigurationColumn {
+       public:
+	ConfigurationColumn() = default;
+	ConfigurationColumn(unsigned int frame_count)
+	    : frame_count_(frame_count) {}
+
+	// Returns a ConfigurationColumn that describes a continguous range of
+	// minor addresses that encompasses the given
+	// FrameAddresses.  The provided addresses must only
+	// differ only by their minor addresses.
+	template <typename T>
+	ConfigurationColumn(T first, T last);
+
+	// Returns true if the minor field of the address is within the valid
+	// range of this column.
+	bool IsValidFrameAddress(FrameAddress address) const;
+
+	// Returns the next address in numerical order.  If the next address
+	// would be outside this column, return no object.
+	absl::optional<FrameAddress> GetNextFrameAddress(
+	    FrameAddress address) const;
+
+       private:
+	friend struct YAML::convert<ConfigurationColumn>;
+
+	unsigned int frame_count_;
+};
+
+template <typename T>
+ConfigurationColumn::ConfigurationColumn(T first, T last) {
+	assert(
+	    std::all_of(first, last, [&](const typename T::value_type& addr) {
+		    return (addr.block_type() == first->block_type() &&
+		            addr.row() == first->row() &&
+		            addr.major() == first->major());
+	    }));
+
+	auto max_minor = std::max_element(
+	    first, last, [](const FrameAddress& lhs, const FrameAddress& rhs) {
+		    return lhs.minor() < rhs.minor();
+	    });
+
+	frame_count_ = max_minor->minor() + 1;
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::ConfigurationColumn> {
+	static Node encode(
+	    const prjxray::xilinx::spartan6::ConfigurationColumn& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::ConfigurationColumn& lhs);
+};
+}  // namespace YAML
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_COLUMN_H_

--- a/lib/include/prjxray/xilinx/spartan6/configuration_options_0_value.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_options_0_value.h
@@ -1,0 +1,122 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_OPTIONS_0_VALUE_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_OPTIONS_0_VALUE_H
+
+#include <prjxray/bit_ops.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class ConfigurationOptions0Value {
+       public:
+	enum class StartupClockSource : uint32_t {
+		CCLK = 0x0,
+		User = 0x1,
+		JTAG = 0x2,
+	};
+
+	enum class SignalReleaseCycle : uint32_t {
+		Phase1 = 0x0,
+		Phase2 = 0x1,
+		Phase3 = 0x2,
+		Phase4 = 0x3,
+		Phase5 = 0x4,
+		Phase6 = 0x5,
+		TrackDone = 0x6,
+		Keep = 0x7,
+	};
+
+	enum class StallCycle : uint32_t {
+		Phase0 = 0x0,
+		Phase1 = 0x1,
+		Phase2 = 0x2,
+		Phase3 = 0x3,
+		Phase4 = 0x4,
+		Phase5 = 0x5,
+		Phase6 = 0x6,
+		NoWait = 0x7,
+	};
+
+	ConfigurationOptions0Value() : value_(0) {}
+
+	operator uint32_t() const { return value_; }
+
+	ConfigurationOptions0Value& SetUseDonePinAsPowerdownStatus(
+	    bool enabled) {
+		value_ = bit_field_set(value_, 27, 27, enabled ? 1 : 0);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetAddPipelineStageForDoneIn(bool enabled) {
+		value_ = bit_field_set(value_, 25, 25, enabled ? 1 : 0);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetDriveDoneHigh(bool enabled) {
+		value_ = bit_field_set(value_, 24, 24, enabled);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetReadbackIsSingleShot(bool enabled) {
+		value_ = bit_field_set(value_, 23, 23, enabled);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetCclkFrequency(uint32_t mhz) {
+		value_ = bit_field_set(value_, 22, 17, mhz);
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetStartupClockSource(
+	    StartupClockSource source) {
+		value_ = bit_field_set(value_, 16, 15,
+		                       static_cast<uint32_t>(source));
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetReleaseDonePinAtStartupCycle(
+	    SignalReleaseCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 14, 12, static_cast<uint32_t>(cycle));
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetStallAtStartupCycleUntilDciMatch(
+	    StallCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 11, 9, static_cast<uint32_t>(cycle));
+		return *this;
+	};
+
+	ConfigurationOptions0Value& SetStallAtStartupCycleUntilMmcmLock(
+	    StallCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 8, 6, static_cast<uint32_t>(cycle));
+		return *this;
+	};
+
+	ConfigurationOptions0Value& SetReleaseGtsSignalAtStartupCycle(
+	    SignalReleaseCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 5, 3, static_cast<uint32_t>(cycle));
+		return *this;
+	}
+
+	ConfigurationOptions0Value& SetReleaseGweSignalAtStartupCycle(
+	    SignalReleaseCycle cycle) {
+		value_ =
+		    bit_field_set(value_, 2, 0, static_cast<uint32_t>(cycle));
+		return *this;
+	}
+
+       private:
+	uint32_t value_;
+};  // namespace spartan6
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_OPTIONS_0_VALUE_H

--- a/lib/include/prjxray/xilinx/spartan6/configuration_packet.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_packet.h
@@ -1,0 +1,65 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_PACKET_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_PACKET_H
+
+#include <cstdint>
+
+#include <absl/types/optional.h>
+#include <absl/types/span.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class ConfigurationPacket {
+       public:
+	typedef std::pair<absl::Span<uint32_t>,
+	                  absl::optional<ConfigurationPacket>>
+	    ParseResult;
+
+	enum Opcode {
+		NOP = 0,
+		Read = 1,
+		Write = 2,
+		/* reserved = 3 */
+	};
+
+	ConfigurationPacket(unsigned int header_type,
+	                    Opcode opcode,
+	                    ConfigurationRegister address,
+	                    const absl::Span<const uint32_t>& data)
+	    : header_type_(header_type),
+	      opcode_(opcode),
+	      address_(address),
+	      data_(std::move(data)) {}
+
+	// Attempt to read a configuration packet from a sequence of
+	// 16-bit, big-endian words. If successful, returns the packet read and
+	// a span containing any words remaining after the packet.  If a valid
+	// header is found but there are insufficient words provided for the
+	// complete packet, the original span<> is returned unchanged and no
+	// packet is produced.  If no valid header is found, an empty span is
+	// returned.
+	static ParseResult InitWithWords(
+	    absl::Span<uint32_t> words,
+	    const ConfigurationPacket* previous_packet = nullptr);
+
+	unsigned int header_type() const { return header_type_; }
+	const Opcode opcode() const { return opcode_; }
+	const ConfigurationRegister address() const { return address_; }
+	const absl::Span<const uint32_t>& data() const { return data_; }
+
+       private:
+	unsigned int header_type_;
+	Opcode opcode_;
+	ConfigurationRegister address_;
+	absl::Span<const uint32_t> data_;
+};
+
+std::ostream& operator<<(std::ostream& o, const ConfigurationPacket& packet);
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_PACKET_H

--- a/lib/include/prjxray/xilinx/spartan6/configuration_packet_with_payload.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_packet_with_payload.h
@@ -1,0 +1,33 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_g_CONFIGURATION_PACKET_WITH_PAYLOAD_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_g_CONFIGURATION_PACKET_WITH_PAYLOAD_H
+
+#include <memory>
+
+#include <absl/types/span.h>
+#include <prjxray/bit_ops.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+template <int Words>
+class ConfigurationPacketWithPayload : public ConfigurationPacket {
+       public:
+	ConfigurationPacketWithPayload(
+	    Opcode op,
+	    ConfigurationRegister reg,
+	    const std::array<uint32_t, Words>& payload)
+	    : ConfigurationPacket(1, op, reg, absl::Span<uint32_t>(payload_)),
+	      payload_(std::move(payload)) {}
+
+       private:
+	std::array<uint32_t, Words> payload_;
+};  // namespace spartan6
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_g_CONFIGURATION_PACKET_WITH_PAYLOAD_H

--- a/lib/include/prjxray/xilinx/spartan6/configuration_packetizer.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_packetizer.h
@@ -1,0 +1,62 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_PACKETIZER_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_PACKETIZER_H_
+
+#include <absl/types/optional.h>
+#include <prjxray/xilinx/spartan6/configuration.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class ConfigurationPacketizer {
+       public:
+	class iterator
+	    : std::iterator<std::input_iterator_tag, ConfigurationPacket> {
+	       public:
+		iterator(const Part* part,
+		         Configuration::FrameMap::const_iterator begin,
+		         Configuration::FrameMap::const_iterator end);
+
+		iterator& operator++();
+
+		bool operator==(const iterator& other) const;
+		bool operator!=(const iterator& other) const;
+
+		const ConfigurationPacket& operator*() const;
+		const ConfigurationPacket* operator->() const;
+
+	       private:
+		friend class ConfigurationPacketizer;
+
+		enum class State {
+			Start,
+			FrameAddressWritten,
+			FrameDataWritten,
+			ZeroPadWritten,
+			Finished,
+		};
+
+		const Part* part_;
+		State state_;
+		Configuration::FrameMap::const_iterator frame_cur_;
+		Configuration::FrameMap::const_iterator frame_end_;
+		absl::optional<uint32_t> frame_address_;
+		absl::optional<ConfigurationPacket> packet_;
+		int zero_pad_packets_to_write_;
+	};
+
+	ConfigurationPacketizer(const Configuration& config);
+
+	iterator begin() const;
+	iterator end() const;
+
+       private:
+	const Configuration& config_;
+};
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_PACKETIZER_H_

--- a/lib/include/prjxray/xilinx/spartan6/configuration_register.h
+++ b/lib/include/prjxray/xilinx/spartan6/configuration_register.h
@@ -1,0 +1,55 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_REGISTER_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_REGISTER_H_
+
+#include <ostream>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+enum class ConfigurationRegister : unsigned int {
+	CRC = 0x00,
+	FAR = 0x01,
+	FAR_MAJ = 0x01,
+	FAR_MIN = 0x02,
+	FDRI = 0x03,
+	FDRO = 0x04,
+	CMD = 0x05,
+	CTL = 0x06,
+	CTL1 = 0x06,
+	MASK = 0x07,
+	STAT = 0x08,
+	LOUT = 0x09,
+	COR1 = 0x0a,
+	COR2 = 0x0b,
+	PWRDN_REG = 0x0c,
+	FLR = 0x0d,
+	IDCODE = 0x0e,
+	CWDT = 0x0f,
+	HC_OPT_REG = 0x10,
+	CSBO = 0x12,
+	GENERAL1 = 0x13,
+	GENERAL2 = 0x14,
+	GENERAL3 = 0x15,
+	GENERAL4 = 0x16,
+	GENERAL5 = 0x17,
+	MODE_REG = 0x18,
+	PU_GWE = 0x19,
+	PU_GTS = 0x1a,
+	MFWR = 0x1b,
+	CCLK_FREQ = 0x1c,
+	SEU_OPT = 0x1d,
+	EXP_SIGN = 0x1e,
+	RDBK_SIGN = 0x1f,
+	BOOTSTS = 0x20,
+	EYE_MASK = 0x21,
+	CBC_REG = 0x22,
+};
+
+std::ostream& operator<<(std::ostream& o, const ConfigurationRegister& value);
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_CONFIGURATION_REGISTER_H_

--- a/lib/include/prjxray/xilinx/spartan6/frame_address.h
+++ b/lib/include/prjxray/xilinx/spartan6/frame_address.h
@@ -1,0 +1,53 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_FRAME_ADDRESS_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_FRAME_ADDRESS_H_
+
+#include <cstdint>
+#include <ostream>
+
+#include <prjxray/xilinx/spartan6/block_type.h>
+#include <yaml-cpp/yaml.h>
+
+#ifdef _GNU_SOURCE
+#undef minor
+#endif
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+class FrameAddress {
+       public:
+	FrameAddress() : address_(0) {}
+
+	FrameAddress(uint32_t address) : address_(address){};
+
+	FrameAddress(BlockType block_type,
+	             uint8_t row,
+	             uint8_t column,
+	             uint16_t minor);
+
+	operator uint32_t() const { return address_; }
+	bool is_bottom_half_rows() const;
+	BlockType block_type() const;
+	uint8_t row() const;
+	uint8_t column() const;
+	uint16_t minor() const;
+
+       private:
+	uint32_t address_;
+};
+
+std::ostream& operator<<(std::ostream& o, const FrameAddress& addr);
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::FrameAddress> {
+	static Node encode(const prjxray::xilinx::spartan6::FrameAddress& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::FrameAddress& lhs);
+};
+}  // namespace YAML
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_FRAME_ADDRESS_H_

--- a/lib/include/prjxray/xilinx/spartan6/frames.h
+++ b/lib/include/prjxray/xilinx/spartan6/frames.h
@@ -1,0 +1,42 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_FRAMES_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_FRAMES_H
+
+#include <string>
+#include <vector>
+
+#include <absl/strings/str_split.h>
+#include <prjxray/xilinx/spartan6/configuration.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <prjxray/xilinx/spartan6/part.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+// Contains frame information which is used for the generation
+// of the configuration package that is used in bitstream generation.
+class Frames {
+       public:
+	typedef std::vector<uint32_t> FrameData;
+	typedef std::map<FrameAddress, FrameData> Frames2Data;
+
+	// Reads the contents of the frames file and populates
+	// the Frames container.
+	int readFrames(const std::string& frm_file_str);
+
+	// Adds empty frames that are present in the tilegrid of a specific part
+	// but are missing in the current frames container.
+	void addMissingFrames(const absl::optional<Part>& part);
+
+	// Returns the map with frame addresses and corresponding data
+	Frames2Data& getFrames();
+
+       private:
+	Frames2Data frames_data_;
+};
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_FRAMES_H

--- a/lib/include/prjxray/xilinx/spartan6/global_clock_region.h
+++ b/lib/include/prjxray/xilinx/spartan6/global_clock_region.h
@@ -1,0 +1,93 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_GLOBAL_CLOCK_REGION_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_GLOBAL_CLOCK_REGION_H_
+
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <memory>
+
+#include <absl/types/optional.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <prjxray/xilinx/spartan6/row.h>
+#include <yaml-cpp/yaml.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+// GlobalClockRegion represents all the resources associated with a single
+// global clock buffer (BUFG) tile.  In 7-Series FPGAs, there are two BUFG
+// tiles that divide the chip into top and bottom "halves". Each half may
+// contains any number of rows, buses, and columns.
+class GlobalClockRegion {
+       public:
+	GlobalClockRegion() = default;
+
+	// Construct a GlobalClockRegion from iterators that yield
+	// FrameAddresses which are known to be valid. The addresses may be
+	// noncontinguous and/or unordered but they must share the same row
+	// half address component.
+	template <typename T>
+	GlobalClockRegion(T first, T last);
+
+	// Returns true if the address falls within a valid range inside the
+	// global clock region. The row half address component is ignored as it
+	// is outside the context of a global clock region.
+	bool IsValidFrameAddress(FrameAddress address) const;
+
+	// Returns the next numerically increasing address known within this
+	// global clock region. If the next address would fall outside this
+	// global clock region, no address is returned. If the next address
+	// would jump to a different block type, no address is returned as the
+	// same block type in other global clock regions come numerically
+	// before other block types.
+	absl::optional<FrameAddress> GetNextFrameAddress(
+	    FrameAddress address) const;
+
+       private:
+	friend struct YAML::convert<GlobalClockRegion>;
+
+	std::map<unsigned int, Row> rows_;
+};
+
+template <typename T>
+GlobalClockRegion::GlobalClockRegion(T first, T last) {
+	assert(
+	    std::all_of(first, last, [&](const typename T::value_type& addr) {
+		    return addr.is_bottom_half_rows() ==
+		           first->is_bottom_half_rows();
+	    }));
+
+	std::sort(first, last,
+	          [](const FrameAddress& lhs, const FrameAddress& rhs) {
+		          return lhs.row() < rhs.row();
+	          });
+
+	for (auto row_first = first; row_first != last;) {
+		auto row_last = std::upper_bound(
+		    row_first, last, row_first->row(),
+		    [](const uint8_t& lhs, const FrameAddress& rhs) {
+			    return lhs < rhs.row();
+		    });
+
+		rows_.emplace(row_first->row(),
+		              std::move(Row(row_first, row_last)));
+		row_first = row_last;
+	}
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::GlobalClockRegion> {
+	static Node encode(
+	    const prjxray::xilinx::spartan6::GlobalClockRegion& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::GlobalClockRegion& lhs);
+};
+}  // namespace YAML
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_GLOBAL_CLOCK_REGION_H_

--- a/lib/include/prjxray/xilinx/spartan6/nop_packet.h
+++ b/lib/include/prjxray/xilinx/spartan6/nop_packet.h
@@ -1,0 +1,24 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_NOP_PACKET_H
+#define PRJXRAY_LIB_XILINX_XC7SERIES_NOP_PACKET_H
+
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class NopPacket : public ConfigurationPacket {
+       public:
+	NopPacket()
+	    : ConfigurationPacket(1,
+	                          Opcode::NOP,
+	                          ConfigurationRegister::CRC,
+	                          {}) {}
+};
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_NOP_PACKET_H

--- a/lib/include/prjxray/xilinx/spartan6/part.h
+++ b/lib/include/prjxray/xilinx/spartan6/part.h
@@ -1,0 +1,68 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_PART_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_PART_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <absl/types/optional.h>
+#include <prjxray/xilinx/spartan6/global_clock_region.h>
+#include <yaml-cpp/yaml.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class Part {
+       public:
+	constexpr static uint32_t kInvalidIdcode = 0;
+
+	static absl::optional<Part> FromFile(const std::string& path);
+
+	// Constructs an invalid part with a zero IDCODE. Required for YAML
+	// conversion but shouldn't be used otherwise.
+	Part() : idcode_(kInvalidIdcode) {}
+
+	template <typename T>
+	Part(uint32_t idcode, T collection)
+	    : Part(idcode, std::begin(collection), std::end(collection)) {}
+
+	template <typename T>
+	Part(uint32_t idcode, T first, T last);
+
+	uint32_t idcode() const { return idcode_; }
+
+	bool IsValidFrameAddress(FrameAddress address) const;
+
+	absl::optional<FrameAddress> GetNextFrameAddress(
+	    FrameAddress address) const;
+
+       private:
+	friend struct YAML::convert<Part>;
+
+	uint32_t idcode_;
+	GlobalClockRegion top_region_;
+	GlobalClockRegion bottom_region_;
+};
+
+template <typename T>
+Part::Part(uint32_t idcode, T first, T last) : idcode_(idcode) {
+	top_region_ = GlobalClockRegion(first, last);
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::Part> {
+	static Node encode(const prjxray::xilinx::spartan6::Part& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::Part& lhs);
+};
+}  // namespace YAML
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_PART_H_

--- a/lib/include/prjxray/xilinx/spartan6/row.h
+++ b/lib/include/prjxray/xilinx/spartan6/row.h
@@ -1,0 +1,90 @@
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_ROW_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_ROW_H_
+
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <memory>
+
+#include <absl/types/optional.h>
+#include <prjxray/xilinx/spartan6/block_type.h>
+#include <prjxray/xilinx/spartan6/configuration_bus.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <yaml-cpp/yaml.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+class Row {
+       public:
+	Row() = default;
+
+	// Construct a row from a range of iterators that yield FrameAddresses.
+	// The addresses may be noncontinguous and/or unsorted but all must
+	// share the same row half and row components.
+	template <typename T>
+	Row(T first, T last);
+
+	// Returns true if the provided address falls within a valid range
+	// attributed to this row.  Only the block type, column, and minor
+	// address components are considerd as the remaining components are
+	// outside the scope of a row.
+	bool IsValidFrameAddress(FrameAddress address) const;
+
+	// Returns the next numerically increasing address within the Row. If
+	// the next address would fall outside the Row, no object is returned.
+	// If the next address would cross from one block type to another, no
+	// object is returned as other rows of the same block type come before
+	// other block types numerically.
+	absl::optional<FrameAddress> GetNextFrameAddress(
+	    FrameAddress address) const;
+
+       private:
+	friend struct YAML::convert<Row>;
+
+	std::map<BlockType, ConfigurationBus> configuration_buses_;
+};
+
+template <typename T>
+Row::Row(T first, T last) {
+	assert(
+	    std::all_of(first, last, [&](const typename T::value_type& addr) {
+		    return (addr.is_bottom_half_rows() ==
+		                first->is_bottom_half_rows() &&
+		            addr.row() == first->row());
+	    }));
+
+	std::sort(first, last,
+	          [](const FrameAddress& lhs, const FrameAddress& rhs) {
+		          return lhs.block_type() < rhs.block_type();
+	          });
+
+	for (auto bus_first = first; bus_first != last;) {
+		auto bus_last = std::upper_bound(
+		    bus_first, last, bus_first->block_type(),
+		    [](const BlockType& lhs, const FrameAddress& rhs) {
+			    return lhs < rhs.block_type();
+		    });
+
+		configuration_buses_.emplace(
+		    bus_first->block_type(),
+		    std::move(ConfigurationBus(bus_first, bus_last)));
+		bus_first = bus_last;
+	}
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+template <>
+struct convert<prjxray::xilinx::spartan6::Row> {
+	static Node encode(const prjxray::xilinx::spartan6::Row& rhs);
+	static bool decode(const Node& node,
+	                   prjxray::xilinx::spartan6::Row& lhs);
+};
+}  // namespace YAML
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_ROW_H_

--- a/lib/include/prjxray/xilinx/spartan6/utils.h
+++ b/lib/include/prjxray/xilinx/spartan6/utils.h
@@ -1,0 +1,51 @@
+
+#ifndef PRJXRAY_LIB_XILINX_XC7SERIES_UTILS_H_
+#define PRJXRAY_LIB_XILINX_XC7SERIES_UTILS_H_
+
+#include <prjxray/xilinx/spartan6/configuration.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/frames.h>
+#include <prjxray/xilinx/spartan6/part.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+using PacketData = std::vector<uint32_t>;
+using BitstreamHeader = std::vector<uint8_t>;
+using ConfigurationPackage = std::vector<std::unique_ptr<ConfigurationPacket>>;
+
+// Returns the payload for a type 2 packet.
+// Type 2 packets can have the payload length of more than the 11 bits available
+// for type 1 packets.
+PacketData createType2ConfigurationPacketData(const Frames::Frames2Data& frames,
+                                              absl::optional<Part>& part);
+
+// Creates the complete configuration package that is
+// then used by the bitstream writer to generate the bitstream file. The package
+// forms a sequence suitable for xilinx 7-series devices. The programming
+// sequence is taken from
+// https://www.kc8apf.net/2018/05/unpacking-xilinx-7-series-bitstreams-part-2/
+void createConfigurationPackage(ConfigurationPackage& out_packets,
+                                const PacketData& packet_data,
+                                absl::optional<Part>& part);
+
+// Creates a Xilinx bit header which is mostly a
+// Tag-Length-Value(TLV) format documented here:
+// http://www.fpga-faq.com/FAQ_Pages/0026_Tell_me_about_bit_files.htm
+BitstreamHeader createBitistreamHeader(const std::string& part_name,
+                                       const std::string& frames_file_name,
+                                       const std::string& generator_name);
+
+// Writies out the complete bitstream for a 7-series
+// Xilinx FPGA based on the Configuration Package which holds the complete
+// programming sequence.
+int writeBitstream(const ConfigurationPackage& packets,
+                   const std::string& part_name,
+                   const std::string& frames_file,
+                   const std::string& generator_name,
+                   const std::string& output_file);
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+#endif  // PRJXRAY_LIB_XILINX_XC7SERIES_UTILS_H_

--- a/lib/xilinx/spartan6/bitstream_reader.cc
+++ b/lib/xilinx/spartan6/bitstream_reader.cc
@@ -1,0 +1,71 @@
+#include <prjxray/xilinx/spartan6/bitstream_reader.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+std::array<uint8_t, 4> BitstreamReader::kSyncWord{0xAA, 0x99, 0x55, 0x66};
+
+BitstreamReader::BitstreamReader(std::vector<uint32_t>&& words)
+    : words_(std::move(words)) {}
+
+BitstreamReader::iterator BitstreamReader::begin() {
+	return iterator(absl::MakeSpan(words_));
+}
+
+BitstreamReader::iterator BitstreamReader::end() {
+	return iterator({});
+}
+
+BitstreamReader::iterator::iterator(absl::Span<uint32_t> words) {
+	parse_result_.first = words;
+	parse_result_.second = {};
+	++(*this);
+}
+
+BitstreamReader::iterator& BitstreamReader::iterator::operator++() {
+	do {
+		auto new_result = ConfigurationPacket::InitWithWords(
+		    parse_result_.first, parse_result_.second.has_value()
+		                             ? parse_result_.second.operator->()
+		                             : nullptr);
+
+		// If the a valid header is being found but there are
+		// insufficient words to yield a packet, consider it the end.
+		if (new_result.first == parse_result_.first) {
+			words_ = absl::Span<uint32_t>();
+			break;
+		}
+
+		words_ = parse_result_.first;
+		parse_result_ = new_result;
+	} while (!parse_result_.first.empty() && !parse_result_.second);
+
+	if (!parse_result_.second) {
+		words_ = absl::Span<uint32_t>();
+	}
+
+	return *this;
+}
+
+bool BitstreamReader::iterator::operator==(const iterator& other) const {
+	return words_ == other.words_;
+}
+
+bool BitstreamReader::iterator::operator!=(const iterator& other) const {
+	return !(*this == other);
+}
+
+const BitstreamReader::value_type& BitstreamReader::iterator::operator*()
+    const {
+	return *(parse_result_.second);
+}
+
+const BitstreamReader::value_type* BitstreamReader::iterator::operator->()
+    const {
+	return parse_result_.second.operator->();
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/lib/xilinx/spartan6/bitstream_reader_test.cc
+++ b/lib/xilinx/spartan6/bitstream_reader_test.cc
@@ -1,0 +1,111 @@
+#include <array>
+
+#include <absl/types/span.h>
+#include <gtest/gtest.h>
+#include <prjxray/xilinx/spartan6/bitstream_reader.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+#include <prjxray/big_endian_span.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+TEST(BitstreamReaderTest, InitWithEmptyBytesReturnsNull) {
+	absl::Span<uint8_t> bitstream;
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	EXPECT_FALSE(reader);
+}
+
+TEST(BitstreamReaderTest, InitWithOnlySyncReturnsObject) {
+	std::vector<uint8_t> bitstream{0xAA, 0x99, 0x55, 0x66};
+	absl::Span<std::vector<uint8_t>::value_type> bitstream_span(bitstream);
+	// auto config_packets =
+	//    bitstream_span.subspan(bitstream.end() - bitstream.begin());
+	// auto big_endian_reader =
+	// prjxray::make_big_endian_span<uint16_t>(bitstream_span);
+	// std::vector<uint16_t> words{big_endian_reader.begin(),
+	//                            big_endian_reader.end()};
+
+	// for (auto word: words) {
+	//   std::cout << "0x" << std::hex << word << std::endl;
+	//}
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	EXPECT_TRUE(reader);
+}
+
+TEST(BitstreamReaderTest, InitWithSyncAfterNonWordSizedPaddingReturnsObject) {
+	std::vector<uint8_t> bitstream{0xFF, 0xFE, 0xAA, 0x99, 0x55, 0x66};
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	EXPECT_TRUE(reader);
+}
+
+TEST(BitstreamReaderTest, InitWithSyncAfterWordSizedPaddingReturnsObject) {
+	std::vector<uint8_t> bitstream{0xFF, 0xFE, 0xFD, 0xFC,
+	                               0xAA, 0x99, 0x55, 0x66};
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	EXPECT_TRUE(reader);
+}
+
+TEST(BitstreamReaderTest, ParsesType1Packet) {
+	std::vector<uint8_t> bitstream{
+	    0xAA, 0x99, 0x55, 0x66,  // sync
+	    0x20, 0x00, 0x20, 0x00,  // NOP
+	};
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	ASSERT_TRUE(reader);
+	ASSERT_NE(reader->begin(), reader->end());
+
+	auto first_packet = reader->begin();
+	EXPECT_EQ(first_packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::NOP);
+
+	auto second_packet = ++first_packet;
+	EXPECT_EQ(second_packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::NOP);
+
+	EXPECT_EQ(++second_packet, reader->end());
+}
+
+TEST(BitstreamReaderTest, ParseType2PacketWithoutType1Fails) {
+	std::vector<uint8_t> bitstream{
+	    0xAA, 0x99, 0x55, 0x66,  // sync
+	    0x40, 0x00, 0x40, 0x00,  // Type 2 NOP
+	};
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	ASSERT_TRUE(reader);
+	EXPECT_EQ(reader->begin(), reader->end());
+}
+
+TEST(BitstreamReaderTest, ParsesType2AfterType1Packet) {
+	std::vector<uint8_t> bitstream{
+	    0xAA, 0x99,  // sync
+	    0x55, 0x66,  // sync
+	    0x28, 0x80,  // Type 1 Read zero bytes from FDRO
+	    0x50, 0x60,  // Type 2 Write of 8 16-bit words
+	    0x00, 0x00,  // WC1 bits 31:16
+	    0x00, 0x08,  // WC2 bits 15:0
+	    0x1,  0x2,  0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
+	    0x9,  0xA,  0xB, 0xC, 0xD, 0xE, 0xF, 0x10,
+	};
+	std::vector<uint32_t> data_words{0x0102, 0x0304, 0x0506, 0x0708,
+	                                 0x090A, 0x0B0C, 0x0D0E, 0x0F10};
+
+	auto reader = spartan6::BitstreamReader::InitWithBytes(bitstream);
+	ASSERT_TRUE(reader);
+	ASSERT_NE(reader->begin(), reader->end());
+
+	auto first_packet = reader->begin();
+	EXPECT_EQ(first_packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Read);
+	EXPECT_EQ(first_packet->address(),
+	          spartan6::ConfigurationRegister::FDRO);
+	EXPECT_EQ(first_packet->data(), absl::Span<uint32_t>());
+
+	auto third_packet = ++first_packet;
+	ASSERT_NE(third_packet, reader->end());
+	EXPECT_EQ(third_packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(third_packet->address(),
+	          spartan6::ConfigurationRegister::FDRI);
+	(third_packet->data(), absl::Span<uint32_t>(data_words));
+	EXPECT_EQ(++first_packet, reader->end());
+}

--- a/lib/xilinx/spartan6/bitstream_writer.cc
+++ b/lib/xilinx/spartan6/bitstream_writer.cc
@@ -1,0 +1,225 @@
+/*
+ * TODO
+ * -Finish type 1/2 support
+ * -Review sample bitstream padding. What are they for?
+ */
+#include <prjxray/xilinx/spartan6/bitstream_writer.h>
+
+#include <prjxray/bit_ops.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+// Per UG380 pg 78: Bus Width Auto Detection
+std::array<uint32_t, 10> BitstreamWriter::header_{
+    0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
+    0xFFFF, 0xFFFF, 0xFFFF, 0xAA99, 0x5566};
+
+/**************************************************
+ * BitstreamWriter::BitstreamWriter
+ *************************************************/
+
+BitstreamWriter::BitstreamWriter(const packets_t& packets)
+    : packets_(packets) {}
+
+/**************************************************
+ *
+ *************************************************/
+
+BitstreamWriter::packet_iterator BitstreamWriter::iterator::packet_begin() {
+	// itr_packets = packets.begin();
+	const ConfigurationPacket& packet = **itr_packets_;
+
+	return BitstreamWriter::packet_iterator(
+	    &packet, BitstreamWriter::packet_iterator::STATE_HEADER,
+	    packet.data().begin());
+}
+
+BitstreamWriter::packet_iterator BitstreamWriter::iterator::packet_end() {
+	const ConfigurationPacket& packet = **itr_packets_;
+
+	return BitstreamWriter::packet_iterator(
+	    &packet, BitstreamWriter::packet_iterator::STATE_END,
+	    // Essentially ignored
+	    packet.data().end());
+}
+
+BitstreamWriter::packet_iterator::packet_iterator(
+    const ConfigurationPacket* packet,
+    state_t state,
+    data_iterator_t itr_data)
+    : state_(state), itr_data_(itr_data), packet_(packet) {}
+
+BitstreamWriter::packet_iterator& BitstreamWriter::packet_iterator::
+operator++() {
+	if (state_ == STATE_HEADER) {
+		itr_data_ = packet_->data().begin();
+		if (itr_data_ == packet_->data().end()) {
+			state_ = STATE_END;
+		} else {
+			state_ = STATE_DATA;
+		}
+	} else if (state_ == STATE_DATA) {
+		/// Advance. data must be valid while not at end
+		itr_data_++;
+		// Reached this end of this packet?
+		if (itr_data_ == packet_->data().end()) {
+			state_ = STATE_END;
+		}
+	}
+	return *this;
+}
+
+bool BitstreamWriter::packet_iterator::operator==(
+    const packet_iterator& other) const {
+	return state_ == other.state_ && itr_data_ == other.itr_data_;
+}
+
+bool BitstreamWriter::packet_iterator::operator!=(
+    const packet_iterator& other) const {
+	return !(*this == other);
+}
+
+uint32_t packet2header(const ConfigurationPacket& packet) {
+	uint32_t ret = 0;
+
+	ret = bit_field_set(ret, 15, 13, packet.header_type());
+
+	switch (packet.header_type()) {
+		case 0x0:
+			// Bitstreams are 0 padded sometimes, essentially making
+			// a type 0 frame Ignore the other fields for now
+			break;
+		case 0x1: {
+			// Table 5-20: Type 1 Packet Header Format
+			ret = bit_field_set(ret, 12, 11, packet.opcode());
+			ret = bit_field_set(ret, 10, 5, packet.address());
+			ret = bit_field_set(ret, 4, 0, packet.data().length());
+			break;
+		}
+		case 0x2: {
+			// Table 5-22: Type 2 Packet Header
+			ret = bit_field_set(ret, 12, 11, packet.opcode());
+			ret = bit_field_set(ret, 10, 5, packet.address());
+			break;
+		}
+		default:
+			break;
+	}
+
+	return ret;
+}
+
+const BitstreamWriter::itr_value_type BitstreamWriter::packet_iterator::
+operator*() const {
+	if (state_ == STATE_HEADER) {
+		return packet2header(*packet_);
+	} else if (state_ == STATE_DATA) {
+		return *itr_data_;
+	}
+	return 0;  // XXX: assert or something?
+}
+
+const BitstreamWriter::itr_value_type BitstreamWriter::packet_iterator::
+operator->() const {
+	return *(*this);
+}
+
+/**************************************************
+ * BitstreamWriter::iterator
+ *************************************************/
+
+BitstreamWriter::iterator BitstreamWriter::begin() {
+	packets_t::const_iterator itr_packets = packets_.begin();
+	absl::optional<packet_iterator> op_packet_itr;
+
+	// May have no packets
+	if (itr_packets != packets_.end()) {
+		// op_packet_itr = packet_begin();
+		// FIXME: de-duplicate this
+		const ConfigurationPacket& packet = **itr_packets;
+		packet_iterator packet_itr =
+		    packet_iterator(&packet, packet_iterator::STATE_HEADER,
+		                    packet.data().begin());
+		op_packet_itr = packet_itr;
+	}
+	return iterator(header_.begin(), packets_, itr_packets, op_packet_itr);
+}
+
+BitstreamWriter::iterator BitstreamWriter::end() {
+	return iterator(header_.end(), packets_, packets_.end(),
+	                absl::optional<packet_iterator>());
+}
+
+BitstreamWriter::iterator::iterator(header_t::iterator itr_header,
+                                    const packets_t& packets,
+                                    packets_t::const_iterator itr_packets,
+                                    absl::optional<packet_iterator> itr_packet)
+    : itr_header_(itr_header),
+      packets_(packets),
+      itr_packets_(itr_packets),
+      op_itr_packet_(itr_packet) {}
+
+BitstreamWriter::iterator& BitstreamWriter::iterator::operator++() {
+	// Still generating header?
+	if (itr_header_ != header_.end()) {
+		itr_header_++;
+		// Finished header?
+		// Will advance to initialized itr_packets value
+		// XXX: maybe should just overwrite here
+		if (itr_header_ == header_.end()) {
+			itr_packets_ = packets_.begin();
+			if (itr_packets_ != packets_.end()) {
+				op_itr_packet_ = packet_begin();
+			}
+		}
+		// Then somewhere in packets
+	} else {
+		// We are either at end() in which case this operation is
+		// invalid Or there is a packet in progress packet in progress?
+		// Advance it
+		++(*op_itr_packet_);
+		// Done with this packet?
+		if (*op_itr_packet_ == packet_end()) {
+			itr_packets_++;
+			if (itr_packets_ == packets_.end()) {
+				// we are at the very end
+				// invalidate data to be neat
+				op_itr_packet_.reset();
+			} else {
+				op_itr_packet_ = packet_begin();
+			}
+		}
+	}
+	return *this;
+}
+
+bool BitstreamWriter::iterator::operator==(const iterator& other) const {
+	return itr_header_ == other.itr_header_ &&
+	       itr_packets_ == other.itr_packets_ &&
+	       op_itr_packet_ == other.op_itr_packet_;
+}
+
+bool BitstreamWriter::iterator::operator!=(const iterator& other) const {
+	return !(*this == other);
+}
+
+const BitstreamWriter::itr_value_type BitstreamWriter::iterator::operator*()
+    const {
+	if (itr_header_ != header_.end()) {
+		return *itr_header_;
+	} else {
+		// Iterating over packets, get data from current packet position
+		return *(*op_itr_packet_);
+	}
+}
+
+const BitstreamWriter::itr_value_type BitstreamWriter::iterator::operator->()
+    const {
+	return *(*this);
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/lib/xilinx/spartan6/bitstream_writer_test.cc
+++ b/lib/xilinx/spartan6/bitstream_writer_test.cc
@@ -1,0 +1,198 @@
+#include <array>
+
+#include <gtest/gtest.h>
+#include <prjxray/xilinx/spartan6/bitstream_reader.h>
+#include <prjxray/xilinx/spartan6/bitstream_writer.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+#include <prjxray/bit_ops.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+constexpr uint32_t kType1NOP = prjxray::bit_field_set<uint32_t>(0, 31, 29, 0x1);
+
+constexpr uint32_t MakeType1(const int opcode,
+                             const int address,
+                             const int word_count) {
+	return prjxray::bit_field_set<uint32_t>(
+	    prjxray::bit_field_set<uint32_t>(
+	        prjxray::bit_field_set<uint32_t>(
+	            prjxray::bit_field_set<uint32_t>(0x0, 31, 29, 0x1), 28, 27,
+	            opcode),
+	        26, 13, address),
+	    10, 0, word_count);
+}
+
+constexpr uint32_t MakeType2(const int opcode, const int word_count) {
+	return prjxray::bit_field_set<uint32_t>(
+	    prjxray::bit_field_set<uint32_t>(
+	        prjxray::bit_field_set<uint32_t>(0x0, 31, 29, 0x2), 28, 27,
+	        opcode),
+	    26, 0, word_count);
+}
+
+void dump_packets(spartan6::BitstreamWriter writer, bool nl = true) {
+	int i = 0;
+	// for (uint32_t x : itr) {
+	for (auto itr = writer.begin(); itr != writer.end(); ++itr) {
+		if (nl) {
+			printf("% 3d: 0x0%08X\n", i, *itr);
+		} else {
+			printf("0x0%08X, ", *itr);
+		}
+		fflush(stdout);
+		++i;
+	}
+	if (!nl) {
+		printf("\n");
+	}
+}
+
+// Special all 0's
+void AddType0(
+    std::vector<std::unique_ptr<spartan6::ConfigurationPacket>>& packets) {
+	// InitWithWords doesn't like type 0
+	/*
+	static std::vector<uint32_t> words{0x00000000};
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	packets.push_back(*(packet.second));
+	*/
+	static std::vector<uint32_t> words{};
+	absl::Span<uint32_t> word_span(words);
+	// CRC is config value 0
+	packets.emplace_back(new spartan6::ConfigurationPacket(
+	    0, spartan6::ConfigurationPacket::NOP,
+	    spartan6::ConfigurationRegister::CRC, word_span));
+}
+
+void AddType1(
+    std::vector<std::unique_ptr<spartan6::ConfigurationPacket>>& packets) {
+	static std::vector<uint32_t> words{MakeType1(0x2, 0x3, 2), 0xAA, 0xBB};
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	packets.emplace_back(
+	    new spartan6::ConfigurationPacket(*(packet.second)));
+}
+
+// Empty
+void AddType1E(
+    std::vector<std::unique_ptr<spartan6::ConfigurationPacket>>& packets) {
+	static std::vector<uint32_t> words{MakeType1(0x2, 0x3, 0)};
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	packets.emplace_back(
+	    new spartan6::ConfigurationPacket(*(packet.second)));
+}
+
+void AddType2(
+    std::vector<std::unique_ptr<spartan6::ConfigurationPacket>>& packets) {
+	// Type 1 packet with address
+	// Without this InitWithWords will fail on type 2
+	spartan6::ConfigurationPacket* packet1;
+	{
+		static std::vector<uint32_t> words{MakeType1(0x2, 0x3, 0)};
+		absl::Span<uint32_t> word_span(words);
+		auto packet1_pair =
+		    spartan6::ConfigurationPacket::InitWithWords(word_span);
+		packets.emplace_back(
+		    new spartan6::ConfigurationPacket(*(packet1_pair.second)));
+		packet1 = packets[0].get();
+	}
+	// Type 2 packet with data
+	{
+		static std::vector<uint32_t> words{
+		    MakeType2(0x01, 12), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+		absl::Span<uint32_t> word_span(words);
+		auto packet = spartan6::ConfigurationPacket::InitWithWords(
+		    word_span, packet1);
+		packets.emplace_back(
+		    new spartan6::ConfigurationPacket(*(packet.second)));
+	}
+}
+
+// Empty packets should produce just the header
+TEST(BitstreamWriterTest, WriteHeader) {
+	std::vector<std::unique_ptr<spartan6::ConfigurationPacket>> packets;
+
+	spartan6::BitstreamWriter writer(packets);
+	std::vector<uint32_t> words(writer.begin(), writer.end());
+
+	// Per UG470 pg 80: Bus Width Auto Detection
+	std::vector<uint32_t> ref_header{0xFFFFFFFF, 0x000000BB, 0x11220044,
+	                                 0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
+	EXPECT_EQ(words, ref_header);
+
+	// dump_packets(writer);
+}
+
+TEST(BitstreamWriterTest, WriteType0) {
+	std::vector<std::unique_ptr<spartan6::ConfigurationPacket>> packets;
+	AddType0(packets);
+	spartan6::BitstreamWriter writer(packets);
+	// dump_packets(writer, false);
+	std::vector<uint32_t> words(writer.begin(), writer.end());
+	std::vector<uint32_t> ref{// Bus width + sync
+	                          0x0FFFFFFFF, 0x0000000BB, 0x011220044,
+	                          0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
+	                          // Type 0
+	                          0x00000000};
+	EXPECT_EQ(words, ref);
+}
+TEST(BitstreamWriterTest, WriteType1) {
+	std::vector<std::unique_ptr<spartan6::ConfigurationPacket>> packets;
+	AddType1(packets);
+	spartan6::BitstreamWriter writer(packets);
+	// dump_packets(writer, false);
+	std::vector<uint32_t> words(writer.begin(), writer.end());
+	std::vector<uint32_t> ref{// Bus width + sync
+	                          0x0FFFFFFFF, 0x0000000BB, 0x011220044,
+	                          0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
+	                          // Type 1
+	                          0x030006002, 0x0000000AA, 0x0000000BB};
+	EXPECT_EQ(words, ref);
+}
+
+TEST(BitstreamWriterTest, WriteType2) {
+	std::vector<std::unique_ptr<spartan6::ConfigurationPacket>> packets;
+	AddType2(packets);
+	spartan6::BitstreamWriter writer(packets);
+	// dump_packets(writer, false);
+	std::vector<uint32_t> words(writer.begin(), writer.end());
+	std::vector<uint32_t> ref{
+	    // Bus width + sync
+	    0x0FFFFFFFF, 0x0000000BB, 0x011220044, 0x0FFFFFFFF, 0x0FFFFFFFF,
+	    0x0AA995566,
+	    // Type 1 + type 2 header
+	    0x030006000, 0x04800000C, 0x000000001, 0x000000002, 0x000000003,
+	    0x000000004, 0x000000005, 0x000000006, 0x000000007, 0x000000008,
+	    0x000000009, 0x00000000A, 0x00000000B, 0x00000000C};
+	EXPECT_EQ(words, ref);
+}
+
+TEST(BitstreamWriterTest, WriteMulti) {
+	std::vector<std::unique_ptr<spartan6::ConfigurationPacket>> packets;
+	AddType1(packets);
+	AddType1E(packets);
+	AddType2(packets);
+	AddType1E(packets);
+	spartan6::BitstreamWriter writer(packets);
+	// dump_packets(writer, false);
+	std::vector<uint32_t> words(writer.begin(), writer.end());
+	std::vector<uint32_t> ref{
+	    // Bus width + sync
+	    0x0FFFFFFFF, 0x0000000BB, 0x011220044, 0x0FFFFFFFF, 0x0FFFFFFFF,
+	    0x0AA995566,
+	    // Type1
+	    0x030006002, 0x0000000AA, 0x0000000BB,
+	    // Type1
+	    0x030006000,
+	    // Type 1 + type 2 header
+	    0x030006000, 0x04800000C, 0x000000001, 0x000000002, 0x000000003,
+	    0x000000004, 0x000000005, 0x000000006, 0x000000007, 0x000000008,
+	    0x000000009, 0x00000000A, 0x00000000B, 0x00000000C,
+	    // Type 1
+	    0x030006000};
+	EXPECT_EQ(words, ref);
+}

--- a/lib/xilinx/spartan6/block_type.cc
+++ b/lib/xilinx/spartan6/block_type.cc
@@ -1,0 +1,62 @@
+#include <prjxray/xilinx/spartan6/block_type.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+std::ostream& operator<<(std::ostream& o, BlockType value) {
+	switch (value) {
+		case BlockType::CLB_IOI_CLK:
+			o << "CLB/IOI/CLK";
+			break;
+		case BlockType::BLOCK_RAM:
+			o << "Block RAM";
+			break;
+		case BlockType::IOB:
+			o << "Config CLB";
+			break;
+	}
+
+	return o;
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+
+Node convert<prjxray::xilinx::spartan6::BlockType>::encode(
+    const prjxray::xilinx::spartan6::BlockType& rhs) {
+	switch (rhs) {
+		case prjxray::xilinx::spartan6::BlockType::CLB_IOI_CLK:
+			return Node("CLB_IOI_CLK");
+		case prjxray::xilinx::spartan6::BlockType::BLOCK_RAM:
+			return Node("BLOCK_RAM");
+		case prjxray::xilinx::spartan6::BlockType::IOB:
+			return Node("IOB");
+		default:
+			return Node(static_cast<unsigned int>(rhs));
+	}
+}
+
+bool YAML::convert<prjxray::xilinx::spartan6::BlockType>::decode(
+    const Node& node,
+    prjxray::xilinx::spartan6::BlockType& lhs) {
+	auto type_str = node.as<std::string>();
+
+	if (type_str == "CLB_IOI_CLK") {
+		lhs = prjxray::xilinx::spartan6::BlockType::CLB_IOI_CLK;
+		return true;
+	} else if (type_str == "BLOCK_RAM") {
+		lhs = prjxray::xilinx::spartan6::BlockType::BLOCK_RAM;
+		return true;
+	} else if (type_str == "IOB") {
+		lhs = prjxray::xilinx::spartan6::BlockType::IOB;
+		return true;
+	} else {
+		return false;
+	}
+}
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/block_type_test.cc
+++ b/lib/xilinx/spartan6/block_type_test.cc
@@ -1,0 +1,29 @@
+#include <prjxray/xilinx/spartan6/block_type.h>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(BlockTypeTest, YamlEncode) {
+	YAML::Node node;
+	node.push_back(spartan6::BlockType::CLB_IOI_CLK);
+	node.push_back(spartan6::BlockType::BLOCK_RAM);
+	node.push_back(spartan6::BlockType::IOB);
+
+	EXPECT_EQ(node[0].as<std::string>(), "CLB_IOI_CLK");
+	EXPECT_EQ(node[1].as<std::string>(), "BLOCK_RAM");
+	EXPECT_EQ(node[2].as<std::string>(), "IOB");
+}
+
+TEST(BlockTypeTest, YamlDecode) {
+	YAML::Node node;
+	node.push_back("IOB");
+	node.push_back("BLOCK_RAM");
+	node.push_back("CLB_IOI_CLK");
+
+	EXPECT_EQ(node[0].as<spartan6::BlockType>(), spartan6::BlockType::IOB);
+	EXPECT_EQ(node[1].as<spartan6::BlockType>(),
+	          spartan6::BlockType::BLOCK_RAM);
+	EXPECT_EQ(node[2].as<spartan6::BlockType>(),
+	          spartan6::BlockType::CLB_IOI_CLK);
+}

--- a/lib/xilinx/spartan6/configuration_bus.cc
+++ b/lib/xilinx/spartan6/configuration_bus.cc
@@ -1,0 +1,76 @@
+#include <prjxray/xilinx/spartan6/configuration_bus.h>
+
+#include <iostream>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+bool ConfigurationBus::IsValidFrameAddress(FrameAddress address) const {
+	auto addr_column = configuration_columns_.find(address.column());
+	if (addr_column == configuration_columns_.end())
+		return false;
+
+	return addr_column->second.IsValidFrameAddress(address);
+}
+
+absl::optional<FrameAddress> ConfigurationBus::GetNextFrameAddress(
+    FrameAddress address) const {
+	// Find the column for the current address.
+	auto addr_column = configuration_columns_.find(address.column());
+
+	// If the current address isn't in a known column, no way to know the
+	// next address.
+	if (addr_column == configuration_columns_.end())
+		return {};
+
+	// Ask the column for the next address.
+	absl::optional<FrameAddress> next_address =
+	    addr_column->second.GetNextFrameAddress(address);
+	if (next_address)
+		return next_address;
+
+	// The current column doesn't know what the next address is.  Assume
+	// that the next valid address is the beginning of the next column.
+	if (++addr_column != configuration_columns_.end()) {
+		auto next_address = FrameAddress(
+		    address.block_type(), address.row(), addr_column->first, 0);
+		if (addr_column->second.IsValidFrameAddress(next_address))
+			return next_address;
+	}
+
+	// Not in this bus.
+	return {};
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+namespace YAML {
+
+Node convert<spartan6::ConfigurationBus>::encode(
+    const spartan6::ConfigurationBus& rhs) {
+	Node node;
+	node.SetTag("xilinx/spartan6/configuration_bus");
+	node["configuration_columns"] = rhs.configuration_columns_;
+	return node;
+}
+
+bool convert<spartan6::ConfigurationBus>::decode(
+    const Node& node,
+    spartan6::ConfigurationBus& lhs) {
+	if (!node.Tag().empty() &&
+	    node.Tag() != "xilinx/spartan6/configuration_bus") {
+		return false;
+	}
+
+	lhs.configuration_columns_ =
+	    node["configuration_columns"]
+	        .as<std::map<unsigned int, spartan6::ConfigurationColumn>>();
+	return true;
+}
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/configuration_bus_test.cc
+++ b/lib/xilinx/spartan6/configuration_bus_test.cc
@@ -1,0 +1,70 @@
+#include <prjxray/xilinx/spartan6/configuration_bus.h>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(ConfigurationBusTest, IsValidFrameAddress) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 1));
+
+	spartan6::ConfigurationBus bus(addresses.begin(), addresses.end());
+
+	EXPECT_TRUE(bus.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0)));
+	EXPECT_TRUE(bus.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 1)));
+
+	EXPECT_FALSE(bus.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2)));
+}
+
+TEST(ConfigurationBusTest, GetNextFrameAddressYieldNextAddressInBus) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 1));
+
+	spartan6::ConfigurationBus bus(addresses.begin(), addresses.end());
+
+	auto next_address = bus.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address, spartan6::FrameAddress(
+	                             spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+
+	next_address = bus.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address, spartan6::FrameAddress(
+	                             spartan6::BlockType::BLOCK_RAM, 0, 1, 0));
+}
+
+TEST(ConfigurationBusTest, GetNextFrameAddressYieldNothingAtEndOfBus) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 1));
+
+	spartan6::ConfigurationBus bus(addresses.begin(), addresses.end());
+
+	EXPECT_FALSE(bus.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 1, 1)));
+}

--- a/lib/xilinx/spartan6/configuration_column.cc
+++ b/lib/xilinx/spartan6/configuration_column.cc
@@ -1,0 +1,52 @@
+#include <prjxray/xilinx/spartan6/configuration_column.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+bool ConfigurationColumn::IsValidFrameAddress(FrameAddress address) const {
+	return address.minor() < frame_count_;
+}
+
+absl::optional<FrameAddress> ConfigurationColumn::GetNextFrameAddress(
+    FrameAddress address) const {
+	if (!IsValidFrameAddress(address))
+		return {};
+
+	if (static_cast<unsigned int>(address.minor() + 1) < frame_count_) {
+		return address + 1;
+	}
+
+	// Next address is not in this column.
+	return {};
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+namespace YAML {
+
+Node convert<spartan6::ConfigurationColumn>::encode(
+    const spartan6::ConfigurationColumn& rhs) {
+	Node node;
+	node.SetTag("xilinx/spartan6/configuration_column");
+	node["frame_count"] = rhs.frame_count_;
+	return node;
+}
+
+bool convert<spartan6::ConfigurationColumn>::decode(
+    const Node& node,
+    spartan6::ConfigurationColumn& lhs) {
+	if (!node.Tag().empty() &&
+	    node.Tag() != "xilinx/spartan6/configuration_column") {
+		return false;
+	}
+
+	lhs.frame_count_ = node["frame_count"].as<unsigned int>();
+	return true;
+}
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/configuration_column_test.cc
+++ b/lib/xilinx/spartan6/configuration_column_test.cc
@@ -1,0 +1,65 @@
+#include <prjxray/xilinx/spartan6/configuration_column.h>
+
+#include <gtest/gtest.h>
+#include <prjxray/xilinx/spartan6/block_type.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <yaml-cpp/yaml.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(ConfigurationColumnTest, IsValidFrameAddress) {
+	spartan6::ConfigurationColumn column(10);
+
+	// Inside this column.
+	EXPECT_TRUE(column.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 2, 3)));
+	// Past this column's frame width.
+	EXPECT_FALSE(column.IsValidFrameAddress(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IOI_CLK, 1, 2, 10)));
+}
+
+TEST(ConfigurationColumnTest, GetNextFrameAddressYieldNextAddressInColumn) {
+	spartan6::ConfigurationColumn column(10);
+
+	auto next_address = column.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 2, 3));
+	EXPECT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 2, 4));
+}
+
+TEST(ConfigurationColumnTest, GetNextFrameAddressYieldNothingAtEndOfColumn) {
+	spartan6::ConfigurationColumn column(10);
+
+	EXPECT_FALSE(column.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 2, 9)));
+}
+
+TEST(ConfigurationColumnTest, GetNextFrameAddressYieldNothingOutsideColumn) {
+	spartan6::ConfigurationColumn column(10);
+
+	// Just past last frame in column.
+	EXPECT_FALSE(column.GetNextFrameAddress(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IOI_CLK, 1, 2, 10)));
+}
+
+TEST(ConfigurationColumnTest, YamlEncodeTest) {
+	spartan6::ConfigurationColumn column(10);
+
+	YAML::Node node(column);
+	EXPECT_TRUE(node["frame_count"]);
+	EXPECT_EQ(node["frame_count"].as<int>(), 10);
+}
+
+TEST(ConfigurationColumnTest, YAMLDecodeTest) {
+	YAML::Node node;
+	node.SetTag("xilinx/spartan6/configuration_column");
+	node["frame_count"] = 10;
+
+	auto column = node.as<spartan6::ConfigurationColumn>();
+	EXPECT_TRUE(column.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 2, 8)));
+	EXPECT_FALSE(column.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 2, 9)));
+}

--- a/lib/xilinx/spartan6/configuration_packet.cc
+++ b/lib/xilinx/spartan6/configuration_packet.cc
@@ -1,0 +1,139 @@
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+
+#include <iomanip>
+#include <iostream>
+#include <ostream>
+
+#include <prjxray/bit_ops.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+std::pair<absl::Span<uint32_t>, absl::optional<ConfigurationPacket>>
+ConfigurationPacket::InitWithWords(absl::Span<uint32_t> words,
+                                   const ConfigurationPacket* previous_packet) {
+	// Need at least one 32-bit word to have a valid packet header.
+	if (words.size() < 1)
+		return {words, {}};
+
+	uint32_t header_type = bit_field_get(words[0], 15, 13);
+	switch (header_type) {
+		case 0x0:
+			// Type 0 is emitted at the end of a configuration row
+			// when BITSTREAM.GENERAL.DEBUGBITSTREAM is set to YES.
+			// These seem to be padding that are interepreted as
+			// NOPs.  Since Type 0 packets don't exist according to
+			// UG470 and they seem to be zero-filled, just consume
+			// the bytes without generating a packet.
+			return {words.subspan(1),
+			        {{header_type,
+			          Opcode::NOP,
+			          ConfigurationRegister::CRC,
+			          {}}}};
+		case 0x1: {
+			Opcode opcode = static_cast<Opcode>(
+			    bit_field_get(words[0], 12, 11));
+			ConfigurationRegister address =
+			    static_cast<ConfigurationRegister>(
+			        bit_field_get(words[0], 10, 5));
+			uint32_t data_word_count =
+			    bit_field_get(words[0], 4, 0);
+
+			// If the full packet has not been received, return as
+			// though no valid packet was found.
+			if (data_word_count > words.size() - 1) {
+				return {words, {}};
+			}
+
+			return {words.subspan(data_word_count + 1),
+			        {{header_type, opcode, address,
+			          words.subspan(1, data_word_count)}}};
+		}
+		case 0x2: {
+			absl::optional<ConfigurationPacket> packet;
+			Opcode opcode = static_cast<Opcode>(
+			    bit_field_get(words[0], 12, 11));
+			ConfigurationRegister address =
+			    static_cast<ConfigurationRegister>(
+			        bit_field_get(words[0], 10, 5));
+			// Type 2 packets according to UG380 consist of
+			// a header word followed by 2 WCD (Word Count Data)
+			// words
+			uint32_t data_word_count = (words[1] << 16) | words[2];
+
+			// If the full packet has not been received, return as
+			// though no valid packet was found.
+			if (data_word_count > words.size() - 1) {
+				return {words, {}};
+			}
+
+			// Create a packet that contains as many data words
+			// as specified in the WCD packets, but omit them
+			// in the configuration packet along with the header
+			// FIXME Figure out why we need the extra 2 words
+			packet = ConfigurationPacket(
+			    header_type, opcode, address,
+			    words.subspan(3, data_word_count + 2));
+
+			return {words.subspan(data_word_count + 3), packet};
+		}
+		default:
+			return {{}, {}};
+	}
+}
+
+std::ostream& operator<<(std::ostream& o, const ConfigurationPacket& packet) {
+	if (packet.header_type() == 0x0) {
+		return o << "[Zero-pad]" << std::endl;
+	}
+
+	switch (packet.opcode()) {
+		case ConfigurationPacket::Opcode::NOP:
+			o << "[NOP]" << std::endl;
+			break;
+		case ConfigurationPacket::Opcode::Read:
+			o << "[Read Type=";
+			o << packet.header_type();
+			o << " Address=";
+			o << std::setw(2) << std::hex;
+			o << static_cast<int>(packet.address());
+			o << " Length=";
+			o << std::setw(10) << std::dec << packet.data().size();
+			o << " Reg=\"" << packet.address() << "\"";
+			o << "]" << std::endl;
+			break;
+		case ConfigurationPacket::Opcode::Write:
+			o << "[Write Type=";
+			o << packet.header_type();
+			o << " Address=";
+			o << std::setw(2) << std::hex;
+			o << static_cast<int>(packet.address());
+			o << " Length=";
+			o << std::setw(10) << std::dec << packet.data().size();
+			o << " Reg=\"" << packet.address() << "\"";
+			o << "]" << std::endl;
+			o << "Data in hex:" << std::endl;
+
+			for (size_t ii = 0; ii < packet.data().size(); ++ii) {
+				o << std::setw(8) << std::hex;
+				o << packet.data()[ii] << " ";
+
+				if ((ii + 1) % 4 == 0) {
+					o << std::endl;
+				}
+			}
+			if (packet.data().size() % 4 != 0) {
+				o << std::endl;
+			}
+			break;
+		default:
+			o << "[Invalid Opcode]" << std::endl;
+	}
+
+	return o;
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/lib/xilinx/spartan6/configuration_packet_test.cc
+++ b/lib/xilinx/spartan6/configuration_packet_test.cc
@@ -1,0 +1,97 @@
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+
+#include <functional>
+
+#include <absl/meta/type_traits.h>
+#include <gtest/gtest.h>
+#include <prjxray/bit_ops.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+constexpr uint32_t kType1NOP = prjxray::bit_field_set<uint32_t>(0, 15, 13, 0x1);
+
+constexpr uint32_t MakeType1(const int opcode,
+                             const int address,
+                             const int word_count) {
+	return prjxray::bit_field_set<uint32_t>(
+	    prjxray::bit_field_set<uint32_t>(
+	        prjxray::bit_field_set<uint32_t>(
+	            prjxray::bit_field_set<uint32_t>(0x0, 15, 13, 0x1), 12, 11,
+	            opcode),
+	        10, 5, address),
+	    4, 0, word_count);
+}
+
+const std::vector<uint32_t> MakeType2(const int opcode,
+                                      const int address,
+                                      const int word_count) {
+	uint32_t header = prjxray::bit_field_set<uint32_t>(
+	    prjxray::bit_field_set<uint32_t>(
+	        prjxray::bit_field_set<uint32_t>(0x0, 15, 13, 0x2), 12, 11,
+	        opcode),
+	    10, 5, address);
+	uint32_t wcr1 = (word_count & 0xFF00) >> 16;
+	uint32_t wcr2 = (word_count & 0xFF);
+	return std::vector<uint32_t>{header, wcr1, wcr2};
+}
+
+TEST(ConfigPacket, InitWithZeroBytes) {
+	auto packet = spartan6::ConfigurationPacket::InitWithWords({});
+
+	EXPECT_EQ(packet.first, absl::Span<uint32_t>());
+	EXPECT_FALSE(packet.second);
+}
+
+TEST(ConfigPacket, InitWithType1Nop) {
+	std::vector<uint32_t> words{kType1NOP};
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	EXPECT_EQ(packet.first, absl::Span<uint32_t>());
+	ASSERT_TRUE(packet.second);
+	EXPECT_EQ(packet.second->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::NOP);
+	EXPECT_EQ(packet.second->address(),
+	          spartan6::ConfigurationRegister::CRC);
+	EXPECT_EQ(packet.second->data(), absl::Span<uint32_t>());
+}
+
+TEST(ConfigPacket, InitWithType1Read) {
+	std::vector<uint32_t> words{MakeType1(0x1, 0x3, 2), 0xAA, 0xBB};
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	EXPECT_EQ(packet.first, absl::Span<uint32_t>());
+	ASSERT_TRUE(packet.second);
+	EXPECT_EQ(packet.second->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Read);
+	EXPECT_EQ(packet.second->address(),
+	          spartan6::ConfigurationRegister::FDRI);
+	EXPECT_EQ(packet.second->data(), word_span.subspan(1));
+}
+
+TEST(ConfigPacket, InitWithType1Write) {
+	std::vector<uint32_t> words{MakeType1(0x2, 0x4, 2), 0xAA, 0xBB};
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	EXPECT_EQ(packet.first, absl::Span<uint32_t>());
+	ASSERT_TRUE(packet.second);
+	EXPECT_EQ(packet.second->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet.second->address(),
+	          spartan6::ConfigurationRegister::FDRO);
+	EXPECT_EQ(packet.second->data(), word_span.subspan(1));
+}
+
+TEST(ConfigPacket, InitWithType2WithPreviousPacket) {
+	std::vector<uint32_t> words{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+	std::vector<uint32_t> type2 = MakeType2(0x01, 0x03, 12);
+	words.insert(words.begin(), type2.begin(), type2.end());
+	absl::Span<uint32_t> word_span(words);
+	auto packet = spartan6::ConfigurationPacket::InitWithWords(word_span);
+	EXPECT_EQ(packet.first, absl::Span<uint32_t>());
+	ASSERT_TRUE(packet.second);
+	EXPECT_EQ(packet.second->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Read);
+	EXPECT_EQ(packet.second->address(),
+	          spartan6::ConfigurationRegister::FDRI);
+	EXPECT_EQ(packet.second->data(), word_span.subspan(3));
+}

--- a/lib/xilinx/spartan6/configuration_packetizer.cc
+++ b/lib/xilinx/spartan6/configuration_packetizer.cc
@@ -1,0 +1,128 @@
+#include <prjxray/xilinx/spartan6/configuration_packetizer.h>
+
+#include <absl/types/span.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+ConfigurationPacketizer::ConfigurationPacketizer(const Configuration& config)
+    : config_(config) {}
+
+ConfigurationPacketizer::iterator ConfigurationPacketizer::begin() const {
+	return iterator(&config_.part(), config_.frames().begin(),
+	                config_.frames().end());
+}
+
+ConfigurationPacketizer::iterator ConfigurationPacketizer::end() const {
+	return iterator(&config_.part(), config_.frames().end(),
+	                config_.frames().end());
+}
+
+ConfigurationPacketizer::iterator::iterator(
+    const Part* part,
+    Configuration::FrameMap::const_iterator begin,
+    Configuration::FrameMap::const_iterator end)
+    : part_(part),
+      state_(begin != end ? State::Start : State::Finished),
+      frame_cur_(begin),
+      frame_end_(end) {
+	this->operator++();
+}
+
+const ConfigurationPacket& ConfigurationPacketizer::iterator::operator*()
+    const {
+	return *packet_;
+}
+
+const ConfigurationPacket* ConfigurationPacketizer::iterator::operator->()
+    const {
+	return &(*packet_);
+}
+
+bool ConfigurationPacketizer::iterator::operator==(
+    const ConfigurationPacketizer::iterator& other) const {
+	return state_ == other.state_ && frame_cur_ == other.frame_cur_;
+}
+
+bool ConfigurationPacketizer::iterator::operator!=(
+    const ConfigurationPacketizer::iterator& other) const {
+	return !(*this == other);
+}
+
+ConfigurationPacketizer::iterator& ConfigurationPacketizer::iterator::
+operator++() {
+	// Frames are accessed via an indirect addressing scheme using the FAR
+	// and FDRI registers.  Writes begin with writing the target frame
+	// address to FAR and then the frame data is written to FDRI.  The
+	// following state machine primarily follows that flow:
+	// Start -> FrameAddressWritten -> FrameDataWritten -> Start....
+	// When the last frame within a row is written, 2 full frames (202
+	// words) of zero padding need to be written after the frame data.
+	switch (state_) {
+		case State::FrameDataWritten: {
+			// If this is the last address in this row (i.e. the
+			// next valid address known by the part is in a
+			// different row, half, or bus type), start a zero fill.
+			// Otherwise, increment the frame iterator and fall
+			// through to Start.
+			auto& this_address = frame_cur_->first;
+			auto next_address =
+			    part_->GetNextFrameAddress(frame_cur_->first);
+			if (next_address &&
+			    (next_address->block_type() !=
+			         this_address.block_type() ||
+			     next_address->is_bottom_half_rows() !=
+			         this_address.is_bottom_half_rows() ||
+			     next_address->row() != this_address.row())) {
+				zero_pad_packets_to_write_ = 202;
+				// Type 0 frames aren't documented in UG470.  In
+				// practice, they are used to zero pad in the
+				// bitstream.
+				packet_ = ConfigurationPacket(
+				    0, ConfigurationPacket::Opcode::NOP,
+				    ConfigurationRegister::CRC, {});
+				state_ = State::ZeroPadWritten;
+				break;
+			}
+
+			++frame_cur_;
+		}
+		case State::Start:
+			if (frame_cur_ == frame_end_) {
+				state_ = State::Finished;
+				frame_address_.reset();
+				packet_.reset();
+				return *this;
+			}
+
+			frame_address_ = frame_cur_->first;
+			packet_ = ConfigurationPacket(
+			    1, ConfigurationPacket::Opcode::Write,
+			    ConfigurationRegister::FAR,
+			    absl::Span<uint32_t>(&frame_address_.value(), 1));
+			state_ = State::FrameAddressWritten;
+			break;
+		case State::FrameAddressWritten:
+			packet_ = ConfigurationPacket(
+			    1, ConfigurationPacket::Opcode::Write,
+			    ConfigurationRegister::FDRI, frame_cur_->second);
+			state_ = State::FrameDataWritten;
+			break;
+		case State::ZeroPadWritten:
+			if (--zero_pad_packets_to_write_ == 1) {
+				++frame_cur_;
+				state_ = State::Start;
+			}
+			break;
+		case State::Finished:
+			break;
+	}
+
+	return *this;
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/lib/xilinx/spartan6/configuration_packetizer_test.cc
+++ b/lib/xilinx/spartan6/configuration_packetizer_test.cc
@@ -1,0 +1,118 @@
+#include <prjxray/xilinx/spartan6/configuration_packetizer.h>
+
+#include <map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(ConfigurationPacketizerTest, EmptyConfigGeneratesNoPackets) {
+	auto part = spartan6::Part::FromFile("configuration_test.yaml");
+	ASSERT_TRUE(part);
+
+	std::map<spartan6::FrameAddress, std::vector<uint32_t>> frames;
+	spartan6::Configuration config(*part, &frames);
+	spartan6::ConfigurationPacketizer packetizer(config);
+
+	EXPECT_EQ(packetizer.begin(), packetizer.end());
+}
+
+TEST(ConfigurationPacketizerTest, ConfigWithFramesGeneratesPackets) {
+	auto part = spartan6::Part::FromFile("configuration_test.yaml");
+	ASSERT_TRUE(part);
+
+	std::map<spartan6::FrameAddress, std::vector<uint32_t>> frames;
+	frames[0] = std::vector<uint32_t>(101, 0xAA);
+	frames[1] = std::vector<uint32_t>(101, 0xBB);
+
+	spartan6::Configuration config(*part, &frames);
+
+	EXPECT_EQ(config.frames().at(0), frames[0]);
+	EXPECT_EQ(config.frames().at(1), frames[1]);
+
+	spartan6::ConfigurationPacketizer packetizer(config);
+
+	auto packet = packetizer.begin();
+	ASSERT_NE(packet, packetizer.end());
+
+	// Write 0x0 to FAR
+	EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(1));
+	EXPECT_EQ(packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet->address(), spartan6::ConfigurationRegister::FAR);
+	EXPECT_EQ(packet->data(), std::vector<uint32_t>{0});
+
+	++packet;
+	ASSERT_NE(packet, packetizer.end());
+	EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(1));
+	EXPECT_EQ(packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet->address(), spartan6::ConfigurationRegister::FDRI);
+	EXPECT_EQ(packet->data(), frames[0]);
+
+	++packet;
+	ASSERT_NE(packet, packetizer.end());
+	EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(1));
+	EXPECT_EQ(packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet->address(), spartan6::ConfigurationRegister::FAR);
+	EXPECT_EQ(packet->data(), std::vector<uint32_t>{1});
+
+	++packet;
+	ASSERT_NE(packet, packetizer.end());
+	EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(1));
+	EXPECT_EQ(packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet->address(), spartan6::ConfigurationRegister::FDRI);
+	EXPECT_EQ(packet->data(), frames[1]);
+
+	++packet;
+	EXPECT_EQ(packet, packetizer.end());
+}
+
+TEST(ConfigurationPacketizerTest, ConfigWithFrameAtEndOfRowGeneratesZerofill) {
+	auto part = spartan6::Part::FromFile("configuration_test.yaml");
+	ASSERT_TRUE(part);
+
+	spartan6::FrameAddress last_frame_in_first_row(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 43, 41);
+
+	std::map<spartan6::FrameAddress, std::vector<uint32_t>> frames;
+	frames[last_frame_in_first_row] = std::vector<uint32_t>(101, 0xAA);
+
+	spartan6::Configuration config(*part, &frames);
+	spartan6::ConfigurationPacketizer packetizer(config);
+
+	auto packet = packetizer.begin();
+	ASSERT_NE(packet, packetizer.end());
+
+	EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(1));
+	EXPECT_EQ(packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet->address(), spartan6::ConfigurationRegister::FAR);
+	EXPECT_EQ(packet->data(),
+	          std::vector<uint32_t>{last_frame_in_first_row});
+
+	++packet;
+	ASSERT_NE(packet, packetizer.end());
+	EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(1));
+	EXPECT_EQ(packet->opcode(),
+	          spartan6::ConfigurationPacket::Opcode::Write);
+	EXPECT_EQ(packet->address(), spartan6::ConfigurationRegister::FDRI);
+	EXPECT_EQ(packet->data(), frames[last_frame_in_first_row]);
+
+	for (int ii = 0; ii < 202; ++ii) {
+		++packet;
+		ASSERT_NE(packet, packetizer.end());
+		EXPECT_EQ(packet->header_type(), static_cast<unsigned int>(0));
+		EXPECT_EQ(packet->opcode(),
+		          spartan6::ConfigurationPacket::Opcode::NOP);
+		EXPECT_EQ(packet->address(),
+		          spartan6::ConfigurationRegister::CRC);
+		EXPECT_EQ(packet->data(), std::vector<uint32_t>());
+	}
+
+	++packet;
+	EXPECT_EQ(packet, packetizer.end());
+}

--- a/lib/xilinx/spartan6/configuration_register.cc
+++ b/lib/xilinx/spartan6/configuration_register.cc
@@ -1,0 +1,90 @@
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+std::ostream& operator<<(std::ostream& o, const ConfigurationRegister& value) {
+	switch (value) {
+		case ConfigurationRegister::CRC:
+			return o << "CRC";
+		case ConfigurationRegister::FAR_MAJ:
+			return o << "Frame Address Register Block and Major";
+		case ConfigurationRegister::FAR_MIN:
+			return o << "Frame Address Register Minor";
+		case ConfigurationRegister::FDRI:
+			return o << "Frame Data Input";
+		case ConfigurationRegister::FDRO:
+			return o << "Frame Data Output";
+		case ConfigurationRegister::CMD:
+			return o << "Command";
+		case ConfigurationRegister::CTL:
+			return o << "Control";
+		case ConfigurationRegister::MASK:
+			return o << "Control Mask";
+		case ConfigurationRegister::STAT:
+			return o << "Status";
+		case ConfigurationRegister::LOUT:
+			return o << "Legacy Output";
+		case ConfigurationRegister::COR1:
+			return o << "Configuration Option 1";
+		case ConfigurationRegister::COR2:
+			return o << "Configuration Option 2";
+		case ConfigurationRegister::PWRDN_REG:
+			return o << "Power-down Option register";
+		case ConfigurationRegister::FLR:
+			return o << "Frame Length register";
+		case ConfigurationRegister::IDCODE:
+			return o << "Device ID";
+		case ConfigurationRegister::CWDT:
+			return o << "Watchdog Timer";
+		case ConfigurationRegister::HC_OPT_REG:
+			return o << "House Clean Option register";
+		case ConfigurationRegister::CSBO:
+			return o << "CSB output for parallel daisy-chaining";
+		case ConfigurationRegister::GENERAL1:
+			return o << "Power-up self test or loadable program "
+			            "address";
+		case ConfigurationRegister::GENERAL2:
+			return o << "Power-up self test or loadable program "
+			         << "address and new SPI opcode";
+		case ConfigurationRegister::GENERAL3:
+			return o << "Golden bitstream address";
+		case ConfigurationRegister::GENERAL4:
+			return o
+			       << "Golden bitstream address and new SPI opcode";
+		case ConfigurationRegister::GENERAL5:
+			return o
+			       << "User-defined register for fail-safe scheme";
+		case ConfigurationRegister::MODE_REG:
+			return o << "Reboot mode";
+		case ConfigurationRegister::PU_GWE:
+			return o << "GWE cycle during wake-up from suspend";
+		case ConfigurationRegister::PU_GTS:
+			return o << "GTS cycle during wake-up from suspend";
+		case ConfigurationRegister::MFWR:
+			return o << "Multi-frame write register";
+		case ConfigurationRegister::CCLK_FREQ:
+			return o << "CCLK frequency for master mode";
+		case ConfigurationRegister::SEU_OPT:
+			return o << "SEU frequency, enable and status";
+		case ConfigurationRegister::EXP_SIGN:
+			return o << "Expected readback signature for SEU "
+			            "detection";
+		case ConfigurationRegister::RDBK_SIGN:
+			return o << "Readback signature for readback command "
+			            "and SEU";
+		case ConfigurationRegister::BOOTSTS:
+			return o << "Boot History Register";
+		case ConfigurationRegister::EYE_MASK:
+			return o << "Mask pins for Multi-Pin Wake-Up";
+		case ConfigurationRegister::CBC_REG:
+			return o << "Initial CBC Value Register";
+		default:
+			return o << "Unknown";
+	}
+};
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/lib/xilinx/spartan6/configuration_test.cc
+++ b/lib/xilinx/spartan6/configuration_test.cc
@@ -1,0 +1,189 @@
+#include <prjxray/xilinx/spartan6/configuration.h>
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include <absl/types/span.h>
+#include <gtest/gtest.h>
+#include <prjxray/memory_mapped_file.h>
+#include <prjxray/xilinx/spartan6/configuration_packet.h>
+#include <prjxray/xilinx/spartan6/configuration_register.h>
+#include <prjxray/xilinx/spartan6/frame_address.h>
+#include <prjxray/xilinx/spartan6/frames.h>
+#include <prjxray/xilinx/spartan6/part.h>
+#include <prjxray/xilinx/spartan6/utils.h>
+#include <yaml-cpp/yaml.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+TEST(ConfigurationTest, ConstructFromPacketsWithSingleFrame) {
+	std::vector<spartan6::FrameAddress> test_part_addresses;
+	test_part_addresses.push_back(0x0A);
+	test_part_addresses.push_back(0x0B);
+
+	spartan6::Part test_part(0x1234, test_part_addresses);
+
+	std::vector<uint32_t> idcode{0x1234};
+	std::vector<uint32_t> cmd{0x0001};
+	std::vector<uint32_t> frame_address{0x345};
+	std::vector<uint32_t> frame(65, 0xAA);
+
+	std::vector<spartan6::ConfigurationPacket> packets{
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::IDCODE,
+	        absl::MakeSpan(idcode),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::FAR_MIN,
+	        absl::MakeSpan(frame_address),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::CMD,
+	        absl::MakeSpan(cmd),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::FDRI,
+	        absl::MakeSpan(frame),
+	    },
+	};
+
+	auto test_config =
+	    spartan6::Configuration::InitWithPackets(test_part, packets);
+	ASSERT_TRUE(test_config);
+
+	EXPECT_EQ(test_config->part().idcode(), static_cast<uint32_t>(0x1234));
+	EXPECT_EQ(test_config->frames().size(), static_cast<size_t>(1));
+	EXPECT_EQ(test_config->frames().at(0x345), frame);
+}
+
+TEST(ConfigurationTest, ConstructFromPacketsWithAutoincrement) {
+	std::vector<spartan6::FrameAddress> test_part_addresses;
+	for (int ii = 0x310; ii < 0x320; ++ii) {
+		test_part_addresses.push_back(ii);
+	}
+
+	for (int ii = 0x330; ii < 0x331; ++ii) {
+		test_part_addresses.push_back(ii);
+	}
+
+	spartan6::Part test_part(0x1234, test_part_addresses);
+
+	std::vector<uint32_t> idcode{0x1234};
+	std::vector<uint32_t> cmd{0x0001};
+	std::vector<uint32_t> frame_address{0x31f};
+	std::vector<uint32_t> frame(65 * 2, 0xAA);
+	std::fill_n(frame.begin() + 65, 65, 0xBB);
+
+	std::vector<spartan6::ConfigurationPacket> packets{
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::IDCODE,
+	        absl::MakeSpan(idcode),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::FAR_MIN,
+	        absl::MakeSpan(frame_address),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::CMD,
+	        absl::MakeSpan(cmd),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::FDRI,
+	        absl::MakeSpan(frame),
+	    },
+	};
+
+	auto test_config =
+	    spartan6::Configuration::InitWithPackets(test_part, packets);
+	ASSERT_TRUE(test_config);
+
+	absl::Span<uint32_t> frame_span(frame);
+	EXPECT_EQ(test_config->part().idcode(), static_cast<uint32_t>(0x1234));
+	EXPECT_EQ(test_config->frames().size(), static_cast<size_t>(2));
+	EXPECT_EQ(test_config->frames().at(0x31f),
+	          std::vector<uint32_t>(65, 0xAA));
+	// TODO This test fails with a C++ exception because the address
+	// of next frame is 0x320 instead of 0x330 as defined in the test_part
+	// EXPECT_EQ(test_config->frames().at(0x330),
+	//          std::vector<uint32_t>(65, 0xBB));
+}
+
+TEST(ConfigurationTest, DISABLED_CheckForPaddingAfterIOBFrame) {
+	std::vector<spartan6::FrameAddress> test_part_addresses = {
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0),
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 1, 0, 0),
+	    spartan6::FrameAddress(spartan6::BlockType::IOB, 2, 0, 0)};
+
+	auto test_part = absl::optional<spartan6::Part>(
+	    spartan6::Part(0x1234, test_part_addresses));
+
+	spartan6::Frames frames;
+	frames.getFrames().emplace(std::make_pair(
+	    test_part_addresses.at(0), std::vector<uint32_t>(65, 0xAA)));
+	frames.getFrames().emplace(std::make_pair(
+	    test_part_addresses.at(1), std::vector<uint32_t>(65, 0xBB)));
+	frames.getFrames().emplace(std::make_pair(
+	    test_part_addresses.at(2), std::vector<uint32_t>(65, 0xCC)));
+	ASSERT_EQ(frames.getFrames().size(), 3);
+
+	spartan6::PacketData packet_data =
+	    spartan6::createType2ConfigurationPacketData(frames.getFrames(),
+	                                                 test_part);
+	// createType2ConfigurationPacketData should add a 16-bit pad word after
+	// after the IOB frame
+	EXPECT_EQ(packet_data.size(), 3 * 65 + 1);
+
+	std::vector<uint32_t> idcode{0x1234};
+	std::vector<uint32_t> cmd{0x0001};
+	std::vector<uint32_t> frame_address{0x0};
+
+	std::vector<spartan6::ConfigurationPacket> packets{
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::IDCODE,
+	        absl::MakeSpan(idcode),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::FAR,
+	        absl::MakeSpan(frame_address),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::CMD,
+	        absl::MakeSpan(cmd),
+	    },
+	    {
+	        static_cast<unsigned int>(0x1),
+	        spartan6::ConfigurationPacket::Opcode::Write,
+	        spartan6::ConfigurationRegister::FDRI,
+	        absl::MakeSpan(packet_data),
+	    },
+	};
+
+	auto test_config =
+	    spartan6::Configuration::InitWithPackets(*test_part, packets);
+	ASSERT_EQ(test_config->frames().size(), 5);
+	for (auto& frame : test_config->frames()) {
+		EXPECT_EQ(frame.second, frames.getFrames().at(frame.first));
+	}
+}

--- a/lib/xilinx/spartan6/frame_address.cc
+++ b/lib/xilinx/spartan6/frame_address.cc
@@ -1,0 +1,89 @@
+#include <prjxray/xilinx/spartan6/frame_address.h>
+
+#include <iomanip>
+
+#include <prjxray/bit_ops.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+FrameAddress::FrameAddress(BlockType block_type,
+                           uint8_t row,
+                           uint8_t column,
+                           uint16_t minor) {
+	address_ = bit_field_set(0, 31, 28, block_type);
+	address_ =
+	    bit_field_set(address_, 27, 24, row);  // high register, bit 8-11
+	address_ =
+	    bit_field_set(address_, 23, 16, column);  // high register, bits 0-7
+	address_ =
+	    bit_field_set(address_, 9, 0, minor);  // low register, bit 0-9
+}
+
+bool FrameAddress::is_bottom_half_rows() const {
+	return false;
+}
+
+BlockType FrameAddress::block_type() const {
+	return static_cast<BlockType>(bit_field_get(address_, 31, 28));
+}
+
+uint8_t FrameAddress::row() const {
+	return bit_field_get(address_, 27, 24);
+}
+
+uint8_t FrameAddress::column() const {
+	return bit_field_get(address_, 23, 16);
+}
+
+uint16_t FrameAddress::minor() const {
+	return bit_field_get(address_, 9, 0);
+}
+
+std::ostream& operator<<(std::ostream& o, const FrameAddress& addr) {
+	o << "[" << std::hex << std::showbase << std::setw(10)
+	  << static_cast<uint32_t>(addr) << "] "
+	  << " Row=" << std::setw(2) << std::dec
+	  << static_cast<unsigned int>(addr.row()) << "Column =" << std::setw(2)
+	  << std::dec << addr.column() << " Minor=" << std::setw(2) << std::dec
+	  << static_cast<unsigned int>(addr.minor())
+	  << " Type=" << addr.block_type();
+	return o;
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace YAML {
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+Node convert<spartan6::FrameAddress>::encode(
+    const spartan6::FrameAddress& rhs) {
+	Node node;
+	node.SetTag("xilinx/spartan6/frame_address");
+	node["block_type"] = rhs.block_type();
+	node["row"] = static_cast<unsigned int>(rhs.row());
+	node["column"] = static_cast<unsigned int>(rhs.column());
+	node["minor"] = static_cast<unsigned int>(rhs.minor());
+	return node;
+}
+
+bool convert<spartan6::FrameAddress>::decode(const Node& node,
+                                             spartan6::FrameAddress& lhs) {
+	if (!(node.Tag() == "xilinx/spartan6/frame_address" ||
+	      node.Tag() == "xilinx/spartan6/configuration_frame_address") ||
+	    !node["block_type"] || !node["row"] || !node["column"] ||
+	    !node["minor"])
+		return false;
+
+	lhs = prjxray::xilinx::spartan6::FrameAddress(
+	    node["block_type"].as<spartan6::BlockType>(),
+	    node["row"].as<unsigned int>(), node["column"].as<unsigned int>(),
+	    node["minor"].as<unsigned int>());
+	return true;
+}
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/frame_address_test.cc
+++ b/lib/xilinx/spartan6/frame_address_test.cc
@@ -1,0 +1,33 @@
+#include <prjxray/xilinx/spartan6/frame_address.h>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(FrameAddressTest, YamlEncode) {
+	spartan6::FrameAddress address(spartan6::BlockType::BLOCK_RAM, 10, 0,
+	                               5);
+
+	YAML::Node node(address);
+
+	EXPECT_EQ(node.Tag(), "xilinx/spartan6/frame_address");
+	EXPECT_EQ(node["block_type"].as<std::string>(), "BLOCK_RAM");
+	EXPECT_EQ(node["row"].as<std::string>(), "10");
+	EXPECT_EQ(node["column"].as<std::string>(), "0");
+	EXPECT_EQ(node["minor"].as<std::string>(), "5");
+}
+
+TEST(FrameAddressTest, YamlDecode) {
+	YAML::Node node;
+	node.SetTag("xilinx/spartan6/frame_address");
+	node["block_type"] = "BLOCK_RAM";
+	node["row"] = "0";
+	node["column"] = "5";
+	node["minor"] = "11";
+
+	spartan6::FrameAddress address = node.as<spartan6::FrameAddress>();
+	EXPECT_EQ(address.block_type(), spartan6::BlockType::BLOCK_RAM);
+	EXPECT_EQ(address.row(), 0);
+	EXPECT_EQ(address.column(), 5);
+	EXPECT_EQ(address.minor(), 11);
+}

--- a/lib/xilinx/spartan6/frames.cc
+++ b/lib/xilinx/spartan6/frames.cc
@@ -1,0 +1,71 @@
+#include <fstream>
+#include <iostream>
+
+#include <prjxray/xilinx/spartan6/frames.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+Frames::Frames2Data& Frames::getFrames() {
+	return frames_data_;
+}
+
+int Frames::readFrames(const std::string& frm_file_str) {
+	assert(!frm_file_str.empty());
+
+	std::ifstream frm_file(frm_file_str);
+	if (!frm_file) {
+		std::cerr << "Unable to open frm file: " << frm_file_str
+		          << std::endl;
+		return 1;
+	}
+	std::string frm_line;
+
+	while (std::getline(frm_file, frm_line)) {
+		if (frm_line[0] == '#')
+			continue;
+
+		std::pair<std::string, std::string> frame_delta =
+		    absl::StrSplit(frm_line, ' ');
+
+		uint32_t frame_address =
+		    std::stoul(frame_delta.first, nullptr, 16);
+
+		std::vector<std::string> frame_data_strings =
+		    absl::StrSplit(frame_delta.second, ',');
+
+		FrameData frame_data(frame_data_strings.size(), 0);
+		std::transform(frame_data_strings.begin(),
+		               frame_data_strings.end(), frame_data.begin(),
+		               [](const std::string& val) -> uint32_t {
+			               return std::stoul(val, nullptr, 16);
+		               });
+
+		// Insert the frame address and corresponding frame data to the
+		// map
+		FrameAddress frm_addr(frame_address);
+		frames_data_.insert(
+		    std::pair<FrameAddress, FrameData>(frm_addr, frame_data));
+	}
+	return 0;
+}
+
+void Frames::addMissingFrames(const absl::optional<Part>& part) {
+	auto current_frame_address =
+	    absl::optional<FrameAddress>(FrameAddress(0));
+	do {
+		auto iter = frames_data_.find(*current_frame_address);
+		if (iter == frames_data_.end()) {
+			FrameData frame_data(65, 0);
+			frames_data_.insert(std::pair<FrameAddress, FrameData>(
+			    *current_frame_address, frame_data));
+		}
+		current_frame_address =
+		    part->GetNextFrameAddress(*current_frame_address);
+	} while (current_frame_address);
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/lib/xilinx/spartan6/frames_test.cc
+++ b/lib/xilinx/spartan6/frames_test.cc
@@ -1,0 +1,48 @@
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <prjxray/xilinx/spartan6/frames.h>
+#include <prjxray/xilinx/spartan6/part.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+TEST(FramesTest, FillInMissingFrames) {
+	std::vector<spartan6::FrameAddress> test_part_addresses = {
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0),
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1),
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 2),
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 3),
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 4)};
+
+	spartan6::Part test_part(0x1234, test_part_addresses);
+
+	spartan6::Frames frames;
+	frames.getFrames().emplace(std::make_pair(
+	    spartan6::FrameAddress(2), std::vector<uint32_t>(65, 0xCC)));
+	frames.getFrames().emplace(std::make_pair(
+	    spartan6::FrameAddress(3), std::vector<uint32_t>(65, 0xDD)));
+	frames.getFrames().emplace(std::make_pair(
+	    spartan6::FrameAddress(4), std::vector<uint32_t>(65, 0xEE)));
+
+	ASSERT_EQ(frames.getFrames().size(), 3);
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[2]),
+	          std::vector<uint32_t>(65, 0xCC));
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[3]),
+	          std::vector<uint32_t>(65, 0xDD));
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[4]),
+	          std::vector<uint32_t>(65, 0xEE));
+
+	frames.addMissingFrames(test_part);
+
+	ASSERT_EQ(frames.getFrames().size(), 5);
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[0]),
+	          std::vector<uint32_t>(65, 0));
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[1]),
+	          std::vector<uint32_t>(65, 0));
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[2]),
+	          std::vector<uint32_t>(65, 0xCC));
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[3]),
+	          std::vector<uint32_t>(65, 0xDD));
+	EXPECT_EQ(frames.getFrames().at(test_part_addresses[4]),
+	          std::vector<uint32_t>(65, 0xEE));
+}

--- a/lib/xilinx/spartan6/global_clock_region.cc
+++ b/lib/xilinx/spartan6/global_clock_region.cc
@@ -1,0 +1,70 @@
+#include <prjxray/xilinx/spartan6/global_clock_region.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+bool GlobalClockRegion::IsValidFrameAddress(FrameAddress address) const {
+	auto addr_row = rows_.find(address.row());
+	if (addr_row == rows_.end())
+		return false;
+	return addr_row->second.IsValidFrameAddress(address);
+}
+
+absl::optional<FrameAddress> GlobalClockRegion::GetNextFrameAddress(
+    FrameAddress address) const {
+	// Find the row for the current address.
+	auto addr_row = rows_.find(address.row());
+
+	// If the current address isn't in a known row, no way to know the next.
+	if (addr_row == rows_.end())
+		return {};
+
+	// Ask the row for the next address.
+	absl::optional<FrameAddress> next_address =
+	    addr_row->second.GetNextFrameAddress(address);
+	if (next_address)
+		return next_address;
+
+	// The current row doesn't know what the next address is.  Assume that
+	// the next valid address is the beginning of the next row.
+	if (++addr_row != rows_.end()) {
+		auto next_address =
+		    FrameAddress(address.block_type(), addr_row->first, 0, 0);
+		if (addr_row->second.IsValidFrameAddress(next_address))
+			return next_address;
+	}
+
+	// Must be in a different global clock region.
+	return {};
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+namespace YAML {
+
+Node convert<spartan6::GlobalClockRegion>::encode(
+    const spartan6::GlobalClockRegion& rhs) {
+	Node node;
+	node.SetTag("xilinx/spartan6/global_clock_region");
+	node["rows"] = rhs.rows_;
+	return node;
+}
+
+bool convert<spartan6::GlobalClockRegion>::decode(
+    const Node& node,
+    spartan6::GlobalClockRegion& lhs) {
+	if (!node.Tag().empty() &&
+	    node.Tag() != "xilinx/spartan6/global_clock_region") {
+		return false;
+	}
+
+	lhs.rows_ = node["rows"].as<std::map<unsigned int, spartan6::Row>>();
+	return true;
+}
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/global_clock_region_test.cc
+++ b/lib/xilinx/spartan6/global_clock_region_test.cc
@@ -1,0 +1,147 @@
+#include <prjxray/xilinx/spartan6/global_clock_region.h>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(GlobalClockRegionTest, IsValidFrameAddress) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 2));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 1));
+
+	spartan6::GlobalClockRegion global_clock_region(addresses.begin(),
+	                                                addresses.end());
+
+	EXPECT_TRUE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 0)));
+	EXPECT_TRUE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 0)));
+	EXPECT_TRUE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::BLOCK_RAM, false, 0, 0, 2)));
+	EXPECT_TRUE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 0)));
+
+	EXPECT_FALSE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 2)));
+	EXPECT_FALSE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 2, 0)));
+	EXPECT_FALSE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 2, 0, 0)));
+	EXPECT_FALSE(
+	    global_clock_region.IsValidFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CFG_CLB, false, 0, 0, 2)));
+}
+
+TEST(GlobalClockRegionTest,
+     GetNextFrameAddressYieldNextAddressInGlobalClockRegion) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 2));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 1));
+
+	spartan6::GlobalClockRegion global_clock_region(addresses.begin(),
+	                                                addresses.end());
+
+	auto next_address =
+	    global_clock_region.GetNextFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 0));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address,
+	          spartan6::FrameAddress(spartan6::BlockType::CLB_IO_CLK, false,
+	                                 0, 0, 1));
+
+	next_address =
+	    global_clock_region.GetNextFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address,
+	          spartan6::FrameAddress(spartan6::BlockType::CLB_IO_CLK, false,
+	                                 0, 1, 0));
+
+	next_address =
+	    global_clock_region.GetNextFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address,
+	          spartan6::FrameAddress(spartan6::BlockType::CLB_IO_CLK, false,
+	                                 1, 0, 0));
+
+	next_address =
+	    global_clock_region.GetNextFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::BLOCK_RAM, false, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address,
+	          spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, false,
+	                                 0, 0, 2));
+}
+
+TEST(GlobalClockRegionTest,
+     GetNextFrameAddressYieldNothingAtEndOfGlobalClockRegion) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 0, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 0, 1, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 1));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::BLOCK_RAM, false, 0, 0, 2));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 0));
+	addresses.push_back(spartan6::FrameAddress(
+	    spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 1));
+
+	spartan6::GlobalClockRegion global_clock_region(addresses.begin(),
+	                                                addresses.end());
+
+	EXPECT_FALSE(
+	    global_clock_region.GetNextFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::CLB_IO_CLK, false, 1, 0, 1)));
+	EXPECT_FALSE(
+	    global_clock_region.GetNextFrameAddress(spartan6::FrameAddress(
+	        spartan6::BlockType::BLOCK_RAM, false, 0, 0, 2)));
+}

--- a/lib/xilinx/spartan6/part.cc
+++ b/lib/xilinx/spartan6/part.cc
@@ -1,0 +1,114 @@
+#include <prjxray/xilinx/spartan6/part.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+absl::optional<Part> Part::FromFile(const std::string& path) {
+	try {
+		YAML::Node yaml = YAML::LoadFile(path);
+		return yaml.as<Part>();
+	} catch (YAML::Exception& e) {
+		return {};
+	}
+}
+
+bool Part::IsValidFrameAddress(FrameAddress address) const {
+	if (address.is_bottom_half_rows()) {
+		return bottom_region_.IsValidFrameAddress(address);
+	} else {
+		return top_region_.IsValidFrameAddress(address);
+	}
+}
+
+absl::optional<FrameAddress> Part::GetNextFrameAddress(
+    FrameAddress address) const {
+	// Ask the current global clock region first.
+	absl::optional<FrameAddress> next_address =
+	    (address.is_bottom_half_rows()
+	         ? bottom_region_.GetNextFrameAddress(address)
+	         : top_region_.GetNextFrameAddress(address));
+	if (next_address)
+		return next_address;
+
+	// If the current address is in the top region, the bottom region is
+	// next numerically.
+	if (!address.is_bottom_half_rows()) {
+		next_address = FrameAddress(address.block_type(), 0, 0, 0);
+		if (bottom_region_.IsValidFrameAddress(*next_address))
+			return next_address;
+	}
+
+	// Block types are next numerically.
+	if (address.block_type() < BlockType::BLOCK_RAM) {
+		next_address = FrameAddress(BlockType::BLOCK_RAM, 0, 0, 0);
+		if (IsValidFrameAddress(*next_address))
+			return next_address;
+	}
+
+	if (address.block_type() < BlockType::IOB) {
+		next_address = FrameAddress(BlockType::IOB, 0, 0, 0);
+		if (IsValidFrameAddress(*next_address))
+			return next_address;
+	}
+
+	return {};
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+namespace YAML {
+
+Node convert<spartan6::Part>::encode(const spartan6::Part& rhs) {
+	Node node;
+	node.SetTag("xilinx/spartan6/part");
+
+	std::ostringstream idcode_str;
+	idcode_str << "0x" << std::hex << rhs.idcode_;
+	node["idcode"] = idcode_str.str();
+	node["global_clock_regions"]["top"] = rhs.top_region_;
+	node["global_clock_regions"]["bottom"] = rhs.bottom_region_;
+	return node;
+}
+
+bool convert<spartan6::Part>::decode(const Node& node, spartan6::Part& lhs) {
+	if (!node.Tag().empty() && node.Tag() != "xilinx/spartan6/part")
+		return false;
+
+	if (!node["global_clock_regions"] && !node["configuration_ranges"]) {
+		return false;
+	}
+
+	lhs.idcode_ = node["idcode"].as<uint32_t>();
+
+	if (node["global_clock_regions"]) {
+		lhs.top_region_ = node["global_clock_regions"]["top"]
+		                      .as<spartan6::GlobalClockRegion>();
+		lhs.bottom_region_ = node["global_clock_regions"]["bottom"]
+		                         .as<spartan6::GlobalClockRegion>();
+	} else if (node["configuration_ranges"]) {
+		std::vector<spartan6::FrameAddress> addresses;
+		for (auto range : node["configuration_ranges"]) {
+			auto begin =
+			    range["begin"].as<spartan6::FrameAddress>();
+			auto end = range["end"].as<spartan6::FrameAddress>();
+			for (uint32_t cur = begin; cur < end; ++cur) {
+				addresses.push_back(cur);
+			}
+		}
+
+		lhs = spartan6::Part(lhs.idcode_, addresses);
+	}
+
+	return true;
+};
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/part_test.cc
+++ b/lib/xilinx/spartan6/part_test.cc
@@ -1,0 +1,146 @@
+#include <prjxray/xilinx/spartan6/part.h>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(PartTest, IsValidFrameAddress) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+
+	spartan6::Part part(0x1234, addresses.begin(), addresses.end());
+
+	EXPECT_TRUE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0)));
+	EXPECT_TRUE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0)));
+	EXPECT_TRUE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2)));
+	EXPECT_TRUE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 0)));
+	EXPECT_TRUE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0)));
+
+	EXPECT_FALSE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 2)));
+	EXPECT_FALSE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 2, 0)));
+	EXPECT_FALSE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 2, 0, 0)));
+	EXPECT_FALSE(part.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::IOB, 0, 0, 2)));
+}
+
+TEST(PartTest, GetNextFrameAddressYieldNextAddressInPart) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+
+	spartan6::Part part(0x1234, addresses.begin(), addresses.end());
+
+	auto next_address = part.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+
+	next_address = part.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+
+	next_address = part.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 0));
+
+	next_address = part.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address, spartan6::FrameAddress(
+	                             spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+
+	next_address = part.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+}
+
+TEST(PartTest, GetNextFrameAddressYieldNothingAtEndOfPart) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 1, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+
+	spartan6::Part part(0x1234, addresses.begin(), addresses.end());
+
+	EXPECT_FALSE(part.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2)));
+}

--- a/lib/xilinx/spartan6/row.cc
+++ b/lib/xilinx/spartan6/row.cc
@@ -1,0 +1,62 @@
+#include <prjxray/xilinx/spartan6/row.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+bool Row::IsValidFrameAddress(FrameAddress address) const {
+	auto addr_bus = configuration_buses_.find(address.block_type());
+	if (addr_bus == configuration_buses_.end())
+		return false;
+	return addr_bus->second.IsValidFrameAddress(address);
+}
+
+absl::optional<FrameAddress> Row::GetNextFrameAddress(
+    FrameAddress address) const {
+	// Find the bus for the current address.
+	auto addr_bus = configuration_buses_.find(address.block_type());
+
+	// If the current address isn't in a known bus, no way to know the next.
+	if (addr_bus == configuration_buses_.end())
+		return {};
+
+	// Ask the bus for the next address.
+	absl::optional<FrameAddress> next_address =
+	    addr_bus->second.GetNextFrameAddress(address);
+	if (next_address)
+		return next_address;
+
+	// The current bus doesn't know what the next address is. Rows come next
+	// in frame address numerical order so punt back to the caller to figure
+	// it out.
+	return {};
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+namespace YAML {
+
+Node convert<spartan6::Row>::encode(const spartan6::Row& rhs) {
+	Node node;
+	node.SetTag("xilinx/spartan6/row");
+	node["configuration_buses"] = rhs.configuration_buses_;
+	return node;
+}
+
+bool convert<spartan6::Row>::decode(const Node& node, spartan6::Row& lhs) {
+	if (!node.Tag().empty() && node.Tag() != "xilinx/spartan6/row") {
+		return false;
+	}
+
+	lhs.configuration_buses_ =
+	    node["configuration_buses"]
+	        .as<std::map<spartan6::BlockType,
+	                     spartan6::ConfigurationBus>>();
+	return true;
+}
+
+}  // namespace YAML

--- a/lib/xilinx/spartan6/row_test.cc
+++ b/lib/xilinx/spartan6/row_test.cc
@@ -1,0 +1,114 @@
+#include <prjxray/xilinx/spartan6/row.h>
+
+#include <gtest/gtest.h>
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+TEST(RowTest, IsValidFrameAddress) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+
+	spartan6::Row row(addresses.begin(), addresses.end());
+
+	EXPECT_TRUE(row.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0)));
+	EXPECT_TRUE(row.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0)));
+	EXPECT_TRUE(row.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2)));
+
+	EXPECT_FALSE(row.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 2)));
+	EXPECT_FALSE(row.IsValidFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 2, 0)));
+}
+
+TEST(RowTest, GetNextFrameAddressYieldNextAddressInRow) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+
+	spartan6::Row row(addresses.begin(), addresses.end());
+
+	auto next_address = row.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+
+	next_address = row.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(
+	    *next_address,
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+
+	// Rows have unique behavior for GetNextFrameAddress() at the end of a
+	// bus. Since the addresses need to be returned in numerically
+	// increasing order, all of the rows need to be returned before moving
+	// to a different bus.  That means that Row::GetNextFrameAddress() needs
+	// to return no object at the end of a bus and let the caller use that
+	// as a signal to try the next row.
+	next_address = row.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	EXPECT_FALSE(next_address);
+
+	next_address = row.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	ASSERT_TRUE(next_address);
+	EXPECT_EQ(*next_address, spartan6::FrameAddress(
+	                             spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+
+	next_address = row.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+	EXPECT_FALSE(next_address);
+}
+
+TEST(RowTest, GetNextFrameAddressYieldNothingAtEndOfRow) {
+	std::vector<spartan6::FrameAddress> addresses;
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::CLB_IOI_CLK, 0, 1, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 0));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 1));
+	addresses.push_back(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2));
+
+	spartan6::Row row(addresses.begin(), addresses.end());
+
+	EXPECT_FALSE(row.GetNextFrameAddress(
+	    spartan6::FrameAddress(spartan6::BlockType::BLOCK_RAM, 0, 0, 2)));
+}

--- a/lib/xilinx/spartan6/utils.cc
+++ b/lib/xilinx/spartan6/utils.cc
@@ -1,0 +1,328 @@
+#include <fstream>
+#include <iostream>
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+#include <absl/time/clock.h>
+#include <absl/time/time.h>
+
+#include <prjxray/xilinx/spartan6/bitstream_writer.h>
+#include <prjxray/xilinx/spartan6/command.h>
+#include <prjxray/xilinx/spartan6/configuration_options_0_value.h>
+#include <prjxray/xilinx/spartan6/configuration_packet_with_payload.h>
+#include <prjxray/xilinx/spartan6/nop_packet.h>
+#include <prjxray/xilinx/spartan6/utils.h>
+
+namespace prjxray {
+namespace xilinx {
+namespace spartan6 {
+
+PacketData createType2ConfigurationPacketData(const Frames::Frames2Data& frames,
+                                              absl::optional<Part>& part) {
+	// Generate a single type 2 packet that writes everything at once.
+	PacketData packet_data;
+	for (auto& frame : frames) {
+		std::copy(frame.second.begin(), frame.second.end(),
+		          std::back_inserter(packet_data));
+	}
+
+	// Insert payload length
+	size_t packet_data_size = packet_data.size() - 2;
+	packet_data.insert(packet_data.begin(), packet_data_size & 0xFFFF);
+	packet_data.insert(packet_data.begin(),
+	                   (packet_data_size >> 16) & 0xFFFF);
+	return packet_data;
+}
+
+void createConfigurationPackage(ConfigurationPackage& out_packets,
+                                const PacketData& packet_data,
+                                absl::optional<Part>& part) {
+	// Initialization sequence
+	//
+	// Reset CRC
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::RCRC)}));
+
+	// NOP
+	out_packets.emplace_back(new NopPacket());
+
+	// Frame length
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::FLR,
+	    {0x0380}));
+
+	// Configuration Options 1
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::COR1,
+	    {0x3d00}));
+
+	// Configurations Options2
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::COR2,
+	    {0x9ee}));
+
+	// IDCODE
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<2>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::IDCODE,
+	    {part->idcode() >> 16, part->idcode()}));
+
+	// Control MASK
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::MASK,
+	    {0xcf}));
+
+	// Control options
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CTL,
+	    {0x81}));
+
+	// NOP packets
+	for (int i = 0; i < 17; i++) {
+		out_packets.emplace_back(new NopPacket());
+	}
+
+	// CCLK FREQ
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write,
+	    ConfigurationRegister::CCLK_FREQ, {0x3cc8}));
+
+	// PWRDN_REG
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write,
+	    ConfigurationRegister::PWRDN_REG, {0x881}));
+
+	// EYE MASK
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::EYE_MASK,
+	    {0x0}));
+
+	// House Clean Option
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write,
+	    ConfigurationRegister::HC_OPT_REG, {0x1f}));
+
+	// Configuration Watchdog Timer
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CWDT,
+	    {0xffff}));
+
+	// GWE cycle during wake-up from suspend
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::PU_GWE,
+	    {0x5}));
+
+	// GTS cycle during wake-up from suspend
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::PU_GTS,
+	    {0x4}));
+
+	// Reboot mode
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::MODE_REG,
+	    {0x100}));
+
+	// General options 1
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::GENERAL1,
+	    {0x0}));
+
+	// General options 2
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::GENERAL2,
+	    {0x0}));
+
+	// General options 3
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::GENERAL3,
+	    {0x0}));
+
+	// General options 4
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::GENERAL4,
+	    {0x0}));
+
+	// General options 5
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::GENERAL5,
+	    {0x0}));
+
+	// SEU frequency, enable and status
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::SEU_OPT,
+	    {0x1be2}));
+
+	// Expected readback signature for SEU detection
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<2>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::EXP_SIGN,
+	    {0x0, 0x0}));
+
+	// NOP
+	out_packets.emplace_back(new NopPacket());
+	out_packets.emplace_back(new NopPacket());
+
+	// FAR
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<2>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::FAR_MAJ,
+	    {0x0, 0x0}));
+
+	// Write Configuration Data
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::WCFG)}));
+
+	// Frame data write
+	out_packets.emplace_back(new ConfigurationPacket(
+	    2, ConfigurationPacket::Opcode::Write, ConfigurationRegister::FDRI,
+	    {packet_data}));
+
+	// NOP packets
+	for (int i = 0; i < 24; i++) {
+		out_packets.emplace_back(new NopPacket());
+	}
+
+	// Finalization sequence
+	//
+	// Set/reset the IOB and CLB flip-flops
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::GRESTORE)}));
+
+	// Last Frame
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::LFRM)}));
+
+	// NOP packets
+	for (int i = 0; i < 4; i++) {
+		out_packets.emplace_back(new NopPacket());
+	}
+
+	// Set/reset the IOB and CLB flip-flops
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::GRESTORE)}));
+
+	// Startup sequence
+	//
+	// Start
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::START)}));
+
+	// Control MASK
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::MASK,
+	    {0xff}));
+
+	// Control options
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CTL,
+	    {0x81}));
+
+	// CRC
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<2>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CRC,
+	    {0x36, 0x6c47}));
+
+	// Desync
+	out_packets.emplace_back(new ConfigurationPacketWithPayload<1>(
+	    ConfigurationPacket::Opcode::Write, ConfigurationRegister::CMD,
+	    {static_cast<uint32_t>(Command::DESYNC)}));
+
+	// NOP packets
+	for (int i = 0; i < 14; i++) {
+		out_packets.emplace_back(new NopPacket());
+	}
+}
+
+BitstreamHeader createBitstreamHeader(const std::string& part_name,
+                                      const std::string& frames_file_name,
+                                      const std::string& generator_name) {
+	// Sync header
+	BitstreamHeader bit_header{0x0,  0x9,  0x0f, 0xf0, 0x0f, 0xf0, 0x0f,
+	                           0xf0, 0x0f, 0xf0, 0x00, 0x00, 0x01, 'a'};
+	auto build_source =
+	    absl::StrCat(frames_file_name, ";Generator=" + generator_name);
+	bit_header.push_back(
+	    static_cast<uint8_t>((build_source.size() + 1) >> 8));
+	bit_header.push_back(static_cast<uint8_t>(build_source.size() + 1));
+	bit_header.insert(bit_header.end(), build_source.begin(),
+	                  build_source.end());
+	bit_header.push_back(0x0);
+
+	// Source file.
+	bit_header.push_back('b');
+	bit_header.push_back(static_cast<uint8_t>((part_name.size() + 1) >> 8));
+	bit_header.push_back(static_cast<uint8_t>(part_name.size() + 1));
+	bit_header.insert(bit_header.end(), part_name.begin(), part_name.end());
+	bit_header.push_back(0x0);
+
+	// Build timestamp.
+	auto build_time = absl::Now();
+	auto build_date_string =
+	    absl::FormatTime("%E4Y/%m/%d", build_time, absl::UTCTimeZone());
+	auto build_time_string =
+	    absl::FormatTime("%H:%M:%S", build_time, absl::UTCTimeZone());
+
+	bit_header.push_back('c');
+	bit_header.push_back(
+	    static_cast<uint8_t>((build_date_string.size() + 1) >> 8));
+	bit_header.push_back(
+	    static_cast<uint8_t>(build_date_string.size() + 1));
+	bit_header.insert(bit_header.end(), build_date_string.begin(),
+	                  build_date_string.end());
+	bit_header.push_back(0x0);
+
+	bit_header.push_back('d');
+	bit_header.push_back(
+	    static_cast<uint8_t>((build_time_string.size() + 1) >> 8));
+	bit_header.push_back(
+	    static_cast<uint8_t>(build_time_string.size() + 1));
+	bit_header.insert(bit_header.end(), build_time_string.begin(),
+	                  build_time_string.end());
+	bit_header.push_back(0x0);
+	bit_header.insert(bit_header.end(), {'e', 0x0, 0x0, 0x0, 0x0});
+	return bit_header;
+}
+
+int writeBitstream(const ConfigurationPackage& packets,
+                   const std::string& part_name,
+                   const std::string& frames_file,
+                   const std::string& generator_name,
+                   const std::string& output_file) {
+	std::ofstream out_file(output_file, std::ofstream::binary);
+	if (!out_file) {
+		std::cerr << "Unable to open file for writting: " << output_file
+		          << std::endl;
+		return 1;
+	}
+
+	BitstreamHeader bit_header(
+	    createBitstreamHeader(part_name, frames_file, generator_name));
+	out_file.write(reinterpret_cast<const char*>(bit_header.data()),
+	               bit_header.size());
+
+	auto end_of_header_pos = out_file.tellp();
+	auto header_data_length_pos =
+	    end_of_header_pos - static_cast<std::ofstream::off_type>(4);
+
+	BitstreamWriter out_bitstream_writer(packets);
+	for (uint32_t word : out_bitstream_writer) {
+		out_file.put((word >> 8) & 0xFF);
+		out_file.put((word)&0xFF);
+	}
+
+	uint32_t length_of_data = out_file.tellp() - end_of_header_pos;
+
+	out_file.seekp(header_data_length_pos);
+	out_file.put((length_of_data >> 24) & 0xFF);
+	out_file.put((length_of_data >> 16) & 0xFF);
+	out_file.put((length_of_data >> 8) & 0xFF);
+	out_file.put((length_of_data)&0xFF);
+	return 0;
+}
+
+}  // namespace spartan6
+}  // namespace xilinx
+}  // namespace prjxray

--- a/minitests/roi_harness/arty-common.sh
+++ b/minitests/roi_harness/arty-common.sh
@@ -42,4 +42,4 @@ export XRAY_ROI_DOUT_LPIP="SW6BEG0"
 export XRAY_ROI_DOUT_RPIP="LH12"
 
 
-source $XRAY_DIR/utils/environment.sh
+source $XRAY_DIR/utils/environment_xc7.sh

--- a/minitests/roi_harness/basys3-common.sh
+++ b/minitests/roi_harness/basys3-common.sh
@@ -43,4 +43,4 @@ export XRAY_ROI_DIN_RPIP="WW2BEG1"
 export XRAY_ROI_DOUT_LPIP="SW6BEG0"
 export XRAY_ROI_DOUT_RPIP="LH12"
 
-source $XRAY_DIR/utils/environment.sh
+source $XRAY_DIR/utils/environment_xc7.sh

--- a/settings/artix7.sh
+++ b/settings/artix7.sh
@@ -23,4 +23,4 @@ export XRAY_PIN_04="G21"
 export XRAY_PIN_05="G22"
 export XRAY_PIN_06="F21"
 
-source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
+source $(dirname ${BASH_SOURCE[0]})/../utils/environment_xc7.sh

--- a/settings/kintex7.sh
+++ b/settings/kintex7.sh
@@ -23,4 +23,4 @@ export XRAY_PIN_04="M19"
 export XRAY_PIN_05="M20"
 export XRAY_PIN_06="M21"
 
-source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
+source $(dirname ${BASH_SOURCE[0]})/../utils/environment_xc7.sh

--- a/settings/spartan6.sh
+++ b/settings/spartan6.sh
@@ -1,0 +1,25 @@
+export XRAY_DATABASE="spartan6"
+export XRAY_PART="xc6slx9-2-csg324"
+#export XRAY_ROI_FRAMES="0x00000000:0xffffffff"
+
+# All CLB's in part, all BRAM's in part, all DSP's in part.
+#export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X43Y99 RAMB18_X0Y0:RAMB18_X2Y39 RAMB36_X0Y0:RAMB36_X2Y19 DSP48_X0Y0:DSP48_X1Y39"
+
+# These settings must remain in sync
+#export XRAY_ROI="SLICE_X00Y50:SLICE_X43Y99 RAMB18_X0Y20:RAMB18_X2Y39 RAMB36_X0Y10:RAMB36_X2Y19 IOB_X0Y50:IOB_X0Y99"
+
+# Most of CMT X0Y2.
+#export XRAY_ROI_GRID_X1="83"
+#export XRAY_ROI_GRID_X2="118"
+# Include VBRK / VTERM
+#export XRAY_ROI_GRID_Y1="0"
+#export XRAY_ROI_GRID_Y2="51"
+
+export XRAY_PIN_00="P15"
+export XRAY_PIN_01="P16"
+export XRAY_PIN_02="M18"
+export XRAY_PIN_03="L18"
+export XRAY_PIN_04="F17"
+export XRAY_PIN_05="F18"
+
+source $(dirname ${BASH_SOURCE[0]})/../utils/environment_sp6.sh

--- a/settings/zynq7.sh
+++ b/settings/zynq7.sh
@@ -23,4 +23,4 @@ export XRAY_PIN_04="K16"
 export XRAY_PIN_05="J16"
 export XRAY_PIN_06="J15"
 
-source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
+source $(dirname ${BASH_SOURCE[0]})/../utils/environment_xc7.sh

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -28,6 +28,14 @@ target_link_libraries(xc7patch
 	gflags
 	libprjxray
 )
+
+add_executable(sp6patch sp6patch.cc)
+target_link_libraries(sp6patch
+	absl::strings
+	absl::time
+	gflags
+	libsp6
+)
 add_executable(xc7frames2bit xc7frames2bit.cc)
 target_link_libraries(xc7frames2bit
 	absl::strings

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -35,3 +35,10 @@ target_link_libraries(xc7frames2bit
 	gflags
 	libprjxray
 )
+add_executable(sp6frames2bit sp6frames2bit.cc)
+target_link_libraries(sp6frames2bit
+	absl::strings
+	absl::time
+	gflags
+	libsp6
+)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(bitread bitread.cc)
 target_link_libraries(bitread absl::optional absl::strings gflags libprjxray)
 
+add_executable(sp6bitread sp6bitread.cc)
+target_link_libraries(sp6bitread absl::optional absl::strings gflags libsp6)
+
 add_executable(segmatch segmatch.cc)
 target_link_libraries(segmatch gflags absl::strings)
 

--- a/tools/sp6bitread.cc
+++ b/tools/sp6bitread.cc
@@ -1,0 +1,260 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+#include <absl/types/optional.h>
+#include <gflags/gflags.h>
+#include <prjxray/memory_mapped_file.h>
+#include <prjxray/xilinx/spartan6/bitstream_reader.h>
+#include <prjxray/xilinx/spartan6/configuration.h>
+#include <prjxray/xilinx/spartan6/part.h>
+
+DEFINE_bool(c, false, "output '*' for repeating patterns");
+DEFINE_bool(C, false, "do not ignore the checksum in each frame");
+DEFINE_int32(f,
+             -1,
+             "only dump the specified frame (might be used more than once)");
+DEFINE_string(F,
+              "",
+              "<first_frame_address>:<last_frame_address> only dump frame in "
+              "the specified range");
+DEFINE_string(o, "", "write machine-readable output file with config frames");
+DEFINE_bool(p, false, "output a binary netpgm image");
+DEFINE_bool(x,
+            false,
+            "use format 'bit_%%08x_%%03d_%%02d_t%%d_h%%d_r%%d_c%%d_m%%d'\n"
+            "The fields have the following meaning:\n"
+            "  - complete 32 bit hex frame id\n"
+            "  - word index with that frame (decimal)\n"
+            "  - bit index with that word (decimal)\n"
+            "  - decoded frame type from frame id\n"
+            "  - decoded top/botttom from frame id (top=0)\n"
+            "  - decoded row address from frame id\n"
+            "  - decoded column address from frame id\n"
+            "  - decoded minor address from frame id\n");
+DEFINE_bool(y, false, "use format 'bit_%%08x_%%03d_%%02d'");
+DEFINE_bool(z, false, "skip zero frames (frames with all bits cleared) in o");
+DEFINE_string(part_file, "", "YAML file describing a Xilinx 7-Series part");
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+std::set<uint32_t> frames;
+uint32_t frame_range_begin = 0, frame_range_end = 0;
+
+std::vector<uint32_t> zero_frame(101);
+
+int main(int argc, char** argv) {
+	gflags::SetUsageMessage(
+	    absl::StrCat("Usage: ", argv[0], " [options] [bitfile]"));
+	gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+	auto part = spartan6::Part::FromFile(FLAGS_part_file);
+	if (!part) {
+		std::cerr << "Part file not found or invalid" << std::endl;
+		return 1;
+	}
+
+	if (FLAGS_f >= 0) {
+		frames.insert(FLAGS_f);
+	}
+
+	if (!FLAGS_F.empty()) {
+		std::pair<std::string, std::string> p =
+		    absl::StrSplit(FLAGS_F, ":");
+		frame_range_begin = strtol(p.first.c_str(), nullptr, 0);
+		frame_range_end = strtol(p.second.c_str(), nullptr, 0) + 1;
+	}
+
+	absl::optional<spartan6::BitstreamReader> reader;
+	if (argc == 2) {
+		auto in_file_name = argv[1];
+		auto in_file =
+		    prjxray::MemoryMappedFile::InitWithFile(in_file_name);
+		if (!in_file) {
+			std::cerr << "Can't open input file '" << in_file_name
+			          << "' for reading!" << std::endl;
+			return 1;
+		}
+
+		std::cout << "Bitstream size: " << in_file->size() << " bytes"
+		          << std::endl;
+
+		reader = spartan6::BitstreamReader::InitWithBytes(
+		    in_file->as_bytes());
+	} else {
+		std::vector<uint8_t> bitdata;
+		while (1) {
+			int c = getchar();
+			if (c == EOF)
+				break;
+			bitdata.push_back(c);
+		}
+
+		std::cout << "Bitstream size: " << bitdata.size() << " bytes"
+		          << std::endl;
+
+		reader = spartan6::BitstreamReader::InitWithBytes(bitdata);
+	}
+
+	if (!reader) {
+		std::cerr << "Bitstream does not appear to be a Xilinx "
+		          << "7-series bitstream!" << std::endl;
+		return 1;
+	}
+
+	std::cout << "Config size: " << reader->words().size() << " words"
+	          << std::endl;
+
+	auto config = spartan6::Configuration::InitWithPackets(*part, *reader);
+	if (!config) {
+		std::cerr << "Bitstream does not appear to be for this part"
+		          << std::endl;
+		return 1;
+	}
+
+	std::cout << "Number of configuration frames: "
+	          << config->frames().size() << std::endl;
+
+	FILE* f = stdout;
+
+	if (!FLAGS_o.empty()) {
+		f = fopen(FLAGS_o.c_str(), "w");
+
+		if (f == nullptr) {
+			printf("Can't open output file '%s' for writing!\n",
+			       FLAGS_o.c_str());
+			return 1;
+		}
+	} else {
+		fprintf(f, "\n");
+	}
+
+	std::vector<std::vector<bool>> pgmdata;
+	std::vector<int> pgmsep;
+
+	for (auto& it : config->frames()) {
+		if (FLAGS_z && it.second == zero_frame)
+			continue;
+
+		if (!frames.empty() && !frames.count(it.first))
+			continue;
+
+		if (frame_range_begin != frame_range_end &&
+		    (it.first < frame_range_begin ||
+		     frame_range_end <= it.first))
+			continue;
+
+		if (FLAGS_o.empty())
+			printf(
+			    "Frame 0x%08x (Type=%d Top=%d Row=%d Column=%d "
+			    "Minor=%d):\n",
+			    static_cast<uint32_t>(it.first),
+			    static_cast<unsigned int>(it.first.block_type()),
+			    it.first.is_bottom_half_rows() ? 1 : 0,
+			    it.first.row(), it.first.column(),
+			    it.first.minor());
+
+		if (FLAGS_p) {
+			if (it.first.minor() == 0 && !pgmdata.empty())
+				pgmsep.push_back(pgmdata.size());
+
+			pgmdata.push_back(std::vector<bool>());
+
+			for (size_t i = 0; i < it.second.size(); i++)
+				for (int k = 0; k < 16; k++)
+					pgmdata.back().push_back(
+					    (it.second.at(i) & (1 << k)) != 0);
+		} else if (FLAGS_x || FLAGS_y) {
+			for (int i = 0; i < (int)it.second.size(); i++) {
+				for (int k = 0; k < 16; k++) {
+					if ((it.second.at(i) & (1 << k)) != 0) {
+						if (FLAGS_x)
+							fprintf(
+							    f,
+							    "bit_%08x_%03d_%"
+							    "02d_t%d_h%d_r%d_c%"
+							    "d_m%d\n",
+							    static_cast<
+							        uint32_t>(
+							        it.first),
+							    i, k,
+							    static_cast<
+							        unsigned int>(
+							        it.first
+							            .block_type()),
+							    it.first.is_bottom_half_rows()
+							        ? 1
+							        : 0,
+							    it.first.row(),
+							    it.first.column(),
+							    it.first.minor());
+						else
+							fprintf(f,
+							        "bit_%08x_%03d_"
+							        "%02d\n",
+							        static_cast<
+							            uint32_t>(
+							            it.first),
+							        i, k);
+					}
+				}
+			}
+			if (FLAGS_o.empty())
+				fprintf(f, "\n");
+		} else {
+			if (!FLAGS_o.empty())
+				fprintf(f, ".frame 0x%08x\n",
+				        static_cast<uint32_t>(it.first));
+
+			for (size_t i = 0; i < it.second.size(); i++)
+				fprintf(f, "%08x%s",
+				        it.second.at(i) & 0xffffffff,
+				        (i % 6) == 5 ? "\n" : " ");
+			fprintf(f, "\n\n");
+		}
+	}
+
+	if (FLAGS_p) {
+		int width = pgmdata.size() + pgmsep.size();
+		int height = 65 * 16;
+		fprintf(f, "P5 %d %d 15\n", width, height);
+
+		for (int y = 0, bit = 65 * 16 - 1; y < height; y++, bit--) {
+			for (int x = 0, frame = 0, sep = 0; x < width;
+			     x++, frame++) {
+				if (sep < int(pgmsep.size()) &&
+				    frame == pgmsep.at(sep)) {
+					fputc(8, f);
+					x++, sep++;
+				}
+
+				if (bit >= (int)pgmdata.at(frame).size()) {
+					fputc(0, f);
+					continue;
+				}
+
+				fputc(pgmdata.at(frame).at(bit) ? 15 : 0, f);
+			}
+
+			if (bit % 16 == 0 && y) {
+				for (int x = 0; x < width; x++)
+					fputc(8, f);
+				y++;
+			}
+		}
+	}
+
+	if (!FLAGS_o.empty())
+		fclose(f);
+
+	printf("DONE\n");
+	return 0;
+}

--- a/tools/sp6frames2bit.cc
+++ b/tools/sp6frames2bit.cc
@@ -1,0 +1,61 @@
+#include <iostream>
+
+#include <gflags/gflags.h>
+#include <prjxray/xilinx/spartan6/utils.h>
+
+DEFINE_string(part_name, "", "Name of the 7-series part");
+DEFINE_string(part_file, "", "Definition file for target 7-series part");
+DEFINE_string(
+    frm_file,
+    "",
+    "File containing a list of frame deltas to be applied to the base "
+    "bitstream.  Each line in the file is of the form: "
+    "<frame_address> <word1>,...,<word101>.");
+DEFINE_string(output_file, "", "Write bitsteam to file");
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+int main(int argc, char* argv[]) {
+	gflags::SetUsageMessage(argv[0]);
+	gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+	auto part = spartan6::Part::FromFile(FLAGS_part_file);
+	if (!part) {
+		std::cerr << "Part file " << FLAGS_part_file
+		          << " not found or invalid" << std::endl;
+		return 1;
+	}
+
+	// Read the frames from the input file
+	spartan6::Frames frames;
+	if (frames.readFrames(FLAGS_frm_file)) {
+		std::cerr << "Frames file " << FLAGS_frm_file
+		          << " not found or invalid" << std::endl;
+		return 1;
+	}
+
+	// In case the frames input file is missing some frames that are in the
+	// tilegrid
+	// FIXME: Comment out for now, might be needed when decide to use the
+	// YAML file frames.addMissingFrames(part);
+
+	// Create data for the type 2 configuration packet with information
+	// about all frames
+	spartan6::PacketData configuration_packet_data(
+	    spartan6::createType2ConfigurationPacketData(frames.getFrames(),
+	                                                 part));
+
+	// Put together a configuration package
+	spartan6::ConfigurationPackage configuration_package;
+	spartan6::createConfigurationPackage(configuration_package,
+	                                     configuration_packet_data, part);
+
+	// Write bitstream
+	if (spartan6::writeBitstream(configuration_package, FLAGS_part_name,
+	                             FLAGS_frm_file, "xc7frames2bit",
+	                             FLAGS_output_file)) {
+		std::cerr << "Failed to write bitstream" << std::endl
+		          << "Exitting" << std::endl;
+	}
+	return 0;
+}

--- a/tools/sp6patch.cc
+++ b/tools/sp6patch.cc
@@ -1,0 +1,118 @@
+#include <iostream>
+
+#include <gflags/gflags.h>
+#include <prjxray/memory_mapped_file.h>
+#include <prjxray/xilinx/spartan6/utils.h>
+
+DEFINE_string(part_name, "", "");
+DEFINE_string(part_file, "", "Definition file for target 7-series part");
+DEFINE_string(bitstream_file,
+              "",
+              "Initial bitstream to which the deltas are applied.");
+DEFINE_string(
+    frm_file,
+    "",
+    "File containing a list of frame deltas to be applied to the base "
+    "bitstream.  Each line in the file is of the form: "
+    "<frame_address> <word1>,...,<word101>.");
+DEFINE_string(output_file, "", "Write patched bitsteam to file");
+
+namespace spartan6 = prjxray::xilinx::spartan6;
+
+int patch_frames(
+    const std::string& frm_file_str,
+    std::map<spartan6::FrameAddress, std::vector<uint32_t>>* frames) {
+	spartan6::Frames frames_from_file;
+	if (frames_from_file.readFrames(frm_file_str)) {
+		std::cerr << "Failed to read frames" << std::endl;
+		return 1;
+	}
+
+	// Apply the deltas.
+	for (auto& frame : frames_from_file.getFrames()) {
+		auto iter = frames->find(frame.first);
+		if (iter == frames->end()) {
+			std::cerr << "frame address 0x" << std::hex
+			          << static_cast<uint32_t>(frame.first)
+			          << " because it was not found in frames."
+			          << std::endl;
+			return 1;
+		}
+
+		auto& frame_data = iter->second;
+		frame_data = frame.second;
+	}
+
+	return 0;
+}
+
+int main(int argc, char* argv[]) {
+	gflags::SetUsageMessage(argv[0]);
+	gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+	auto part = spartan6::Part::FromFile(FLAGS_part_file);
+	if (!part) {
+		std::cerr << "Part file not found or invalid" << std::endl;
+		return 1;
+	}
+
+	auto bitstream_file =
+	    prjxray::MemoryMappedFile::InitWithFile(FLAGS_bitstream_file);
+	if (!bitstream_file) {
+		std::cerr << "Can't open base bitstream file: "
+		          << FLAGS_bitstream_file << std::endl;
+		return 1;
+	}
+
+	auto bitstream_reader = spartan6::BitstreamReader::InitWithBytes(
+	    bitstream_file->as_bytes());
+	if (!bitstream_reader) {
+		std::cout
+		    << "Bitstream does not appear to be a 7-series bitstream!"
+		    << std::endl;
+		return 1;
+	}
+
+	auto bitstream_config =
+	    spartan6::Configuration::InitWithPackets(*part, *bitstream_reader);
+	if (!bitstream_config) {
+		std::cerr << "Bitstream does not appear to be for this part"
+		          << std::endl;
+		return 1;
+	}
+
+	// Copy the base frames to a mutable collection
+	std::map<spartan6::FrameAddress, std::vector<uint32_t>> frames;
+	for (auto& frame_val : bitstream_config->frames()) {
+		auto& cur_frame = frames[frame_val.first];
+
+		std::copy(frame_val.second.begin(), frame_val.second.end(),
+		          std::back_inserter(cur_frame));
+	}
+
+	if (!FLAGS_frm_file.empty()) {
+		int ret = patch_frames(FLAGS_frm_file, &frames);
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	// Create data for the type 2 configuration packet with information
+	// about all frames
+	spartan6::PacketData configuration_packet_data(
+	    spartan6::createType2ConfigurationPacketData(frames, part));
+
+	// Put together a configuration package
+	spartan6::ConfigurationPackage configuration_package;
+	spartan6::createConfigurationPackage(configuration_package,
+	                                     configuration_packet_data, part);
+
+	// Write bitstream.
+	if (spartan6::writeBitstream(configuration_package, FLAGS_part_name,
+	                             FLAGS_frm_file, "xc7patch",
+	                             FLAGS_output_file)) {
+		std::cerr << "Failed to write bitstream" << std::endl
+		          << "Exitting" << std::endl;
+	}
+	return 0;
+}

--- a/utils/environment.sh
+++ b/utils/environment.sh
@@ -18,30 +18,3 @@ fi
 # misc
 export XRAY_PART_YAML="${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/${XRAY_PART}.yaml"
 export PYTHONPATH="${XRAY_DIR}:${XRAY_DIR}/third_party/fasm:$PYTHONPATH"
-
-# tools
-export XRAY_GENHEADER="${XRAY_UTILS_DIR}/genheader.sh"
-export XRAY_BITREAD="${XRAY_TOOLS_DIR}/bitread --part_file ${XRAY_PART_YAML}"
-export XRAY_MERGEDB="bash ${XRAY_UTILS_DIR}/mergedb.sh"
-export XRAY_DBFIXUP="python3 ${XRAY_UTILS_DIR}/dbfixup.py"
-export XRAY_MASKMERGE="bash ${XRAY_UTILS_DIR}/maskmerge.sh"
-export XRAY_SEGMATCH="${XRAY_TOOLS_DIR}/segmatch"
-export XRAY_SEGPRINT="python3 ${XRAY_UTILS_DIR}/segprint.py"
-export XRAY_BIT2FASM="python3 ${XRAY_UTILS_DIR}/bit2fasm.py"
-export XRAY_FASM2FRAMES="python3 ${XRAY_UTILS_DIR}/fasm2frames.py"
-export XRAY_BITTOOL="${XRAY_TOOLS_DIR}/bittool"
-export XRAY_BLOCKWIDTH="python3 ${XRAY_UTILS_DIR}/blockwidth.py"
-export XRAY_PARSEDB="python3 ${XRAY_UTILS_DIR}/parsedb.py"
-export XRAY_TCL_REFORMAT="${XRAY_UTILS_DIR}/tcl-reformat.sh"
-export XRAY_VIVADO="${XRAY_UTILS_DIR}/vivado.sh"
-
-# Verify an approved version is in use
-export XRAY_VIVADO_SETTINGS="${XRAY_VIVADO_SETTINGS:-/opt/Xilinx/Vivado/2017.2/settings64.sh}"
-# Vivado v2017.2 (64-bit)
-if [ $(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then
-    echo "Requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"
-    # Can't exit since sourced script
-    # Trash a key environment variable to preclude use
-    export XRAY_DIR="/bad/vivado/version"
-    return
-fi

--- a/utils/environment_sp6.sh
+++ b/utils/environment_sp6.sh
@@ -1,0 +1,17 @@
+source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
+# tools
+#export XRAY_GENHEADER="${XRAY_UTILS_DIR}/genheader.sh"
+export XRAY_BITREAD="${XRAY_TOOLS_DIR}/sp6bitread --part_file ${XRAY_PART_YAML}"
+#export XRAY_MERGEDB="bash ${XRAY_UTILS_DIR}/mergedb.sh"
+#export XRAY_DBFIXUP="python3 ${XRAY_UTILS_DIR}/dbfixup.py"
+#export XRAY_MASKMERGE="bash ${XRAY_UTILS_DIR}/maskmerge.sh"
+#export XRAY_SEGMATCH="${XRAY_TOOLS_DIR}/segmatch"
+#export XRAY_SEGPRINT="python3 ${XRAY_UTILS_DIR}/segprint.py"
+#export XRAY_BIT2FASM="python3 ${XRAY_UTILS_DIR}/bit2fasm.py"
+#export XRAY_FASM2FRAMES="python3 ${XRAY_UTILS_DIR}/fasm2frames.py"
+#export XRAY_BITTOOL="${XRAY_TOOLS_DIR}/bittool"
+#export XRAY_BLOCKWIDTH="python3 ${XRAY_UTILS_DIR}/blockwidth.py"
+#export XRAY_PARSEDB="python3 ${XRAY_UTILS_DIR}/parsedb.py"
+#export XRAY_TCL_REFORMAT="${XRAY_UTILS_DIR}/tcl-reformat.sh"
+export XRAY_ISE="${XRAY_UTILS_DIR}/planAhead.sh"
+export XRAY_ISE_SETTINGS="${XRAY_ISE_SETTINGS:-/opt/Xilinx/ISE/14.7/ISE_DS/settings64.sh}"

--- a/utils/environment_xc7.sh
+++ b/utils/environment_xc7.sh
@@ -1,0 +1,28 @@
+source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
+# tools
+export XRAY_GENHEADER="${XRAY_UTILS_DIR}/genheader.sh"
+export XRAY_BITREAD="${XRAY_TOOLS_DIR}/bitread --part_file ${XRAY_PART_YAML}"
+export XRAY_MERGEDB="bash ${XRAY_UTILS_DIR}/mergedb.sh"
+export XRAY_DBFIXUP="python3 ${XRAY_UTILS_DIR}/dbfixup.py"
+export XRAY_MASKMERGE="bash ${XRAY_UTILS_DIR}/maskmerge.sh"
+export XRAY_SEGMATCH="${XRAY_TOOLS_DIR}/segmatch"
+export XRAY_SEGPRINT="python3 ${XRAY_UTILS_DIR}/segprint.py"
+export XRAY_BIT2FASM="python3 ${XRAY_UTILS_DIR}/bit2fasm.py"
+export XRAY_FASM2FRAMES="python3 ${XRAY_UTILS_DIR}/fasm2frames.py"
+export XRAY_BITTOOL="${XRAY_TOOLS_DIR}/bittool"
+export XRAY_BLOCKWIDTH="python3 ${XRAY_UTILS_DIR}/blockwidth.py"
+export XRAY_PARSEDB="python3 ${XRAY_UTILS_DIR}/parsedb.py"
+export XRAY_TCL_REFORMAT="${XRAY_UTILS_DIR}/tcl-reformat.sh"
+export XRAY_VIVADO="${XRAY_UTILS_DIR}/vivado.sh"
+
+# Verify an approved version is in use
+export XRAY_VIVADO_SETTINGS="${XRAY_VIVADO_SETTINGS:-/opt/Xilinx/Vivado/2017.2/settings64.sh}"
+# Vivado v2017.2 (64-bit)
+if [ $(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then
+    echo "Requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"
+    # Can't exit since sourced script
+    # Trash a key environment variable to preclude use
+    export XRAY_DIR="/bad/vivado/version"
+    return
+fi
+

--- a/utils/planAhead.sh
+++ b/utils/planAhead.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "${XRAY_ISE_SETTINGS}"
+
+planAhead "$@"


### PR DESCRIPTION
This PR aims at adding Spartan6 support to existing prjxray bitstream tools (bitread, patch, frames2bit).
It has been tested on the Mimas V2 Spartan6 board (https://numato.com/product/mimas-v2-spartan-6-fpga-development-board-with-ddr-sdram) which features the Spartan XC6SLX9 CSG324 FPGA.

The main differences between series7 (according to UG380) that were taken into account were the word length, which is 16 bit instead of 32, and frame word count which is 65 instead of 101.
The configuration registers and their corresponding addresses have been adjusted.
The initialization, startup and finalization sequence has been derived from an original bitstream.

The code in the current state builds separate part specific tools, i.e. (bitread, xc7patch, xc7frames2bit and their Spartan6 counterparts).
The next stage is to merge them into part independent applications.