### PR TITLE
Add reset config to allow upload to PS region

### DIFF
--- a/utils/openocd/board-digilent-pynqz1.cfg
+++ b/utils/openocd/board-digilent-pynqz1.cfg
@@ -58,3 +58,14 @@ proc zynqpl_program {tap} {
 	irscan $tap $XC7_BYPASS
 	runtest 2000
 }
+
+proc zynqpl_reset_release {target} {
+   # Unlock SLCR
+    $target mww 0xf8000008 0xdf0d
+    # Enable level shifters, both PL-PS and PS-PL
+    $target mww 0xf8000900 0xF
+    # Release FPGA reset
+    $target mww 0xf8000240 0x0
+    # Lock SLCR
+    $target mww 0xf8000004 0x767b
+}


### PR DESCRIPTION
Signed-off-by: Andrew Butt <butta@seas.upenn.edu>

Usage example: openocd -f board-digilent-pynqz1.cfg -c "init; halt; pld load 0 top.bit; zynqpl_reset_release zynq.cpu0; halt; targets zynq.cpu0; load_image blink.elf; resume 0; exit" 

Loads the bitstream to the pl, releases the pl for interfacing with cpu0, and then loads the .elf file.  Currently this flashes over the FSBL bootloader because the blink.elf file I used is intended to run without a bootloader, but it should also be possible to upload with a bootloader with relatively few changes to the command.