### PR TITLE
bram-sdp minitest: added minitest to check features of SDP brams

### DIFF
--- a/minitests/bram-sdp/Makefile
+++ b/minitests/bram-sdp/Makefile
@@ -1,0 +1,7 @@
+all:
+	mkdir -p build
+	cd build && bash ../runme.sh
+
+clean:
+	rm -rf build/
+

--- a/minitests/bram-sdp/runme.sh
+++ b/minitests/bram-sdp/runme.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+${XRAY_VIVADO} -mode batch -source ../runme.tcl
+${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
+test -z "$(fgrep CRITICAL vivado.log)"
+${XRAY_SEGPRINT} -z -D design.bits > design.txt
+${XRAY_BIT2FASM} design.bit > design.fasm
+

--- a/minitests/bram-sdp/runme.sh
+++ b/minitests/bram-sdp/runme.sh
@@ -5,5 +5,5 @@ ${XRAY_VIVADO} -mode batch -source ../runme.tcl
 ${XRAY_BITREAD} -F $XRAY_ROI_FRAMES -o design.bits -z -y design.bit
 test -z "$(fgrep CRITICAL vivado.log)"
 ${XRAY_SEGPRINT} -z -D design.bits > design.txt
-${XRAY_BIT2FASM} design.bit > design.fasm
+${XRAY_BIT2FASM} --verbose design.bit > design.fasm
 

--- a/minitests/bram-sdp/runme.tcl
+++ b/minitests/bram-sdp/runme.tcl
@@ -1,0 +1,16 @@
+create_project -force -part $::env(XRAY_PART) design design
+read_verilog ../top.v
+synth_design -top top -flatten_hierarchy none
+
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+place_design
+route_design
+
+set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
+set_property IS_ENABLED 0 [get_drc_checks {UCIO-1}]
+
+write_checkpoint -force design.dcp
+write_bitstream -force design.bit

--- a/minitests/bram-sdp/top.v
+++ b/minitests/bram-sdp/top.v
@@ -1,0 +1,126 @@
+module top (
+);
+
+  // Both RAMB18 in the same tile
+  (* KEEP, DONT_TOUCH, LOC="RAMB18_X0Y25" *)
+  RAMB18E1 #(
+    .RAM_MODE("SDP"),
+    .READ_WIDTH_A(36),
+    .READ_WIDTH_B(0),
+    .WRITE_MODE_A("READ_FIRST"),
+    .WRITE_MODE_B("READ_FIRST"),
+    .WRITE_WIDTH_A(0),
+    .WRITE_WIDTH_B(36)
+  ) RAMB18E1_BOTH_X1  (
+    .ENARDEN(1'b1),
+    .ENBWREN(1'b1),
+    .REGCEAREGCE(1'b1),
+    .REGCEB(1'b0),
+    .RSTRAMARSTRAM(1'b1),
+    .RSTRAMB(1'b1),
+    .RSTREGARSTREG(1'b1),
+    .RSTREGB(1'b1),
+    .WEA({1'b0}),
+    .WEBWE({1'b0})
+  );
+
+  (* KEEP, DONT_TOUCH, LOC="RAMB18_X0Y24" *)
+  RAMB18E1 #(
+    .RAM_MODE("SDP"),
+    .READ_WIDTH_A(36),
+    .READ_WIDTH_B(0),
+    .WRITE_MODE_A("READ_FIRST"),
+    .WRITE_MODE_B("READ_FIRST"),
+    .WRITE_WIDTH_A(0),
+    .WRITE_WIDTH_B(36)
+  ) RAMB18E1_BOTH_X0  (
+    .ENARDEN(1'b1),
+    .ENBWREN(1'b1),
+    .REGCEAREGCE(1'b1),
+    .REGCEB(1'b0),
+    .RSTRAMARSTRAM(1'b1),
+    .RSTRAMB(1'b1),
+    .RSTREGARSTREG(1'b1),
+    .RSTREGB(1'b1),
+    .WEA({1'b0}),
+    .WEBWE({1'b0})
+  );
+
+  // ---------------------------------------
+
+  // One RAMB18 in Y0
+  (* KEEP, DONT_TOUCH, LOC="RAMB18_X0Y22" *)
+  RAMB18E1 #(
+    .RAM_MODE("SDP"),
+    .READ_WIDTH_A(36),
+    .READ_WIDTH_B(0),
+    .WRITE_MODE_A("READ_FIRST"),
+    .WRITE_MODE_B("READ_FIRST"),
+    .WRITE_WIDTH_A(0),
+    .WRITE_WIDTH_B(36)
+  ) RAMB18E1_X0  (
+    .ENARDEN(1'b1),
+    .ENBWREN(1'b1),
+    .REGCEAREGCE(1'b1),
+    .REGCEB(1'b0),
+    .RSTRAMARSTRAM(1'b1),
+    .RSTRAMB(1'b1),
+    .RSTREGARSTREG(1'b1),
+    .RSTREGB(1'b1),
+    .WEA({1'b0}),
+    .WEBWE({1'b0})
+  );
+
+  // ---------------------------------------
+
+  // One RAMB18 in Y1
+  (* KEEP, DONT_TOUCH, LOC="RAMB18_X0Y21" *)
+  RAMB18E1 #(
+    .RAM_MODE("SDP"),
+    .READ_WIDTH_A(36),
+    .READ_WIDTH_B(0),
+    .WRITE_MODE_A("READ_FIRST"),
+    .WRITE_MODE_B("READ_FIRST"),
+    .WRITE_WIDTH_A(0),
+    .WRITE_WIDTH_B(36)
+  ) RAMB18E1_X1  (
+    .ENARDEN(1'b1),
+    .ENBWREN(1'b1),
+    .REGCEAREGCE(1'b1),
+    .REGCEB(1'b0),
+    .RSTRAMARSTRAM(1'b1),
+    .RSTRAMB(1'b1),
+    .RSTREGARSTREG(1'b1),
+    .RSTREGB(1'b1),
+    .WEA({1'b0}),
+    .WEBWE({1'b0})
+  );
+
+
+  // ---------------------------------------
+
+  // One RAMB36
+  (* KEEP, DONT_TOUCH, LOC="RAMB36_X0Y9" *)
+  RAMB36E1 #(
+    .RAM_MODE("SDP"),
+    .READ_WIDTH_A(72),
+    .READ_WIDTH_B(0),
+    .WRITE_MODE_A("READ_FIRST"),
+    .WRITE_MODE_B("READ_FIRST"),
+    .WRITE_WIDTH_A(0),
+    .WRITE_WIDTH_B(72)
+  ) RAMB36E1_X0  (
+    .ENARDEN(1'b1),
+    .ENBWREN(1'b1),
+    .REGCEAREGCE(1'b1),
+    .REGCEB(1'b0),
+    .RSTRAMARSTRAM(1'b1),
+    .RSTRAMB(1'b1),
+    .RSTREGARSTREG(1'b1),
+    .RSTREGB(1'b1),
+    .WEA({1'b0}),
+    .WEBWE({1'b0})
+  );
+
+
+endmodule


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to add a simple BRAMs minitest to verify feature relations among different RAMB18/36 packing locations.