### PR TITLE
fuzzers: Add support for KiB, MiB and GiB units

### DIFF
--- a/fuzzers/run_fuzzer.py
+++ b/fuzzers/run_fuzzer.py
@@ -287,6 +287,9 @@ def mem_convert(s):
     62.0
     """
     units = {
+        'Gi': pow(2, 30),
+        'Mi': pow(2, 20),
+        'Ki': pow(2, 10),
         'G': 1e9,
         'M': 1e6,
         'K': 1e3,


### PR DESCRIPTION
The `run_fuzzers.py` script assumes that the memory reported by `free` is in GB, MB or kB.
This PR adds GiB, MiB and KiB support. 