### PR TITLE
MAKEFILE - Check if Root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 SHELL = bash
 ALL_EXCLUDE = third_party .git env build
 
+# Check if root
+ifeq ($(shell id -u),0)
+        $(error ERROR: Running as ID 0)
+endif
+
 # Tools + Environment
 IN_ENV = if [ -e env/bin/activate ]; then . env/bin/activate; fi;
 env:


### PR DESCRIPTION
Added a check to the top-level Makefile to ensure that it has not been
invoked by ID 0 i.e. `root` or `sudo`.

Resolves #1100.

Signed-off-by: Jake Mercer <jake.mercer@civica.co.uk>