### PR TITLE
bitstream_writer: fix 7 series and US+ headers

### DIFF
--- a/lib/xilinx/bitstream_writer.cc
+++ b/lib/xilinx/bitstream_writer.cc
@@ -16,7 +16,9 @@ typename BitstreamWriter<Spartan6>::header_t BitstreamWriter<Spartan6>::header_{
 // Per UG470 pg 80: Bus Width Auto Detection
 template <>
 typename BitstreamWriter<Series7>::header_t BitstreamWriter<Series7>::header_{
-    0xFFFFFFFF, 0x000000BB, 0x11220044, 0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
+    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x000000BB, 0x11220044,
+    0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
 
 template <>
 typename BitstreamWriter<UltraScale>::header_t
@@ -26,7 +28,10 @@ typename BitstreamWriter<UltraScale>::header_t
 template <>
 typename BitstreamWriter<UltraScalePlus>::header_t
     BitstreamWriter<UltraScalePlus>::header_{
-        0xFFFFFFFF, 0x000000BB, 0x11220044, 0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
+        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x000000BB, 0x11220044,
+        0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
 
 uint32_t packet2header(
     const ConfigurationPacket<Spartan6ConfigurationRegister>& packet) {

--- a/lib/xilinx/tests/xc7series/bitstream_writer_test.cc
+++ b/lib/xilinx/tests/xc7series/bitstream_writer_test.cc
@@ -132,8 +132,10 @@ TEST(BitstreamWriterTest, WriteHeader) {
 	std::vector<uint32_t> words(writer.begin(), writer.end());
 
 	// Per UG470 pg 80: Bus Width Auto Detection
-	std::vector<uint32_t> ref_header{0xFFFFFFFF, 0x000000BB, 0x11220044,
-	                                 0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
+	std::vector<uint32_t> ref_header{
+	    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
+	    0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x000000BB, 0x11220044,
+	    0xFFFFFFFF, 0xFFFFFFFF, 0xAA995566};
 	EXPECT_EQ(words, ref_header);
 
 	// dump_packets(writer);
@@ -146,11 +148,13 @@ TEST(BitstreamWriterTest, WriteType0) {
 	BitstreamWriter<Series7> writer(packets);
 	// dump_packets(writer, false);
 	std::vector<uint32_t> words(writer.begin(), writer.end());
-	std::vector<uint32_t> ref{// Bus width + sync
-	                          0x0FFFFFFFF, 0x0000000BB, 0x011220044,
-	                          0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
-	                          // Type 0
-	                          0x00000000};
+	std::vector<uint32_t> ref{
+	    // Bus width + sync
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0000000BB, 0x011220044,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
+	    // Type 0
+	    0x00000000};
 	EXPECT_EQ(words, ref);
 }
 TEST(BitstreamWriterTest, WriteType1) {
@@ -160,11 +164,13 @@ TEST(BitstreamWriterTest, WriteType1) {
 	BitstreamWriter<Series7> writer(packets);
 	// dump_packets(writer, false);
 	std::vector<uint32_t> words(writer.begin(), writer.end());
-	std::vector<uint32_t> ref{// Bus width + sync
-	                          0x0FFFFFFFF, 0x0000000BB, 0x011220044,
-	                          0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
-	                          // Type 1
-	                          0x030006002, 0x0000000AA, 0x0000000BB};
+	std::vector<uint32_t> ref{
+	    // Bus width + sync
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0000000BB, 0x011220044,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
+	    // Type 1
+	    0x030006002, 0x0000000AA, 0x0000000BB};
 	EXPECT_EQ(words, ref);
 }
 
@@ -177,8 +183,9 @@ TEST(BitstreamWriterTest, WriteType2) {
 	std::vector<uint32_t> words(writer.begin(), writer.end());
 	std::vector<uint32_t> ref{
 	    // Bus width + sync
-	    0x0FFFFFFFF, 0x0000000BB, 0x011220044, 0x0FFFFFFFF, 0x0FFFFFFFF,
-	    0x0AA995566,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0000000BB, 0x011220044,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
 	    // Type 1 + type 2 header
 	    0x030006000, 0x04800000C, 0x000000001, 0x000000002, 0x000000003,
 	    0x000000004, 0x000000005, 0x000000006, 0x000000007, 0x000000008,
@@ -198,8 +205,9 @@ TEST(BitstreamWriterTest, WriteMulti) {
 	std::vector<uint32_t> words(writer.begin(), writer.end());
 	std::vector<uint32_t> ref{
 	    // Bus width + sync
-	    0x0FFFFFFFF, 0x0000000BB, 0x011220044, 0x0FFFFFFFF, 0x0FFFFFFFF,
-	    0x0AA995566,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0FFFFFFFF, 0x0000000BB, 0x011220044,
+	    0x0FFFFFFFF, 0x0FFFFFFFF, 0x0AA995566,
 	    // Type1
 	    0x030006002, 0x0000000AA, 0x0000000BB,
 	    // Type1


### PR DESCRIPTION
This PR fixes bitstream header generation for series 7 and US+. Without this fix the bistreams could not be loaded from U-Boot or Linux on both Zynq-7000 and ZynqMP. The loading was failing on header check. The headers were fixed to follow the definitions from:

- Zynq7000: https://github.com/Xilinx/u-boot-xlnx/blob/master/drivers/fpga/zynqpl.c#L46
- ZynqMP: https://github.com/Xilinx/u-boot-xlnx/blob/master/drivers/fpga/zynqmppl.c#L18

Signed-off-by: Karol Gugala <kgugala@antmicro.com>