### PR TITLE
fuzzers: 038-cfg: Add always on bit for Zynq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,9 @@ db-extras-kintex7:
 
 db-extras-zynq7:
 	+source minitests/roi_harness/zybo-swbut.sh && $(MAKE) -C fuzzers part_only
-	# TODO(#746): Zybo harness is missing some bits, disable automatic harness
-	# generation.
-	#+source minitests/roi_harness/zybo-swbut.sh && \
-	#	$(MAKE) -C minitests/roi_harness \
-	#		HARNESS_DIR=database/artix7/harness/zybo/swbut run
+	+source minitests/roi_harness/zybo-swbut.sh && \
+		$(MAKE) -C minitests/roi_harness \
+			HARNESS_DIR=database/artix7/harness/zybo/swbut run
 
 db-check:
 	@true

--- a/fuzzers/038-cfg/Makefile
+++ b/fuzzers/038-cfg/Makefile
@@ -5,6 +5,11 @@ database: build/segbits_cfg.rdb
 	${XRAY_DBFIXUP} --db-root build --zero-db bits.dbf \
                 --seg-fn-in build/segbits_cfg.rdb \
                 --seg-fn-out build/segbits_cfg.db
+# Some of the bits in Zynq seem to be always set
+# see https://github.com/SymbiFlow/prjxray/issues/746
+ifeq (${XRAY_DATABASE}, zynq7)
+	python3 add_constant_bits.py build/segbits_cfg.db
+endif
 
 
 build/segbits_cfg.rdb: $(SPECIMENS_OK)

--- a/fuzzers/038-cfg/add_constant_bits.py
+++ b/fuzzers/038-cfg/add_constant_bits.py
@@ -1,0 +1,11 @@
+import sys
+
+constant_bits = {
+    "CFG_CENTER_MID.ALWAYS_ON_PROP1": "26_2206",
+    "CFG_CENTER_MID.ALWAYS_ON_PROP2": "26_2207",
+    "CFG_CENTER_MID.ALWAYS_ON_PROP3": "27_2205"
+}
+
+with open(sys.argv[1], "a") as f:
+    for bit_name, bit_value in constant_bits.items():
+        f.write(bit_name + " " + bit_value + "\n")

--- a/fuzzers/038-cfg/add_constant_bits.py
+++ b/fuzzers/038-cfg/add_constant_bits.py
@@ -1,3 +1,17 @@
+"""
+Add bits that are considered always on to the db file.
+
+This script is Zynq specific.
+
+There are three bits that are present in all Zynq bitstreams.
+The investigation that was done to reach this conclusion is captured on GH
+(https://github.com/SymbiFlow/prjxray/issues/746)
+In brief, these bits seem to be bitstream properties related,
+but no evidence of this could be found.
+Due to the fact that the base address of these bits is the same as for the
+CFG_CENTER_MID tile it has been decided to append the bits to its db file.
+"""
+
 import sys
 
 constant_bits = {


### PR DESCRIPTION
This PR is a remedy to the current situation in which 3 bits which are reported as unknown (#746) and thus show up in the fasm file keep the harness generation for Zynq from being successful and block the following PR: https://github.com/SymbiFlow/symbiflow-arch-defs/pull/500.
 