### PR TITLE
database make: clean also part-dependent directories

### DIFF
--- a/database/Makefile
+++ b/database/Makefile
@@ -1,18 +1,21 @@
-
-DATABASE_FILES = *.csv *.db *.json *.yaml
+DATABASE_FILES = *.csv *.db *.json *.yaml *.fasm
 TIMINGS_FILES = *.sdf
+PART_DIRECTORIES = xc7*/
 
 clean-artix7-db:
 	rm -f $(addprefix artix7/,$(DATABASE_FILES))
 	rm -f $(addprefix artix7/timings/,$(TIMINGS_FILES))
+	rm -rf $(addprefix artix7/,$(PART_DIRECTORIES))
 
 clean-kintex7-db:
 	rm -f $(addprefix kintex7/,$(DATABASE_FILES))
 	rm -f $(addprefix kintex7/timings/,$(TIMINGS_FILES))
+	rm -rf $(addprefix kintex7/,$(PART_DIRECTORIES))
 
 clean-zynq7-db:
 	rm -f $(addprefix zynq7/,$(DATABASE_FILES))
 	rm -f $(addprefix zynq7/timings/,$(TIMINGS_FILES))
+	rm -rf $(addprefix zynq7/,$(PART_DIRECTORIES))
 
 clean-db: clean-artix7-db clean-kintex7-db clean-zynq7-db
 	@true


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to correctly handle cleaning of part-dependent files in the new db structure after https://github.com/SymbiFlow/prjxray/pull/1196