### PR TITLE
SSTL15 features

### DIFF
--- a/fuzzers/030-iob/generate.py
+++ b/fuzzers/030-iob/generate.py
@@ -26,7 +26,7 @@ def drives_for_iostandard(iostandard):
         drives = [4, 8, 12, 16, 24]
     elif iostandard == 'LVCMOS12':
         drives = [4, 8, 12]
-    elif iostandard == 'SSTL135':
+    elif iostandard in ['SSTL135', 'SSTL15']:
         return ['_FIXED']
     else:
         drives = [4, 8, 12, 16]
@@ -34,8 +34,10 @@ def drives_for_iostandard(iostandard):
     return drives
 
 
-STEPDOWN_IOSTANDARDS = ['LVCMOS12', 'LVCMOS15', 'LVCMOS18', 'SSTL135']
-IBUF_LOW_PWR_SUPPORTED = ['SSTL135']
+STEPDOWN_IOSTANDARDS = [
+    'LVCMOS12', 'LVCMOS15', 'LVCMOS18', 'SSTL135', 'SSTL15'
+]
+IBUF_LOW_PWR_SUPPORTED = ['SSTL135', 'SSTL15']
 
 
 def main():
@@ -185,6 +187,7 @@ def main():
                     drive_opts.add(mk_drive_opt(opt, drive_opt))
 
             drive_opts.add(mk_drive_opt("SSTL135", None))
+            drive_opts.add(mk_drive_opt("SSTL15", None))
 
             segmaker.add_site_group_zero(
                 segmk, site, '', drive_opts, mk_drive_opt('LVCMOS25', '12'),

--- a/fuzzers/030-iob/process_rdb.py
+++ b/fuzzers/030-iob/process_rdb.py
@@ -66,7 +66,7 @@ def main():
     iostandard_lines = []
     with open(args.input_rdb) as f:
         for l in f:
-            if ('.SSTL135' in l or '.LVCMOS' in l
+            if ('.SSTL' in l or '.LVCMOS' in l
                     or '.LVTTL' in l) and 'IOB_' in l:
                 iostandard_lines.append(l)
             else:

--- a/fuzzers/030-iob/top.py
+++ b/fuzzers/030-iob/top.py
@@ -56,10 +56,12 @@ def run():
         'LVCMOS33',
         'LVTTL',
         'SSTL135',
+        'SSTL15',
     ]
 
     diff_map = {
         "SSTL135": ["DIFF_SSTL135"],
+        "SSTL15": ["DIFF_SSTL15"],
     }
 
     IN_TERM_ALLOWED = [
@@ -81,7 +83,7 @@ def run():
         drives = [4, 8, 12, 16, 24]
     elif iostandard in ['LVCMOS12']:
         drives = [4, 8, 12]
-    elif iostandard == 'SSTL135':
+    elif iostandard in ['SSTL135', 'SSTL15']:
         drives = None
     else:
         drives = [4, 8, 12, 16]
@@ -104,7 +106,7 @@ def run():
 
     params['iobanks'] = iobanks
 
-    if iostandard in ['SSTL135']:
+    if iostandard in ['SSTL135', 'SSTL15']:
         for iobank in iobanks:
             params['INTERNAL_VREF'][iobank] = random.choice(
                 (

--- a/minitests/iostandard/dump_iobs.tcl
+++ b/minitests/iostandard/dump_iobs.tcl
@@ -24,8 +24,8 @@ proc dump_iobs {file_name} {
     close $fp
 }
 
-create_project -force -in_memory -name dump_iobs -part $::env(VIVADO_PART)
+create_project -force -in_memory -name dump_iobs -part $::env(PART)
 set_property design_mode PinPlanning [current_fileset]
 open_io_design -name io_1
 
-dump_iobs "iobs-$::env(VIVADO_PART).csv"
+dump_iobs "iobs-$::env(PART).csv"

--- a/minitests/iostandard/features/Makefile
+++ b/minitests/iostandard/features/Makefile
@@ -1,5 +1,4 @@
-PART?=xc7a50tfgg484-1
-VIVADO_PART?=$(PART)
+PART?=${XRAY_PART}
 
 BIT2FASM_ARGS= --part "$(XRAY_DIR)/database/$(XRAY_DATABASE)/$(PART)" --verbose
 
@@ -33,20 +32,20 @@ clean:
 	@rm -rf features.csv
 	@rm -rf results.json
 	@rm -rf unknown_bits.jl
-	@rm -rf iobs-$(VIVADO_PART).csv
+	@rm -rf iobs-$(PART).csv
 
-iobs-$(VIVADO_PART).csv: ../dump_iobs.tcl
-	env VIVADO_PART=$(VIVADO_PART) $(XRAY_VIVADO) -mode batch -source ../dump_iobs.tcl -nojournal -log dump_iobs.log
+iobs-$(PART).csv: ../dump_iobs.tcl
+	env PART=$(PART) $(XRAY_VIVADO) -mode batch -source ../dump_iobs.tcl -nojournal -log dump_iobs.log
 
-designs.ok: iobs-$(VIVADO_PART).csv generate.py
-	env VIVADO_PART=$(VIVADO_PART) python3 ./generate.py
+designs.ok: iobs-$(PART).csv generate.py
+	env PART=$(PART) python3 ./generate.py
 	touch designs.ok
 
 designs: designs.ok
 
 %.bit: %.v designs.ok ../syn+par.tcl
 	mkdir -p build-$(basename $@)
-	cd build-$(basename $@) && env PROJECT_NAME=$(basename $@) VIVADO_PART=${VIVADO_PART} $(XRAY_VIVADO) -mode batch -source ../../syn+par.tcl -nojournal -log ../$@.log
+	cd build-$(basename $@) && env PROJECT_NAME=$(basename $@) PART=${PART} $(XRAY_VIVADO) -mode batch -source ../../syn+par.tcl -nojournal -log ../$@.log
 	rm -rf *.backup.log
 
 %.fasm: %.bit

--- a/minitests/iostandard/features/generate.py
+++ b/minitests/iostandard/features/generate.py
@@ -26,7 +26,6 @@ def load_iob_sites(file_name):
     for site_data in data:
         iob_sites[site_data["clock_region"]].append(site_data)
 
-    print(data)
     return iob_sites
 
 
@@ -40,6 +39,7 @@ IOBUF_NOT_ALLOWED = [
 
 DIFF_MAP = {
     'SSTL135': 'DIFF_SSTL135',
+    'SSTL15':  'DIFF_SSTL15',
 }
 
 
@@ -56,10 +56,10 @@ def gen_iosettings():
         'LVCMOS33',
         'LVTTL',
         'SSTL135',
+        'SSTL15',
 
         # Those are available but not currently fuzzed.
         #        'SSTL135_R',
-        #        'SSTL15',
         #        'SSTL15_R',
         #        'SSTL18_I',
         #        'SSTL18_II',
@@ -111,7 +111,7 @@ def run():
     """
 
     # Load IOB data
-    iob_sites = load_iob_sites("iobs-{}.csv".format(os.getenv("VIVADO_PART")))
+    iob_sites = load_iob_sites("iobs-{}.csv".format(os.getenv("PART")))
 
     # Generate IOB site to package pin map and *M site to *S site map.
     site_to_pkg_pin = {}
@@ -134,6 +134,8 @@ def run():
     iosettings_gen = gen_iosettings()
     design_index = 0
     while True:
+
+        print("Design #{}".format(design_index))
 
         num_inp = 0
         num_out = 0
@@ -194,7 +196,7 @@ def run():
                     "output": used_sites[2:4],
                     "inout": used_sites[4:5],
                 })
-            print(region, iosettings)
+            print("", region, iosettings)
 
         # No more
         if len(region_data) == 0:

--- a/minitests/iostandard/syn+par.tcl
+++ b/minitests/iostandard/syn+par.tcl
@@ -1,4 +1,4 @@
-create_project -force -name $env(PROJECT_NAME) -part $env(VIVADO_PART)
+create_project -force -name $env(PROJECT_NAME) -part $env(PART)
 
 set_property SEVERITY {Warning} [get_drc_checks NSTD-1]
 set_property SEVERITY {Warning} [get_drc_checks UCIO-1]

--- a/utils/fasm2frames.py
+++ b/utils/fasm2frames.py
@@ -186,7 +186,7 @@ def run(
         # unclear how to know which IOSTANDARD to use.
         missing_features = []
         for line in fasm.parse_fasm_string("""
-{tile}.{site}.LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135.IN_ONLY
+{tile}.{site}.LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.IN_ONLY
 {tile}.{site}.LVCMOS25_LVCMOS33_LVTTL.IN
 {tile}.{site}.PULLTYPE.PULLUP
 """.format(


### PR DESCRIPTION
This PR adds SSTL15 features to fuzzer 030. No new bits were found for that IO standard. Some features changed names though.

Apart from that, the IOSTANDARD minitest has been updated to also check SSTL15 and set INTERNAL_VREF wherever appropriate. The latter change eliminated missing bits that the test was reporting previously.