### PR TITLE
Fix links generation for markdown-code-symlinks

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -69,5 +69,5 @@ links: fuzzers-links minitests-links
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile links
+%: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ import recommonmark
 #
 import os
 import sys
+import subprocess
+
 sys.path.insert(0, os.path.abspath('.'))
 from markdown_code_symlinks import LinkParser, MarkdownSymlinksDomain
 
@@ -86,7 +88,6 @@ if not on_rtd:
 else:
     docs_dir = os.path.abspath(os.path.dirname(__file__))
     print("Docs dir is:", docs_dir)
-    import subprocess
     subprocess.call('git fetch origin --unshallow', cwd=docs_dir, shell=True)
     subprocess.check_call('git fetch origin --tags', cwd=docs_dir, shell=True)
     subprocess.check_call('make links', cwd=docs_dir, shell=True)
@@ -268,6 +269,9 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 
 def setup(app):
+    # Generate links for markdown-code-symlinks
+    subprocess.check_call("make links", shell=True)
+
     github_code_repo = 'https://github.com/SymbiFlow/prjxray/'
     github_code_branch = 'blob/master/'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ from markdown_code_symlinks import LinkParser, MarkdownSymlinksDomain
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '3.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,8 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
-    'sphinx_markdown_tables'
+    'sphinx_markdown_tables',
+    'recommonmark'
 ]
 # yapf: enable
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,7 @@
 sphinx_materialdesign_theme
 
 docutils
-# Disabling direct sphinx because of https://github.com/pypa/pip/issues/9031
-# sphinx
+sphinx>=3.0
 sphinx-autobuild
 
 breathe


### PR DESCRIPTION
This PR fixes the missing symbolic links generation during building the Sphinx documentation
Resolves https://github.com/SymbiFlow/prjxray/issues/1504

https://github.com/SymbiFlow/prjxray/pull/1513 should be merged first.