### PR TITLE
Added support for xc7z020clg400-1 and added an openocd config file for pynq-z1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,10 @@ db-extras-kintex7-harness:
 db-extras-zynq7-parts: $(addprefix db-part-only-,$(ZYNQ_PARTS))
 
 db-extras-zynq7-harness:
-	@true
-
+	+source settings/zynq7.sh && \
+                XRAY_PIN_00=T9 XRAY_PIN_01=P14 XRAY_PIN_02=T14 XRAY_PIN_03=R18 \
+                XRAY_PART=xc7z020clg400-1 XRAY_EQUIV_PART=xc7z020clg484-1 \
+                $(MAKE) -C fuzzers roi_only
 db-check:
 	@true
 

--- a/utils/openocd/board-digilent-pynqz1.cfg
+++ b/utils/openocd/board-digilent-pynqz1.cfg
@@ -1,0 +1,60 @@
+
+#
+# PYNQ-Z1: Python Productivity for Zynq-7000 ARM/FPGA SoC
+#
+# https://reference.digilentinc.com/reference/programmable-logic/pynq-z1/start
+#
+
+# Device description changed from Digilent HS1 but is otherwise identical.
+interface ftdi
+transport select jtag
+ftdi_device_desc "Digilent Adept USB Device"
+ftdi_vid_pid 0x0403 0x6010
+
+# channel 1 does not have any functionality
+ftdi_channel 0
+
+# just TCK TDI TDO TMS, no reset
+ftdi_layout_init 0x0088 0x008b
+adapter_khz 20000
+reset_config none
+
+# Modified Zynq-7000 configuration
+set _CHIPNAME zynq
+set _TARGETNAME $_CHIPNAME.cpu
+
+jtag newtap zynq_pl bs -irlen 6 -ircapture 0x1 -irmask 0x03 \
+    -expected-id 0x23727093 \
+    -expected-id 0x13722093 \
+    -expected-id 0x03727093 \
+    -expected-id 0x03736093
+
+jtag newtap $_CHIPNAME dap -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id 0x4ba00477
+
+target create ${_TARGETNAME}0 cortex_a -chain-position $_CHIPNAME.dap \
+    -coreid 0 -dbgbase 0x80090000
+target create ${_TARGETNAME}1 cortex_a -chain-position $_CHIPNAME.dap \
+    -coreid 1 -dbgbase 0x80092000
+target smp ${_TARGETNAME}0 ${_TARGETNAME}1
+
+${_TARGETNAME}0 configure -event reset-assert-post "cortex_a dbginit"
+${_TARGETNAME}1 configure -event reset-assert-post "cortex_a dbginit"
+
+pld device virtex2 zynq_pl.bs 1
+
+set XC7_JSHUTDOWN 0x0d
+set XC7_JPROGRAM 0x0b
+set XC7_JSTART 0x0c
+set XC7_BYPASS 0x3f
+
+proc zynqpl_program {tap} {
+	global XC7_JSHUTDOWN XC7_JPROGRAM XC7_JSTART XC7_BYPASS
+	irscan $tap $XC7_JSHUTDOWN
+	irscan $tap $XC7_JPROGRAM
+	runtest 60000
+	#JSTART prevents this from working...
+	#irscan $tap $XC7_JSTART
+	runtest 2000
+	irscan $tap $XC7_BYPASS
+	runtest 2000
+}


### PR DESCRIPTION
Added generation of the xc7z020clg400-1, which is required for using the pynq-z1 board.  Also, created a working openocd configuration for the pynq-z1.