### PR TITLE
001-part-yaml: Add iobanks information to part's json

### DIFF
--- a/fuzzers/001-part-yaml/Makefile
+++ b/fuzzers/001-part-yaml/Makefile
@@ -4,7 +4,8 @@ SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
 database: $(SPECIMENS)
 	mkdir -p build
 	cp build/specimen_001/part.yaml build/part.yaml
-	python3 -m utils.xyaml build/part.yaml > build/part.json
+	python3 -m utils.xyaml build/part.yaml > build/part_no_iobanks.json
+	python3 add_iobanks.py --part_json build/part_no_iobanks.json --iobanks_info build/specimen_001/iobanks.txt > build/part.json
 
 $(SPECIMENS): Makefile.specimen
 	mkdir -p $@

--- a/fuzzers/001-part-yaml/add_iobanks.py
+++ b/fuzzers/001-part-yaml/add_iobanks.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+'''
+Script for adding the IO Banks information to the Part's generated JSON.
+'''
+import argparse
+import json
+
+
+def main(argv):
+    with open(args.part_json) as json_file, open(
+            args.iobanks_info) as iobanks_info:
+        part_data = json.load(json_file)
+        json_file.close()
+        iobank_data = dict()
+        for iobank in iobanks_info:
+            iobank = iobank.strip()
+            bank, coordinates = iobank.split(",")
+            iobank_data[bank] = coordinates
+        iobanks_info.close()
+        if len(iobank_data) > 0:
+            part_data["iobanks"] = iobank_data
+        print(json.dumps(part_data, indent=4))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--part_json', help='Input json')
+    parser.add_argument('--iobanks_info', help='Input IO Banks info file')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
This PR adds the IO banks information to the part's json which is generate in the `001-part-yaml` fuzzer.
This information is needed for the xdc plugins (https://github.com/SymbiFlow/yosys-symbiflow-plugins/pull/1) to work and is a prerequisite for (https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1158)