### PR TITLE
Fix segprint tool for new tileconn.json location

### DIFF
--- a/utils/segprint.py
+++ b/utils/segprint.py
@@ -419,9 +419,9 @@ def tile_segnames(tiles):
     return ret
 
 
-def load_tiles(db_root):
+def load_tiles(db_root, part):
     # TODO: Migrate to new tilegrid format via library.
-    with open("%s/tilegrid.json" % (db_root), "r") as f:
+    with open("%s/%s/tilegrid.json" % (db_root, part), "r") as f:
         tiles = json.load(f)
     return tiles
 
@@ -438,7 +438,7 @@ def run(
         bit_only=False,
         verbose=False):
     db = prjxraydb.Database(db_root, part)
-    tiles = load_tiles(db_root)
+    tiles = load_tiles(db_root, part)
     segments = mk_segments(tiles)
     bitdata = bitstream.load_bitdata2(open(bits_file, "r"))
 


### PR DESCRIPTION
Found this via trying to run `make install` in `minitests/picorv32-v`.

```
+ /home/tansell/github/SymbiFlow/prjxray/build/tools/bitread --part_file /home/tansell/github/SymbiFlow/prjxray/database/artix7/xc7a50tfgg484-1/part.yaml -F 0x00000000:0xffffffff -o design.bits -z -y design.bit
Bitstream size: 2298099 bytes
Config size: 574487 words
Number of configuration frames: 5408
DONE
++ fgrep CRITICAL vivado.log
+ test -z ''
+ python3 /home/tansell/github/SymbiFlow/prjxray/utils/segprint.py -z -D design.bits
Traceback (most recent call last):
  File "/home/tansell/github/SymbiFlow/prjxray/utils/segprint.py", line 520, in <module>
    main()
  File "/home/tansell/github/SymbiFlow/prjxray/utils/segprint.py", line 516, in main
    verbose=args.verbose)
  File "/home/tansell/github/SymbiFlow/prjxray/utils/segprint.py", line 441, in run
    tiles = load_tiles(db_root)
  File "/home/tansell/github/SymbiFlow/prjxray/utils/segprint.py", line 424, in load_tiles
    with open("%s/tilegrid.json" % (db_root), "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/tansell/github/SymbiFlow/prjxray/database/artix7/tilegrid.json'
make: *** [Makefile:2: all] Error 1
(env) tansell@tansell-glaptop:~/github/SymbiFlow/prjxray/minitests/picorv32-v$ ls -l /home/tansell/github/SymbiFlow/prjxray/database/artix7/tilegrid.json
/bin/ls: cannot access '/home/tansell/github/SymbiFlow/prjxray/database/artix7/tilegrid.json': No such file or directory
(env) tansell@tansell-glaptop:~/github/SymbiFlow/prjxray/minitests/picorv32-v$ ls -l /home/tansell/github/SymbiFlow/prjxray/database/artix7/xc7a50tfgg484-1/
package_pins.csv  part.json         part.yaml         tileconn.json     tilegrid.json     
```

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>