### PR TITLE
Add xc7a35tfgg484-1 extra data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ db-extras-artix7-parts: $(addprefix db-part-only-,$(ARTIX_PARTS))
 db-extras-artix7-harness:
 	+XRAY_PIN_00=J13 XRAY_PIN_01=J14 XRAY_PIN_02=K15 XRAY_PIN_03=K16 \
 		XRAY_PART=xc7a35tftg256-1 XRAY_EQUIV_PART=xc7a50tfgg484-1 $(MAKE) -C fuzzers roi_only
+	+XRAY_PART=xc7a35tfgg484-1 XRAY_EQUIV_PART=xc7a50tfgg484-1 $(MAKE) -C fuzzers roi_only
 	+source settings/artix7_200t.sh && \
 		XRAY_PIN_00=V10 XRAY_PIN_01=W10 XRAY_PIN_02=Y11 XRAY_PIN_03=Y12 \
 		XRAY_PART=xc7a200tsbg484-1 XRAY_EQUIV_PART=xc7a200tffg1156-1 \


### PR DESCRIPTION
As discussed on IRC. I think this is all that's required; since it's the same package as the base part, the pins shouldn't have to be changed. Unfortunately I can't do the real-name signoff, so if that's really required even for mostly copy-pasted one-line additions, I guess someone else will have to commit it. The PR should be useful for CI either way.