### PR TITLE
setup: temporarily add `utils` to the python pkg to enable fasm2frames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/SymbiFlow/prjxray",
-    packages=['prjxray'],
+    packages=['prjxray', 'utils'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: ISC License",


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>