### PR TITLE
README/Dependencies - Updated "Quickstart Guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,26 +46,32 @@ Build the C++ tools:
     make build
 
 ### Step 5: ###
+Alias python to python3 to avoid using python2 accidentally:
+
+    alias python=python3
+
+Choose one of the following options:
+
 (Option 1) - Install the Python environment locally
 
-    sudo apt-get install virtualenv python3-virtualenv python3-yaml
+    sudo apt-get install virtualenv python3 python3-pip python3-virtualenv python3-yaml
     make env
 
 (Option 2) - Install the Python environment globally
 
-    sudo apt-get install python3-yaml
-    sudo pip3 install -r requirements.txt
+    sudo apt-get install python3 python3-pip python3-yaml
+    sudo -H pip3 install -r requirements.txt
 
 This step is known to fail with a compiler error while building the `pyjson5`
-library when using Arch Linux and Fedora. `pyjson5` needs one change to build
-correctly:
+library when using Arch Linux and Fedora. If this occurs, `pyjson5` needs one
+change to build correctly:
 
     git clone https://github.com/Kijewski/pyjson5.git
     cd pyjson5
     sed -i 's/char \*PyUnicode/const char \*PyUnicode/' src/_imports.pyx
     sudo make
 
-This might give you and error about `sphinx_autodoc_typehints` but it should
+This might give you an error about `sphinx_autodoc_typehints` but it should
 correctly build and install pyjson5. After this, run either option 1 or 2 again.
 
 ### Step 6: ###
@@ -88,7 +94,7 @@ Python API with a pre-generated database)
 ### Step 8: ###
 Pick a fuzzer (or write your own) and run:
 
-    cd fuzzers/010-lutinit
+    cd fuzzers/010-clb-lutinit
     make -j$(nproc) run
 
 ### Step 9: ###

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ Build the C++ tools:
     make build
 
 ### Step 5: ###
-Alias python to python3 to avoid using python2 accidentally:
-
-    alias python=python3
-
 Choose one of the following options:
 
 (Option 1) - Install the Python environment locally

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyfasm
+-e third_party/fasm
 intervaltree
 junit-xml
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-fasm
-futures
+pyfasm
 intervaltree
 junit-xml
 numpy


### PR DESCRIPTION
Updated the Quickstart Guide section of the README as some deviations were
required when following this with a fresh Ubuntu 16.04 install.  Fixes to
''requirements.txt'' were required to remove the "futures" dependency which is
in the python3 standard library and is only intended for use with python2;
"fasm" now goes by "pyfasm".

Signed-off-by: Jake Mercer <jmercer04@qub.ac.uk>