### PR TITLE
gtp_common: add to tilegrid

### DIFF
--- a/fuzzers/005-tilegrid/Makefile
+++ b/fuzzers/005-tilegrid/Makefile
@@ -33,6 +33,7 @@ GENERATE_FULL_ARGS=
 ifeq (${XRAY_DATABASE}, artix7)
 # Artix7 only
 TILEGRID_TDB_DEPENDENCIES += pcie/$(BUILD_FOLDER)/segbits_tilegrid.tdb
+TILEGRID_TDB_DEPENDENCIES += gtp_common/$(BUILD_FOLDER)/segbits_tilegrid.tdb
 endif
 
 ifeq (${XRAY_DATABASE}, zynq7)
@@ -139,6 +140,9 @@ hclk_ioi/$(BUILD_FOLDER)/segbits_tilegrid.tdb: ${BASICDB_TILEGRID}
 pcie/$(BUILD_FOLDER)/segbits_tilegrid.tdb: ${BASICDB_TILEGRID}
 	cd pcie && $(MAKE)
 
+gtp_common/$(BUILD_FOLDER)/segbits_tilegrid.tdb: ${BASICDB_TILEGRID}
+	cd gtp_common && $(MAKE)
+
 $(BUILD_FOLDER)/tilegrid_tdb.json: add_tdb.py $(TILEGRID_TDB_DEPENDENCIES)
 	python3 add_tdb.py \
 		--fn-in ${BASICDB_TILEGRID} \
@@ -180,6 +184,7 @@ clean:
 	cd hclk_cmt && $(MAKE) clean
 	cd hclk_ioi && $(MAKE) clean
 	cd pcie && $(MAKE) clean
+	cd gtp_common && $(MAKE) clean
 
 .PHONY: database pushdb clean run
 

--- a/fuzzers/005-tilegrid/Makefile
+++ b/fuzzers/005-tilegrid/Makefile
@@ -5,6 +5,7 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
+
 FUZDIR=$(shell pwd)
 BUILD_FOLDER=build_${XRAY_PART}
 BUILD_DIR=$(FUZDIR)/$(BUILD_FOLDER)
@@ -185,5 +186,33 @@ clean:
 	cd pcie && $(MAKE) clean
 	cd gtp_common && $(MAKE) clean
 
-.PHONY: database pushdb clean run
+clean_all:
+	rm -rf build_* run.*.ok
+	cd clb && $(MAKE) clean_all
+	cd clb_int && $(MAKE) clean_all
+	cd cfg && $(MAKE) clean_all
+	cd iob && $(MAKE) clean_all
+	cd iob_int && $(MAKE) clean_all
+	cd ioi && $(MAKE) clean_all
+	cd mmcm && $(MAKE) clean_all
+	cd pll && $(MAKE) clean_all
+	cd ps7_int && $(MAKE) clean_all
+	cd bram && $(MAKE) clean_all
+	cd bram_block && $(MAKE) clean_all
+	cd bram_int && $(MAKE) clean_all
+	cd dsp && $(MAKE) clean_all
+	cd dsp_int && $(MAKE) clean_all
+	cd fifo_int && $(MAKE) clean_all
+	cd monitor && $(MAKE) clean_all
+	cd monitor_int && $(MAKE) clean_all
+	cd cfg_int && $(MAKE) clean_all
+	cd orphan_int_column && $(MAKE) clean_all
+	cd clk_hrow && $(MAKE) clean_all
+	cd clk_bufg && $(MAKE) clean_all
+	cd hclk_cmt && $(MAKE) clean_all
+	cd hclk_ioi && $(MAKE) clean_all
+	cd pcie && $(MAKE) clean_all
+	cd gtp_common && $(MAKE) clean_all
+
+.PHONY: database pushdb clean clean_all run
 

--- a/fuzzers/005-tilegrid/Makefile
+++ b/fuzzers/005-tilegrid/Makefile
@@ -152,14 +152,13 @@ $(BUILD_FOLDER)/tilegrid.json: generate_full.py $(BUILD_FOLDER)/tilegrid_tdb.jso
 	cd $(BUILD_FOLDER) && python3 ${FUZDIR}/generate_full.py \
         --json-in tilegrid_tdb.json --json-out ${BUILD_DIR}/tilegrid.json
 run:
-	find -name $(BUILD_FOLDER) -exec rm -rf {} \;
-	find -name run.${XRAY_PART}.ok -delete
+	$(MAKE) clean
 	$(MAKE) database
 	$(MAKE) pushdb
 	touch run.${XRAY_PART}.ok
 
 clean:
-	rm -rf build_* run.*.ok
+	rm -rf $(BUILD_FOLDER) run.${XRAY_PART}.ok
 	cd clb && $(MAKE) clean
 	cd clb_int && $(MAKE) clean
 	cd cfg && $(MAKE) clean

--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -102,6 +102,7 @@ def run(fn_in, fn_out, verbose=False):
         ("hclk_cmt", 30, 10),
         ("hclk_ioi", 42, 1),
         ("pcie", 36, 101),
+        ("gtp_common", 42, 101),
         ("clb_int", int_frames, int_words),
         ("iob_int", int_frames, int_words),
         ("bram_int", int_frames, int_words),

--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -56,7 +56,13 @@ def load_db(fn):
 
         tparts = tagstr.split('.')
         tile = tparts[0]
+
         for part in tparts[1:]:
+            # Auto align the frame address to the next lowest multiple of 0x80.
+            if part == 'AUTO_FRAME':
+                frame -= (frame % 0x80)
+                continue
+
             k, v = part.split(':')
             if k == "DFRAME":
                 frame -= int(v, 16)

--- a/fuzzers/005-tilegrid/fuzzaddr/common.mk
+++ b/fuzzers/005-tilegrid/fuzzaddr/common.mk
@@ -16,5 +16,8 @@ $(SPECIMENS_OK):
 clean:
 	rm -rf $(BUILD_DIR)
 
+clean_all:
+	rm -rf build_*
+
 .PHONY: database clean
 

--- a/fuzzers/005-tilegrid/fuzzaddr/common.mk
+++ b/fuzzers/005-tilegrid/fuzzaddr/common.mk
@@ -14,7 +14,7 @@ $(SPECIMENS_OK):
 	touch $@
 
 clean:
-	rm -rf build_*
+	rm -rf $(BUILD_DIR)
 
 .PHONY: database clean
 

--- a/fuzzers/005-tilegrid/fuzzaddr/generate.py
+++ b/fuzzers/005-tilegrid/fuzzaddr/generate.py
@@ -18,6 +18,7 @@ def run(
         fnout,
         oneval,
         dframe,
+        auto_frame,
         dword,
         dbit,
         multi=False,
@@ -30,6 +31,8 @@ def run(
         metastr += ".DFRAME:%02x" % dframe
     if multi:
         metastr += ".MULTI"
+    if auto_frame:
+        metastr += ".AUTO_FRAME"
 
     tags = dict()
     f = open(design_fn, 'r')
@@ -67,6 +70,10 @@ def main():
         default="",
         help="Reference frame delta (base 16)")
     parser.add_argument(
+        "--auto-frame",
+        action='store_true',
+        help="Auto align frame address to next lowest multiple of 0x80")
+    parser.add_argument(
         "--dword",
         type=str,
         required=True,
@@ -85,6 +92,7 @@ def main():
         args.fnout,
         args.oneval,
         None if args.dframe == "" else int(args.dframe, 16),
+        args.auto_frame,
         int(args.dword, 10),
         None if args.dbit == "" else int(args.dbit, 10),
         multi=args.multi,

--- a/fuzzers/005-tilegrid/gtp_common/Makefile
+++ b/fuzzers/005-tilegrid/gtp_common/Makefile
@@ -1,0 +1,10 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+N ?= 8
+GENERATE_ARGS?="--oneval 0 --design params.csv --dframe 1d --dword 45 --dbit 3"
+include ../fuzzaddr/common.mk

--- a/fuzzers/005-tilegrid/gtp_common/Makefile
+++ b/fuzzers/005-tilegrid/gtp_common/Makefile
@@ -6,5 +6,5 @@
 #
 # SPDX-License-Identifier: ISC
 N ?= 8
-GENERATE_ARGS?="--oneval 0 --design params.csv --dframe 1d --dword 45 --dbit 3"
+GENERATE_ARGS?="--oneval 0 --design params.csv --dword 45 --dbit 3 --auto-frame"
 include ../fuzzaddr/common.mk

--- a/fuzzers/005-tilegrid/gtp_common/generate.tcl
+++ b/fuzzers/005-tilegrid/gtp_common/generate.tcl
@@ -1,0 +1,36 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+source "$::env(XRAY_DIR)/utils/utils.tcl"
+
+proc run {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+    # Disable MMCM frequency etc sanity checks
+    set_property IS_ENABLED 0 [get_drc_checks {PDRC-29}]
+    set_property IS_ENABLED 0 [get_drc_checks {PDRC-30}]
+    set_property IS_ENABLED 0 [get_drc_checks {AVAL-50}]
+    set_property IS_ENABLED 0 [get_drc_checks {AVAL-53}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-126}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-48}]
+    set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
+    set_property IS_ENABLED 0 [get_drc_checks {UCIO-1}]
+
+    place_design
+    route_design
+
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+}
+
+run

--- a/fuzzers/005-tilegrid/gtp_common/top.py
+++ b/fuzzers/005-tilegrid/gtp_common/top.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+import os
+import random
+random.seed(int(os.getenv("SEED"), 16))
+from prjxray import util
+from prjxray.db import Database
+
+
+def gen_sites():
+    db = Database(util.get_db_root(), util.get_part())
+    grid = db.grid()
+    for tile_name in sorted(grid.tiles()):
+        loc = grid.loc_of_tilename(tile_name)
+        gridinfo = grid.gridinfo_at_loc(loc)
+
+        for site_name, site_type in gridinfo.sites.items():
+            if site_type in ['GTPE2_COMMON']:
+                yield tile_name, site_name
+
+
+def write_params(params):
+    pinstr = 'tile,val,site\n'
+    for tile, (site, val) in sorted(params.items()):
+        pinstr += '%s,%s,%s\n' % (tile, val, site)
+    open('params.csv', 'w').write(pinstr)
+
+
+def run():
+    print('''
+module top(input wire in, output wire out);
+    ''')
+
+    params = {}
+
+    sites = list(gen_sites())
+    for (tile_name, site_name), isone in zip(sites,
+                                             util.gen_fuzz_states(len(sites))):
+        params[tile_name] = (site_name, isone)
+
+        attr = 4 if isone else 5
+        print(
+            '''
+    (* KEEP, DONT_TOUCH, LOC="{site}" *)
+    GTPE2_COMMON #(
+        .PLL0_FBDIV_45({attr})
+    ) {site} ();'''.format(attr=attr, site=site_name))
+
+    print("endmodule")
+    write_params(params)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

For the time being, the GTP_COMMON is restricted only to the artix7 devices. We can enable them for the other families in a second moment.