### PR TITLE
Add pin functions column to package pins output.

### DIFF
--- a/fuzzers/075-pins/generate.tcl
+++ b/fuzzers/075-pins/generate.tcl
@@ -3,7 +3,7 @@ set_property design_mode PinPlanning [current_fileset]
 open_io_design -name io_1
 
 set fp [open $::env(XRAY_PART)_package_pins.csv w]
-puts $fp "pin,site,tile"
+puts $fp "pin,site,tile,pin_function"
 foreach pin [get_package_pins] {
     set site [get_sites -quiet -of_object $pin]
     if { $site == "" } {
@@ -11,6 +11,7 @@ foreach pin [get_package_pins] {
     }
 
     set tile [get_tiles -of_object $site]
+    set pin_function [get_property PIN_FUNC [get_package_pins E18]]
 
-    puts $fp "$pin,$site,$tile"
+    puts $fp "$pin,$site,$tile,$pin_function"
 }

--- a/fuzzers/075-pins/generate.tcl
+++ b/fuzzers/075-pins/generate.tcl
@@ -11,7 +11,7 @@ foreach pin [get_package_pins] {
     }
 
     set tile [get_tiles -of_object $site]
-    set pin_function [get_property PIN_FUNC [get_package_pins E18]]
+    set pin_function [get_property PIN_FUNC [get_package_pins $pin]]
 
     puts $fp "$pin,$site,$tile,$pin_function"
 }


### PR DESCRIPTION
This is required to know which pin is a PUDC pin, which requires special
handling.