### PR TITLE
Dumping PPIPs for Zynq PS7

### DIFF
--- a/fuzzers/071-ppips/generate.tcl
+++ b/fuzzers/071-ppips/generate.tcl
@@ -119,6 +119,26 @@ proc write_ioi_ppips_db {filename tile} {
     close $fp
 }
 
+proc write_pss_ppips_db {filename tile} {
+    if {[llength $tile] != 0} {
+        set fp [open $filename "w"]
+        set tile [get_tiles $tile]
+        set tile_type [get_property TILE_TYPE $tile]
+
+        # Skip bi-directional PIPs as they represent hard-wired PS7 connections
+        # and are not routable.
+        foreach pip [get_pips -of_objects $tile -filter "IS_DIRECTIONAL == 1"] {
+            set dst_wire [get_wires -downhill -of_objects $pip]
+            if {[get_pips -uphill -of_objects [get_nodes -of_objects $dst_wire]] == $pip} {
+                set src_wire [get_wires -uphill -of_objects $pip]
+                puts $fp "${tile_type}.[regsub {.*/} $dst_wire ""].[regsub {.*/} $src_wire ""] always"
+            }
+        }
+
+        close $fp
+    }
+}
+
 foreach tile_type {CLBLM_L CLBLM_R CLBLL_L CLBLL_R} {
     set tiles [get_tiles -filter "TILE_TYPE == $tile_type"]
     if {[llength $tiles] != 0} {
@@ -165,5 +185,13 @@ foreach tile_type {BRAM_L BRAM_R} {
     if {[llength $tiles] != 0} {
         set tile [lindex $tiles 0]
         write_bram_ppips_db "ppips_[string tolower $tile_type].db" $tile
+    }
+}
+
+foreach tile_type {PSS0 PSS1 PSS2 PSS3 PSS4 INT_INTERFACE_PSS_L} {
+    set tiles [get_tiles -filter "TILE_TYPE == $tile_type"]
+    if {[llength $tiles] != 0} {
+        set tile [lindex $tiles 0]
+        write_pss_ppips_db "ppips_[string tolower $tile_type].db" $tile
     }
 }


### PR DESCRIPTION
Added dumping of PPIPs for Zynq PS7 tiles and interconnects. PPIPs related to MIO and DDR are omitted as they are not routable at all.