### PR TITLE
Change main fuzzed device to A100T

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ $(foreach DB,$(DATABASES),$(eval $(call database,$(DB))))
 # Targets related to Project X-Ray parts
 # --------------------------------------
 
-ARTIX_PARTS=artix7_200t artix7_100t
+ARTIX_PARTS=artix7_50t artix7_200t
 ZYNQ_PARTS=zynq7010
 KINTEX_PARTS=kintex70t
 
@@ -201,11 +201,11 @@ db-extras-artix7-parts: $(addprefix db-part-only-,$(ARTIX_PARTS))
 #    override the XRAY_PIN_0X setting below to pick a pin that *is* bonded.
 db-extras-artix7-harness:
 	+source settings/artix7.sh && \
+		XRAY_PIN_00=N15 XRAY_PART=xc7a100tcsg324-1 XRAY_EQUIV_PART=xc7a100tfgg676-1 \
+		$(MAKE) -C fuzzers roi_only
+	+source settings/artix7_50t.sh && \
 		XRAY_PIN_00=J13 XRAY_PIN_01=J14 XRAY_PIN_02=K15 XRAY_PIN_03=K16 \
 		XRAY_PART=xc7a35tftg256-1 XRAY_EQUIV_PART=xc7a50tfgg484-1 \
-		$(MAKE) -C fuzzers roi_only
-	+source settings/artix7_100t.sh && \
-		XRAY_PIN_00=N15 XRAY_PART=xc7a100tcsg324-1 XRAY_EQUIV_PART=xc7a100tfgg676-1 \
 		$(MAKE) -C fuzzers roi_only
 	+source settings/artix7_200t.sh && \
 		XRAY_PIN_00=V10 XRAY_PIN_01=W10 XRAY_PIN_02=Y11 XRAY_PIN_03=Y12 \

--- a/fuzzers/032-cmt-pll/generate.py
+++ b/fuzzers/032-cmt-pll/generate.py
@@ -98,12 +98,12 @@ def bus_tags(segmk, ps, site):
     segmk.add_site_tag(
             site, 'COMPENSATION.ZHOLD_NO_CLKIN_BUF_NO_TOP', match and \
                     not bufg_on_clkin and \
-                    site != "PLLE2_ADV_X0Y2"
+                    site != "PLLE2_ADV_X0Y3" and site != "PLLE2_ADV_X0Y0"
                     )
     segmk.add_site_tag(
             site, 'COMP.ZHOLD_NO_CLKIN_BUF_TOP', match and \
                     not bufg_on_clkin and \
-                    site == "PLLE2_ADV_X0Y2"
+                    (site == "PLLE2_ADV_X0Y3" or site == "PLLE2_ADV_X0Y0")
                     )
 
     # No INTERNAL as it has conflicting bits

--- a/minitests/roi_harness/arty-common.sh
+++ b/minitests/roi_harness/arty-common.sh
@@ -6,6 +6,9 @@
 #
 # SPDX-License-Identifier: ISC
 # XC7A35TICSG324-1L
+
+source $(dirname ${BASH_SOURCE[0]})/../../settings/artix7_50t.sh
+
 export XRAY_PART=xc7a35tcsg324-1
 export XRAY_EQUIV_PART=xc7a50tfgg484-1
 

--- a/minitests/roi_harness/basys3-common.sh
+++ b/minitests/roi_harness/basys3-common.sh
@@ -6,6 +6,9 @@
 #
 # SPDX-License-Identifier: ISC
 # XC7A35T-1CPG236C
+
+source $(dirname ${BASH_SOURCE[0]})/../../settings/artix7_50t.sh
+
 export XRAY_PART=xc7a35tcpg236-1
 export XRAY_EQUIV_PART=xc7a50tfgg484-1
 if [ -z "$XRAY_PINCFG" ]; then

--- a/settings/artix7.sh
+++ b/settings/artix7.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (C) 2017-2020  The Project X-Ray Authors.
 #
 # Use of this source code is governed by a ISC-style
@@ -6,12 +7,12 @@
 #
 # SPDX-License-Identifier: ISC
 export XRAY_DATABASE="artix7"
-export XRAY_PART="xc7a50tfgg484-1"
+export XRAY_PART="xc7a100tfgg676-1"
 export XRAY_ROI_FRAMES="0x00000000:0xffffffff"
 
 # All CLB's in part, all BRAM's in part, all DSP's in part.
 # tcl queries IOB => don't bother adding
-export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X65Y99 SLICE_X0Y100:SLICE_X57Y149 RAMB18_X0Y0:RAMB18_X1Y59 RAMB36_X0Y0:RAMB36_X1Y29 RAMB18_X2Y0:RAMB18_X2Y39 RAMB36_X2Y0:RAMB36_X2Y19 DSP48_X0Y0:DSP48_X1Y59"
+export XRAY_ROI_TILEGRID="RAMB36_X0Y0:RAMB36_X3Y39 RAMB18_X0Y0:RAMB18_X3Y79 DSP48_X0Y0:DSP48_X2Y79 IOB_X0Y0:IOB_X1Y199 SLICE_X0Y0:SLICE_X89Y199"
 
 export XRAY_EXCLUDE_ROI_TILEGRID=""
 
@@ -19,25 +20,26 @@ export XRAY_EXCLUDE_ROI_TILEGRID=""
 # (special handling for frame addresses of certain IOIs -- see the script for details).
 # This needs to be changed for any new device!
 # If you have a FASM mismatch or unknown bits in IOIs, CHECK THIS FIRST.
-export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X43Y9"
+export XRAY_IOI3_TILES="LIOI3_X0Y9 LIOI3_X0Y109 RIOI3_X57Y109"
 
 # These settings must remain in sync
-export XRAY_ROI="SLICE_X0Y100:SLICE_X35Y149 RAMB18_X0Y40:RAMB18_X0Y59 RAMB36_X0Y20:RAMB36_X0Y29 DSP48_X0Y40:DSP48_X0Y59 IOB_X0Y100:IOB_X0Y149"
+export XRAY_ROI="SLICE_X0Y150:SLICE_X51Y199 RAMB18_X0Y60:RAMB18_X0Y79 RAMB36_X0Y30:RAMB36_X0Y39 DSP48_X0Y60:DSP48_X0Y79 IOB_X0Y150:IOB_X0Y199"
 # Most of CMT X0Y2.
-export XRAY_ROI_GRID_X1="10"
-export XRAY_ROI_GRID_X2="58"
+export XRAY_ROI_GRID_X1="0"
+export XRAY_ROI_GRID_X2="77"
 # Include VBRK / VTERM
 export XRAY_ROI_GRID_Y1="0"
 export XRAY_ROI_GRID_Y2="51"
 
 # clock pin
-export XRAY_PIN_00="E22"
+export XRAY_PIN_00="Y22"
 # data pins
-export XRAY_PIN_01="D22"
-export XRAY_PIN_02="E21"
-export XRAY_PIN_03="D21"
-export XRAY_PIN_04="G21"
-export XRAY_PIN_05="G22"
-export XRAY_PIN_06="F21"
+export XRAY_PIN_01="U17"
+export XRAY_PIN_02="V17"
+export XRAY_PIN_03="V16"
+export XRAY_PIN_04="V14"
+export XRAY_PIN_05="U14"
+export XRAY_PIN_06="U16"
 
 source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
+

--- a/settings/artix7_50t.sh
+++ b/settings/artix7_50t.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (C) 2017-2020  The Project X-Ray Authors.
 #
 # Use of this source code is governed by a ISC-style
@@ -7,12 +6,12 @@
 #
 # SPDX-License-Identifier: ISC
 export XRAY_DATABASE="artix7"
-export XRAY_PART="xc7a100tfgg676-1"
+export XRAY_PART="xc7a50tfgg484-1"
 export XRAY_ROI_FRAMES="0x00000000:0xffffffff"
 
 # All CLB's in part, all BRAM's in part, all DSP's in part.
 # tcl queries IOB => don't bother adding
-export XRAY_ROI_TILEGRID="RAMB36_X0Y0:RAMB36_X3Y39 RAMB18_X0Y0:RAMB18_X3Y79 DSP48_X0Y0:DSP48_X2Y79 IOB_X0Y0:IOB_X1Y199 SLICE_X0Y0:SLICE_X89Y199"
+export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X65Y99 SLICE_X0Y100:SLICE_X57Y149 RAMB18_X0Y0:RAMB18_X1Y59 RAMB36_X0Y0:RAMB36_X1Y29 RAMB18_X2Y0:RAMB18_X2Y39 RAMB36_X2Y0:RAMB36_X2Y19 DSP48_X0Y0:DSP48_X1Y59"
 
 export XRAY_EXCLUDE_ROI_TILEGRID=""
 
@@ -20,17 +19,25 @@ export XRAY_EXCLUDE_ROI_TILEGRID=""
 # (special handling for frame addresses of certain IOIs -- see the script for details).
 # This needs to be changed for any new device!
 # If you have a FASM mismatch or unknown bits in IOIs, CHECK THIS FIRST.
-export XRAY_IOI3_TILES="LIOI3_X0Y9 LIOI3_X0Y109 RIOI3_X57Y109"
+export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X43Y9"
+
+# These settings must remain in sync
+export XRAY_ROI="SLICE_X0Y100:SLICE_X35Y149 RAMB18_X0Y40:RAMB18_X0Y59 RAMB36_X0Y20:RAMB36_X0Y29 DSP48_X0Y40:DSP48_X0Y59 IOB_X0Y100:IOB_X0Y149"
+# Most of CMT X0Y2.
+export XRAY_ROI_GRID_X1="10"
+export XRAY_ROI_GRID_X2="58"
+# Include VBRK / VTERM
+export XRAY_ROI_GRID_Y1="0"
+export XRAY_ROI_GRID_Y2="51"
 
 # clock pin
-export XRAY_PIN_00="Y22"
+export XRAY_PIN_00="E22"
 # data pins
-export XRAY_PIN_01="U17"
-export XRAY_PIN_02="V17"
-export XRAY_PIN_03="V16"
-export XRAY_PIN_04="V14"
-export XRAY_PIN_05="U14"
-export XRAY_PIN_06="U16"
+export XRAY_PIN_01="D22"
+export XRAY_PIN_02="E21"
+export XRAY_PIN_03="D21"
+export XRAY_PIN_04="G21"
+export XRAY_PIN_05="G22"
+export XRAY_PIN_06="F21"
 
 source $(dirname ${BASH_SOURCE[0]})/../utils/environment.sh
-


### PR DESCRIPTION
This PR changes the main fuzzed device from A50T to A100T, which should result in new fuzzed bits.
The new bits should be related to additional device components, absent in A50T fabric.

Resolves https://github.com/SymbiFlow/prjxray/issues/1382