### PR TITLE
grid: add prohibited sites to GridInfo

### DIFF
--- a/prjxray/grid.py
+++ b/prjxray/grid.py
@@ -68,6 +68,7 @@ class Grid(object):
             self.tileinfo[tile] = GridInfo(
                 bits=bits,
                 sites=tileinfo['sites'],
+                prohibited_sites=tileinfo['prohibited_sites'],
                 tile_type=tileinfo['type'],
                 pin_functions=tileinfo.get('pin_functions', {}),
                 clock_region=clock_region,

--- a/prjxray/grid_types.py
+++ b/prjxray/grid_types.py
@@ -13,7 +13,8 @@ class BlockType(enum.Enum):
 GridLoc = namedtuple('GridLoc', 'grid_x grid_y')
 ClockRegion = namedtuple('ClockRegion', 'name x y')
 GridInfo = namedtuple(
-    'GridInfo', 'bits sites prohibited_sites tile_type pin_functions clock_region')
+    'GridInfo',
+    'bits sites prohibited_sites tile_type pin_functions clock_region')
 BitAlias = namedtuple('BitAlias', 'tile_type start_offset sites')
 Bits = namedtuple('Bits', 'base_address frames offset words alias')
 BitsInfo = namedtuple('BitsInfo', 'block_type tile bits')

--- a/prjxray/grid_types.py
+++ b/prjxray/grid_types.py
@@ -13,7 +13,7 @@ class BlockType(enum.Enum):
 GridLoc = namedtuple('GridLoc', 'grid_x grid_y')
 ClockRegion = namedtuple('ClockRegion', 'name x y')
 GridInfo = namedtuple(
-    'GridInfo', 'bits sites tile_type pin_functions clock_region')
+    'GridInfo', 'bits sites prohibited_sites tile_type pin_functions clock_region')
 BitAlias = namedtuple('BitAlias', 'tile_type start_offset sites')
 Bits = namedtuple('Bits', 'base_address frames offset words alias')
 BitsInfo = namedtuple('BitsInfo', 'block_type tile bits')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,6 +50,7 @@ class TestUtil(TestCase):
                     "segment": "ASEGMENT",
                     "segment_type": "bram0_l",
                     "sites": sites,
+                    "prohibited_sites": [],
                     "type": "BRAM_INT_INTERFACE_L"
                 }
             }

--- a/utils/test_data/db/xc7/tilegrid.json
+++ b/utils/test_data/db/xc7/tilegrid.json
@@ -17,6 +17,7 @@
             "SLICE_X12Y102": "SLICEM",
             "SLICE_X13Y102": "SLICEL"
         },
+        "prohibited_sites": [],
         "type": "CLBLM_L"
     },
     "HCLK_L_X31Y130": {
@@ -34,6 +35,7 @@
         "segment": "SEG_HCLK_L_X31Y130",
         "segment_type": "hclk_l",
         "sites": {},
+        "prohibited_sites": [],
         "type": "HCLK_L"
     },
     "INT_L_X10Y102": {
@@ -53,6 +55,7 @@
         "sites": {
             "TIEOFF_X11Y102": "TIEOFF"
         },
+        "prohibited_sites": [],
         "type": "INT_L"
     },
     "LIOB33_SING_X0Y0": {
@@ -79,6 +82,7 @@
         "sites": {
             "IOB_X0Y0": "IOB33"
         },
+        "prohibited_sites": [],
         "type": "LIOB33_SING"
     },
     "LIOB33_X0Y1": {
@@ -100,6 +104,7 @@
             "IOB_X0Y1": "IOB33S",
             "IOB_X0Y2": "IOB33M"
         },
+        "prohibited_sites": [],
         "type": "LIOB33"
     },
     "LIOB33_X0Y3": {
@@ -121,6 +126,7 @@
             "IOB_X0Y3": "IOB33S",
             "IOB_X0Y4": "IOB33M"
         },
+        "prohibited_sites": [],
         "type": "LIOB33"
     },
     "RIOB33_SING_X43Y0": {
@@ -147,6 +153,7 @@
         "sites": {
             "IOB_X1Y0": "IOB33"
         },
+        "prohibited_sites": [],
         "type": "RIOB33_SING"
     },
     "RIOB33_X43Y1": {
@@ -168,6 +175,7 @@
             "IOB_X1Y1": "IOB33S",
             "IOB_X1Y2": "IOB33M"
         },
+        "prohibited_sites": [],
         "type": "RIOB33"
     },
     "RIOB33_X43Y3": {
@@ -189,6 +197,7 @@
             "IOB_X1Y3": "IOB33S",
             "IOB_X1Y4": "IOB33M"
         },
+        "prohibited_sites": [],
         "type": "RIOB33"
     },
     "HCLK_IOI3_X113Y26": {
@@ -214,6 +223,7 @@
             "BUFR_X1Y3": "BUFR",
             "IDELAYCTRL_X1Y0": "IDELAYCTRL"
         },
+        "prohibited_sites": [],
         "type": "HCLK_IOI3"
     },
     "HCLK_IOI3_X1Y26": {
@@ -239,6 +249,7 @@
             "BUFR_X0Y3": "BUFR",
             "IDELAYCTRL_X0Y0": "IDELAYCTRL"
         },
+        "prohibited_sites": [],
         "type": "HCLK_IOI3"
     }
 }


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the prohibited sites to the GridInfo