### PR TITLE
Explicitly set which lists in JSON files should be sorted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = bash
-ALL_EXCLUDE = third_party .git env build docs/env
+ALL_EXCLUDE = third_party .git env build docs/venv docs/env
 
 # Check if root
 ifeq ($(shell id -u),0)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(shell id -u),0)
 endif
 
 # Tools + Environment
-IN_ENV = if [ -e env/bin/activate ]; then . env/bin/activate; fi;
+IN_ENV = if [ -e env/bin/activate ]; then . env/bin/activate; fi; source utils/environment.python.sh;
 env:
 	virtualenv --python=python3 env
 	# Install prjxray

--- a/fuzzers/005-tilegrid/generate.py
+++ b/fuzzers/005-tilegrid/generate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from utils import xjson
+import json
 
 
 def load_tiles(tiles_fn):
@@ -87,7 +87,7 @@ def run(tiles_fn, pin_func_fn, json_fn, verbose=False):
     database = make_database(tiles, pin_func)
 
     # Save
-    xjson.pprint(open(json_fn, 'w'), database)
+    json.dump(database, open(json_fn, 'w'), indent=2, sort_keys=True)
 
 
 def main():

--- a/fuzzers/005-tilegrid/generate_full.py
+++ b/fuzzers/005-tilegrid/generate_full.py
@@ -2,7 +2,6 @@
 import copy
 import json
 import os
-from utils import xjson
 '''
 Historically we grouped data into "segments"
 These were a region of the bitstream that encoded one or more tiles
@@ -452,7 +451,7 @@ def run(json_in_fn, json_out_fn, verbose=False):
     alias_HCLKs(database)
 
     # Save
-    xjson.pprint(open(json_out_fn, "w"), database)
+    json.dump(database, open(json_out_fn, "w"), indent=2, sort_keys=True)
 
 
 def main():

--- a/minitests/roi_harness/create_design_json.py
+++ b/minitests/roi_harness/create_design_json.py
@@ -1,4 +1,4 @@
-import xjson
+import json
 import csv
 import argparse
 import sys
@@ -107,7 +107,7 @@ def main():
     design_json['required_features'] = fasm.fasm_tuple_to_string(
         required_features, canonical=True).split('\n')
 
-    xjson.pprint(sys.stdout, design_json)
+    xjson.pprint(design_json, sys.stdout, indent=' ', sort_keys=True)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 intervaltree
 junit-xml
 numpy
+openpyxl
 ordered-set
 parse
 progressbar2
@@ -14,4 +15,3 @@ simplejson
 sympy
 textx
 yapf==0.24.0
-openpyxl

--- a/utils/environment.python.sh
+++ b/utils/environment.python.sh
@@ -1,0 +1,6 @@
+# FIXME: fasm should be installed into the running Python environment.
+export PYTHONPATH="${XRAY_DIR}:${XRAY_DIR}/third_party/fasm:$PYTHONPATH"
+
+# Suppress the following warnings;
+# - env/lib/python3.7/distutils/__init__.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
+export PYTHONWARNINGS=ignore::DeprecationWarning:distutils

--- a/utils/environment.sh
+++ b/utils/environment.sh
@@ -18,7 +18,7 @@ fi
 
 # misc
 export XRAY_PART_YAML="${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/${XRAY_PART}/part.yaml"
-export PYTHONPATH="${XRAY_DIR}:${XRAY_DIR}/third_party/fasm:$PYTHONPATH"
+source $XRAY_UTILS_DIR/environment.python.sh
 
 # tools
 export XRAY_GENHEADER="${XRAY_UTILS_DIR}/genheader.sh"

--- a/utils/find_missing_segbits.py
+++ b/utils/find_missing_segbits.py
@@ -113,7 +113,7 @@ def main(argv):
     # List tile types
     tile_types = []
     for file in files:
-        match = re.match("^tile_type_(\w+).json$", file)
+        match = re.match("^tile_type_(\\w+).json$", file)
         if match:
             tile_types.append(match.group(1))
 

--- a/utils/sort_db.py
+++ b/utils/sort_db.py
@@ -392,7 +392,7 @@ def sort_lists_in_json(pathname):
 
     elif fname == 'tileconn.json':
         converting = ['^$', 'wire_pairs$']
-        keeping = ['grid_deltas$', 'tile_types$', 'wire_pairs\[[0-9]+\]$']
+        keeping = ['grid_deltas$', 'tile_types$', 'wire_pairs\\[[0-9]+\\]$']
 
     keeping = [re.compile(i) for i in keeping]
     converting = [re.compile(i) for i in converting]

--- a/utils/sort_db.py
+++ b/utils/sort_db.py
@@ -380,15 +380,19 @@ def sort_lists_in_json(pathname):
     converting = []
 
     if fname.startswith('tile_type_'):
-        converting = ['sites$',]
-        keeping = ['delay$',]
+        converting = [
+            'sites$',
+        ]
+        keeping = [
+            'delay$',
+        ]
 
     elif fname == 'design.json':
-        converting = ['ports$','wires_outside_roi$','required_features$']
+        converting = ['ports$', 'wires_outside_roi$', 'required_features$']
 
     elif fname == 'tileconn.json':
         converting = ['^$', 'wire_pairs$']
-        keeping = ['grid_deltas$','tile_types$','wire_pairs\[[0-9]+\]$']
+        keeping = ['grid_deltas$', 'tile_types$', 'wire_pairs\[[0-9]+\]$']
 
     keeping = [re.compile(i) for i in keeping]
     converting = [re.compile(i) for i in converting]
@@ -398,6 +402,7 @@ def sort_lists_in_json(pathname):
             if n.search(name):
                 return True
         return False
+
     def convert_cb(name):
         for n in converting:
             if n.search(name):
@@ -439,6 +444,7 @@ def sort_tileconn(filename):
                 yield v
             for v in x['grid_deltas']:
                 yield v
+
         return list(i())
 
     c.sort(key=keyf)

--- a/utils/xjson.py
+++ b/utils/xjson.py
@@ -64,13 +64,14 @@ def setify(data, should_keep_list, should_convert_list):
             new = {}
             for k, v in data.items():
                 vname = '{}.{}'.format(name, k)
-                new[convert(name, k)]=convert(vname, v)
+                new[convert(name, k)] = convert(vname, v)
             return tuple(new.items())
         elif isinstance(data, (list, tuple)):
             keep_list = should_keep_list(name)
             convert_list = should_convert_list(name)
             if not keep_list and not convert_list:
-                raise TypeError("Unknown list with name: {} - {}".format(name, data))
+                raise TypeError(
+                    "Unknown list with name: {} - {}".format(name, data))
             if keep_list:
                 new = []
                 new_add = new.append
@@ -124,6 +125,7 @@ def sort(data, should_keep_list, should_convert_list):
     t6: (5, 3.0, 2.0)
 
     """
+
     def key(o):
         if o is None:
             return None
@@ -178,7 +180,8 @@ def sort(data, should_keep_list, should_convert_list):
             keep_list = should_keep_list(name)
             convert_list = should_convert_list(name)
             if not keep_list and not convert_list:
-                raise TypeError("Unknown list with name: {} - {}".format(name, o))
+                raise TypeError(
+                    "Unknown list with name: {} - {}".format(name, o))
 
             nlist = []
             for i, v in enumerate(o):

--- a/utils/xyaml.py
+++ b/utils/xyaml.py
@@ -20,7 +20,7 @@ def load(f):
 def tojson(f):
     d = load(f)
     o = io.StringIO()
-    xjson.pprint(o, d)
+    xjson.pprint(o, d, lambda x: False, lambda x: False)
     return o.getvalue()
 
 


### PR DESCRIPTION
This is an alternative to https://github.com/SymbiFlow/prjxray/pull/1237

The primary difference is that it keeps all the sorting behaviour in the `sort_db.py` script.

The `sort` function now takes two functions which check if a list should be sorted or not. Any list which isn't **explicitly** marked as should be sorted or should be ordered will raise an error (which is why one function is not just the inverse of the other). This means the "hack" around two length lists and `tileconn.json` can be removed.

Fixes https://github.com/SymbiFlow/prjxray/issues/1236.