### PR TITLE
Add .gitattributes so GitHub gets the language right.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Settings to improve linguist data reporting (used by GitHub)
+*.v                     linguist-language=Verilog
+*.vh                    linguist-language=Verilog
+
+database/**             linguist-generated
+third_party/**          linguist-vendored
+
+# FIXME: All vendor files should be under third_party
+minitests/litex/**              linguist-vendored
+minitests/litex_litedram/**     linguist-vendored
+minitests/picorv32-v/**         linguist-vendored
+minitests/picorv32-y/**         linguist-vendored


### PR DESCRIPTION
GitHub uses https://github.com/github/linguist to do language stats.
linguist however mis-detects a bunch of things in this repo. It also
needs to be told about the "vendored" files in the repo.

This can be fixed by setting values via `.gitattributes` file which is
done here.

#### Before
```
74.90%  Coq
13.42%  Python
3.71%   C++
3.62%   Tcl
1.42%   Makefile
1.26%   Verilog
0.73%   JavaScript
0.62%   Shell
0.10%   HTML
0.08%   XSLT
0.07%   CMake
0.03%   Assembly
0.02%   Ruby
0.01%   Dockerfile
```

#### After
```
42.45%  Python
25.18%  Verilog
12.00%  C++
10.96%  Tcl
4.07%   Makefile
2.34%   JavaScript
1.99%   Shell
0.34%   HTML
0.26%   XSLT
0.22%   CMake
0.09%   Assembly
0.08%   Ruby
0.03%   Dockerfile
```

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>