### PR TITLE
third_party: Add sanitizers-cmake module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "third_party/yosys"]
 	path = third_party/yosys
 	url = https://github.com/YosysHQ/yosys
+[submodule "third_party/sanitizers-cmake"]
+	path = third_party/sanitizers-cmake
+	url = https://github.com/arsenm/sanitizers-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.5.0)
 project(prjxray)
 option(PRJXRAY_BUILD_TESTING "" OFF)
 
+# Add sanitizers-cmake package
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/third_party/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})
+find_package(Sanitizers)
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Release CACHE STRING
 		"Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."


### PR DESCRIPTION
This PR adds sanitizers support to cmake - issue #1066 
Sanitizers can be enabled with SANITIZE_ADDRESS, SANITIZE_MEMORY, SANITIZE_THREAD or SANITIZE_UNDEFINED options for example by passing -DSANITIZE_ADDRESS=On to the command line.
To enable sanitizer support on a given target you have to add:
<pre>
add_executable(some_exe foo.c bar.c)
add_sanitizers(some_exe)
</pre>

This PR will have follow up PRs enabling sanitizer support for chosen targets.