### PR TITLE
Fixes get_node_for_wire by initializing self.node

### DIFF
--- a/prjxray/node_model.py
+++ b/prjxray/node_model.py
@@ -45,7 +45,7 @@ class NodeModel():
 
         self.nodes = None
 
-        self.wire_to_node_map = {}
+        self.wire_to_node_map = None
 
         if progressbar is None:
             self.progressbar = lambda x: x
@@ -143,6 +143,8 @@ class NodeModel():
         return self.nodes[tile, wire]
 
     def _build_wire_to_node_map(self):
+        self.wire_to_node_map = {}
+
         if self.nodes is None:
             self._build_nodes()
 
@@ -153,7 +155,7 @@ class NodeModel():
 
     def get_node_for_wire(self, tile, wire):
         """ Get node for specified tile and wire. """
-        if not self.wire_to_node_map:
+        if self.wire_to_node_map is None:
             self._build_wire_to_node_map()
 
         return self.wire_to_node_map[tile, wire]

--- a/prjxray/node_model.py
+++ b/prjxray/node_model.py
@@ -45,7 +45,7 @@ class NodeModel():
 
         self.nodes = None
 
-        self.wire_to_node_map = None
+        self.wire_to_node_map = {}
 
         if progressbar is None:
             self.progressbar = lambda x: x
@@ -143,6 +143,9 @@ class NodeModel():
         return self.nodes[tile, wire]
 
     def _build_wire_to_node_map(self):
+        if self.nodes is None:
+            self._build_nodes()
+
         for node, wires in self.nodes.items():
             for tile_wire in wires:
                 assert tile_wire not in self.wire_to_node_map
@@ -150,7 +153,7 @@ class NodeModel():
 
     def get_node_for_wire(self, tile, wire):
         """ Get node for specified tile and wire. """
-        if self.wire_to_node_map is None:
+        if not self.wire_to_node_map:
             self._build_wire_to_node_map()
 
         return self.wire_to_node_map[tile, wire]


### PR DESCRIPTION
The method `get_node_for_wire` fails in `node_model.py` when called for the first time and errors out with:
```
AttributeError: 'NoneType' object has no attribute 'items'
```
Example usage:
```
db = prjxray.db.Database(args.db_root, args.part)
node_model = db.node_model(progressbar_utils.progressbar)
test = node_model.get_node_for_wire('BRAM_L_X4Y0','BRAM_EE4B0_4')
```

This patch fixes the bug by calling `self._build_nodes()` when `self.nodes` is `None`. Moreover, the initialization of `self.wire_to_node_map` is changed to an empty dictionary, otherwise `assert tile_wire not in self.wire_to_node_map` fails with:
```
TypeError: argument of type 'NoneType' is not iterable
```