### PR TITLE
Add a third IOI, LIOI_X0Y9, for special handling.  Without this change,

### DIFF
--- a/settings/artix7_100t.sh
+++ b/settings/artix7_100t.sh
@@ -12,7 +12,7 @@ export XRAY_EXCLUDE_ROI_TILEGRID=""
 # (special handling for frame addresses of certain IOIs -- see the script for details).
 # This needs to be changed for any new device!
 # If you have a FASM mismatch or unknown bits in IOIs, CHECK THIS FIRST.
-export XRAY_IOI3_TILES="RIOI3_X57Y109 LIOI3_X0Y109"
+export XRAY_IOI3_TILES="LIOI3_X0Y9 LIOI3_X0Y109 RIOI3_X57Y109"
 
 # clock pin
 export XRAY_PIN_00="Y22"


### PR DESCRIPTION
This PR adds a third IOI, LIOI_X0Y9, for special handling on the 100T.  Without this change,
LIOI_X0Y9 has empty "bits" in tilegrid.json.  Note there is no RIOI at Y9,
since the bottom right region of the 100T is high speed serial IO.

I wasn't really thinking; I just assumed each device would have two such IOIs that needed special handling.   But the 100T has three it seems: LIOI_X0Y9, LIOI3_X0Y109, RIOI3_X57Y109

Signed-off-by: Tim Callahan <tcal@google.com>