### PR TITLE
disassembler: sort remaining unknown bits

### DIFF
--- a/prjxray/fasm_disassembler.py
+++ b/prjxray/fasm_disassembler.py
@@ -149,7 +149,7 @@ class FasmDisassembler(object):
                         len(remaining_bits),
                     ))
 
-                for bit in remaining_bits:
+                for bit in sorted(remaining_bits):
                     frame_offset = frame % bitstream.FRAME_ALIGNMENT
                     aligned_frame = frame - frame_offset
                     wordidx = bit // bitstream.WORD_SIZE_BITS


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

To get a better understanding on the differing unknown bits from two different bitstreams it is helpful to have all the missing ones sorted.

It happens that, two bitstreams that have many unknown bits and differ only in one of these unkown bits, have a completely unsorted output when using the `--verbose` option, making it hard to track where the differences are.