### PR TITLE
Add overlay.py to allow for overlay architecture generation

### DIFF
--- a/prjxray/overlay.py
+++ b/prjxray/overlay.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 class Overlay(object):
     """ Object that represents an overlay.
 
@@ -5,8 +15,8 @@ class Overlay(object):
 
     """
 
-    def __init__(self, db, region_dict):
-        self.grid = db.grid()
+    def __init__(self, grid, region_dict):
+        self.grid = grid
         self.region_dict = region_dict
 
     def tile_in_roi(self, grid_loc):
@@ -18,43 +28,3 @@ class Overlay(object):
             if x1 <= x and x <= x2 and y1 <= y and y <= y2:
                 return False
         return True
-
-    def gen_tiles(self, tile_types=None):
-        ''' Yield tile names within overlay.
-
-        tile_types: list of tile types to keep, or None for all
-        '''
-
-        for tile_name in self.grid.tiles():
-            loc = self.grid.loc_of_tilename(tile_name)
-
-            if not self.tile_in_roi(loc):
-                continue
-
-            gridinfo = self.grid.gridinfo_at_loc(loc)
-
-            if tile_types is not None and gridinfo.tile_type not in tile_types:
-                continue
-
-            yield tile_name
-
-    def gen_sites(self, site_types=None):
-        ''' Yield (tile_name, site_name, site_type) within overlay.
-
-        site_types: list of site types to keep, or None for all
-
-        '''
-
-        for tile_name in self.grid.tiles():
-            loc = self.grid.loc_of_tilename(tile_name)
-
-            if not self.tile_in_roi(loc):
-                continue
-
-            gridinfo = self.grid.gridinfo_at_loc(loc)
-
-            for site_name, site_type in gridinfo.sites.items():
-                if site_types is not None and site_type not in site_types:
-                    continue
-
-                yield (tile_name, site_name, site_type)

--- a/prjxray/overlay.py
+++ b/prjxray/overlay.py
@@ -1,0 +1,60 @@
+class Overlay(object):
+    """ Object that represents an overlay.
+
+    Can be used to iterate over tiles and sites not inside a partition region.
+
+    """
+
+    def __init__(self, db, region_dict):
+        self.grid = db.grid()
+        self.region_dict = region_dict
+
+    def tile_in_roi(self, grid_loc):
+        """ Returns true if grid_loc (GridLoc tuple) is within the overlay. """
+        x = grid_loc.grid_x
+        y = grid_loc.grid_y
+        for _, bounds in self.region_dict.items():
+            x1, x2, y1, y2 = bounds
+            if x1 <= x and x <= x2 and y1 <= y and y <= y2:
+                return False
+        return True
+
+    def gen_tiles(self, tile_types=None):
+        ''' Yield tile names within overlay.
+
+        tile_types: list of tile types to keep, or None for all
+        '''
+
+        for tile_name in self.grid.tiles():
+            loc = self.grid.loc_of_tilename(tile_name)
+
+            if not self.tile_in_roi(loc):
+                continue
+
+            gridinfo = self.grid.gridinfo_at_loc(loc)
+
+            if tile_types is not None and gridinfo.tile_type not in tile_types:
+                continue
+
+            yield tile_name
+
+    def gen_sites(self, site_types=None):
+        ''' Yield (tile_name, site_name, site_type) within overlay.
+
+        site_types: list of site types to keep, or None for all
+
+        '''
+
+        for tile_name in self.grid.tiles():
+            loc = self.grid.loc_of_tilename(tile_name)
+
+            if not self.tile_in_roi(loc):
+                continue
+
+            gridinfo = self.grid.gridinfo_at_loc(loc)
+
+            for site_name, site_type in gridinfo.sites.items():
+                if site_types is not None and site_type not in site_types:
+                    continue
+
+                yield (tile_name, site_name, site_type)

--- a/prjxray/overlay.py
+++ b/prjxray/overlay.py
@@ -15,8 +15,7 @@ class Overlay(object):
 
     """
 
-    def __init__(self, grid, region_dict):
-        self.grid = grid
+    def __init__(self, region_dict):
         self.region_dict = region_dict
 
     def tile_in_roi(self, grid_loc):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,9 +22,9 @@ environ['XRAY_DATABASE_ROOT'] = '.'
 environ['XRAY_PART'] = './'
 
 from prjxray.util import get_roi, get_db_root
-from prjxray.db import Database
 from prjxray.overlay import Overlay
 from prjxray.grid_types import GridLoc
+
 
 @contextmanager
 def setup_database(contents):
@@ -72,16 +72,16 @@ class TestUtil(TestCase):
                 list(get_roi().gen_sites()), [('ATILE', 'FOO', 'BAR')])
 
     def test_in_roi_overlay(self):
-        db = Database(get_db_root(), './database/artix7/xc7a50tfgg484-1')
         region_dict = {}
         region_dict['pr1'] = (10, 58, 0, 51)
         region_dict['pr2'] = (10, 58, 52, 103)
-        overlay = Overlay(db.grid(), region_dict)
+        overlay = Overlay(region_dict)
         self.assertFalse(overlay.tile_in_roi(GridLoc(18, 50)))
         self.assertFalse(overlay.tile_in_roi(GridLoc(18, 84)))
         self.assertTrue(overlay.tile_in_roi(GridLoc(8, 50)))
         self.assertTrue(overlay.tile_in_roi(GridLoc(18, 112)))
         self.assertTrue(overlay.tile_in_roi(GridLoc(80, 40)))
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,8 +21,10 @@ from unittest import TestCase, main
 environ['XRAY_DATABASE_ROOT'] = '.'
 environ['XRAY_PART'] = './'
 
-from prjxray.util import get_roi
-
+from prjxray.util import get_roi, get_db_root
+from prjxray.db import Database
+from prjxray.overlay import Overlay
+from prjxray.grid_types import GridLoc
 
 @contextmanager
 def setup_database(contents):
@@ -69,6 +71,17 @@ class TestUtil(TestCase):
             self.assertListEqual(
                 list(get_roi().gen_sites()), [('ATILE', 'FOO', 'BAR')])
 
+    def test_in_roi_overlay(self):
+        db = Database(get_db_root(), './database/artix7/xc7a50tfgg484-1')
+        region_dict = {}
+        region_dict['pr1'] = (10, 58, 0, 51)
+        region_dict['pr2'] = (10, 58, 52, 103)
+        overlay = Overlay(db.grid(), region_dict)
+        self.assertFalse(overlay.tile_in_roi(GridLoc(18, 50)))
+        self.assertFalse(overlay.tile_in_roi(GridLoc(18, 84)))
+        self.assertTrue(overlay.tile_in_roi(GridLoc(8, 50)))
+        self.assertTrue(overlay.tile_in_roi(GridLoc(18, 112)))
+        self.assertTrue(overlay.tile_in_roi(GridLoc(80, 40)))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Signed-off-by: Andrew Butt <butta@seas.upenn.edu>

Essentially an inverse roi.  Can accommodate cutting out multiple roi like regions.  Testing with symbiflow-arch-defs overlay generation and working.