### PR TITLE
gtp_common: add conf fuzzer

### DIFF
--- a/fuzzers/063-gtp-common-conf/Makefile
+++ b/fuzzers/063-gtp-common-conf/Makefile
@@ -1,0 +1,27 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+N ?= 20
+
+include ../fuzzer.mk
+
+database: build/segbits_gtp_common.db
+
+build/segbits_gtp_common.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} -o build/segbits_gtp_common.rdb $(addsuffix /segdata_gtp_common.txt,$(SPECIMENS))
+
+build/segbits_gtp_common.db: build/segbits_gtp_common.rdb
+	${XRAY_DBFIXUP} --db-root build --zero-db bits.dbf \
+		--seg-fn-in build/segbits_gtp_common.rdb \
+		--seg-fn-out build/segbits_gtp_common.db
+	${XRAY_MASKMERGE} build/mask_gtp_common.db $(addsuffix /segdata_gtp_common.txt,$(SPECIMENS))
+
+pushdb:
+	${XRAY_MERGEDB} gtp_common build/segbits_gtp_common.db
+	${XRAY_MERGEDB} mask_gtp_common build/mask_gtp_common.db
+
+.PHONY: database pushdb

--- a/fuzzers/063-gtp-common-conf/Makefile
+++ b/fuzzers/063-gtp-common-conf/Makefile
@@ -5,23 +5,46 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
+
+SHELL = bash
+
 N ?= 20
 
-include ../fuzzer.mk
+SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
+SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
+FUZDIR ?= ${PWD}
+
+all: database
+
+# generate.sh / top_generate.sh call make, hence the command must
+# have a + before it.
+$(SPECIMENS_OK): $(SPECIMENS_DEPS)
+	mkdir -p build
+	bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@)
+
+run:
+	$(MAKE) clean
+	$(MAKE) database
+	$(MAKE) pushdb
+	touch run.${XRAY_PART}.ok
+
+clean:
+	rm -rf build run.ok
+
+.PHONY: all run clean
 
 database: build/segbits_gtp_common.db
 
 build/segbits_gtp_common.rdb: $(SPECIMENS_OK)
-	${XRAY_SEGMATCH} -o build/segbits_gtp_common.rdb $(addsuffix /segdata_gtp_common.txt,$(SPECIMENS))
+	${XRAY_SEGMATCH} -o build/segbits_gtp_common.rdb $$(find $(SPECIMENS) -name "segdata_gtp_common*")
 
 build/segbits_gtp_common.db: build/segbits_gtp_common.rdb
 	${XRAY_DBFIXUP} --db-root build --zero-db bits.dbf \
 		--seg-fn-in build/segbits_gtp_common.rdb \
 		--seg-fn-out build/segbits_gtp_common.db
-	${XRAY_MASKMERGE} build/mask_gtp_common.db $(addsuffix /segdata_gtp_common.txt,$(SPECIMENS))
+	${XRAY_MASKMERGE} build/mask_gtp_common.db $$(find $(SPECIMENS) -name "segdata_gtp_common*")
 
 pushdb:
-	${XRAY_MERGEDB} gtp_common build/segbits_gtp_common.db
-	${XRAY_MERGEDB} mask_gtp_common build/mask_gtp_common.db
+	source pushdb.sh
 
 .PHONY: database pushdb

--- a/fuzzers/063-gtp-common-conf/Makefile
+++ b/fuzzers/063-gtp-common-conf/Makefile
@@ -10,16 +10,19 @@ SHELL = bash
 
 N ?= 20
 
-SPECIMENS := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
+BUILD_DIR = build_${XRAY_PART}
+
+SPECIMENS := $(addprefix ${BUILD_DIR}/specimen_,$(shell seq -f '%03.0f' $(N)))
 SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
 FUZDIR ?= ${PWD}
+
 
 all: database
 
 # generate.sh / top_generate.sh call make, hence the command must
 # have a + before it.
 $(SPECIMENS_OK): $(SPECIMENS_DEPS)
-	mkdir -p build
+	mkdir -p ${BUILD_DIR}
 	bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@)
 
 run:
@@ -29,22 +32,22 @@ run:
 	touch run.${XRAY_PART}.ok
 
 clean:
-	rm -rf build run.ok
+	rm -rf ${BUILD_DIR} run.${XRAY_PART}.ok
 
 .PHONY: all run clean
 
-database: build/segbits_gtp_common.db
+database: ${BUILD_DIR}/segbits_gtp_common.db
 
-build/segbits_gtp_common.rdb: $(SPECIMENS_OK)
-	${XRAY_SEGMATCH} -o build/segbits_gtp_common.rdb $$(find $(SPECIMENS) -name "segdata_gtp_common*")
+${BUILD_DIR}/segbits_gtp_common.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} -o ${BUILD_DIR}/segbits_gtp_common.rdb $$(find $(SPECIMENS) -name "segdata_gtp_common*")
 
-build/segbits_gtp_common.db: build/segbits_gtp_common.rdb
-	${XRAY_DBFIXUP} --db-root build --zero-db bits.dbf \
-		--seg-fn-in build/segbits_gtp_common.rdb \
-		--seg-fn-out build/segbits_gtp_common.db
-	${XRAY_MASKMERGE} build/mask_gtp_common.db $$(find $(SPECIMENS) -name "segdata_gtp_common*")
+${BUILD_DIR}/segbits_gtp_common.db: ${BUILD_DIR}/segbits_gtp_common.rdb
+	${XRAY_DBFIXUP} --db-root ${BUILD_DIR} --zero-db bits.dbf \
+		--seg-fn-in ${BUILD_DIR}/segbits_gtp_common.rdb \
+		--seg-fn-out ${BUILD_DIR}/segbits_gtp_common.db
+	${XRAY_MASKMERGE} ${BUILD_DIR}/mask_gtp_common.db $$(find $(SPECIMENS) -name "segdata_gtp_common*")
 
 pushdb:
-	source pushdb.sh
+	BUILD_DIR=$(BUILD_DIR) source pushdb.sh
 
 .PHONY: database pushdb

--- a/fuzzers/063-gtp-common-conf/attrs.json
+++ b/fuzzers/063-gtp-common-conf/attrs.json
@@ -1,0 +1,103 @@
+{
+    "PLL0_CFG": {
+        "type": "BIN",
+        "values": [134150145],
+        "digits": 27
+    },
+    "PLL0_REFCLK_DIV": {
+        "type": "INT",
+        "values": [1, 2],
+        "encoding": [16, 0],
+        "digits": 5
+    },
+    "PLL0_FBDIV_45": {
+        "type": "INT",
+        "values": [4, 5],
+        "encoding": [0, 1],
+        "digits": 1
+    },
+    "PLL0_FBDIV": {
+        "type": "INT",
+        "values": [1, 2, 3, 4, 5],
+        "encoding": [16, 0, 1, 2, 3],
+        "digits": 6
+    },
+    "PLL0_LOCK_CFG": {
+        "type": "BIN",
+        "values": [511],
+        "digits": 9
+    },
+    "PLL0_INIT_CFG": {
+        "type": "BIN",
+        "values": [16711425],
+        "digits": 24
+    },
+    "RSVD_ATTR0": {
+        "type": "BIN",
+        "values": [65535],
+        "digits": 16
+    },
+    "PLL1_DMON_CFG": {
+        "type": "BIN",
+        "values": [1],
+        "digits": 1
+    },
+    "PLL0_DMON_CFG": {
+        "type": "BIN",
+        "values": [1],
+        "digits": 1
+    },
+    "COMMON_CFG": {
+        "type": "BIN",
+        "values": [4294836225],
+        "digits": 32
+    },
+    "PLL_CLKOUT_CFG": {
+        "type": "BIN",
+        "values": [255],
+        "digits": 8
+    },
+    "BIAS_CFG": {
+        "type": "BIN",
+        "values": [18445618199572250625],
+        "digits": 64
+    },
+    "RSVD_ATTR1": {
+        "type": "BIN",
+        "values": [65535],
+        "digits": 16
+    },
+    "PLL1_INIT_CFG": {
+        "type": "BIN",
+        "values": [16711425],
+        "digits": 24
+    },
+    "PLL1_LOCK_CFG": {
+        "type": "BIN",
+        "values": [511],
+        "digits": 9
+    },
+    "PLL1_REFCLK_DIV": {
+        "type": "INT",
+        "values": [1, 2],
+        "encoding": [16, 0],
+        "digits": 5
+    },
+    "PLL1_FBDIV_45": {
+        "type": "INT",
+        "values": [4, 5],
+        "encoding": [0, 1],
+        "digits": 1
+    },
+    "PLL1_FBDIV": {
+        "type": "INT",
+        "values": [1, 2, 3, 4, 5],
+        "encoding": [16, 0, 1, 2, 3],
+        "digits": 6
+    },
+    "PLL1_CFG": {
+        "type": "BIN",
+        "values": [134150145],
+        "digits": 27
+    }
+}

--- a/fuzzers/063-gtp-common-conf/generate.py
+++ b/fuzzers/063-gtp-common-conf/generate.py
@@ -36,11 +36,15 @@ def main():
         attrs = json.load(attr_file)
 
     print("Loading tags")
-    with open('params.json') as f:
+    with open("params.json") as f:
         params = json.load(f)
 
-        site = params['site']
+    site = params["site"]
+    in_use = params["IN_USE"]
 
+    segmk.add_site_tag(site, "IN_USE", in_use)
+
+    if in_use:
         for param, param_info in attrs.items():
             value = params[param]
             param_type = param_info["type"]
@@ -65,7 +69,15 @@ def main():
                 ]
 
                 for i in range(param_digits):
-                    segmk.add_site_tag(site, '%s[%u]' % (param, i), bitstr[i])
+                    segmk.add_site_tag(site, "%s[%u]" % (param, i), bitstr[i])
+
+        for param, invert in [("GTGREFCLK1", 0), ("GTGREFCLK0", 0),
+                              ("PLL0LOCKDETCLK", 1), ("PLL1LOCKDETCLK",
+                                                      1), ("DRPCLK", 1)]:
+            if invert:
+                segmk.add_site_tag(site, "ZINV_" + param, 1 ^ params[param])
+            else:
+                segmk.add_site_tag(site, "INV_" + param, params[param])
 
     segmk.compile(bitfilter=bitfilter)
     segmk.write()

--- a/fuzzers/063-gtp-common-conf/generate.py
+++ b/fuzzers/063-gtp-common-conf/generate.py
@@ -21,7 +21,7 @@ BIN = "BIN"
 
 def bitfilter(frame, bit):
     # Filter out interconnect bits.
-    if frame not in [28, 29]:
+    if frame not in [28, 29, 0, 1]:
         return False
 
     return True
@@ -37,47 +37,51 @@ def main():
 
     print("Loading tags")
     with open("params.json") as f:
-        params = json.load(f)
+        params_list = json.load(f)
 
-    site = params["site"]
-    in_use = params["IN_USE"]
+    for params in params_list:
+        site = params["site"]
+        in_use = params["IN_USE"]
 
-    segmk.add_site_tag(site, "IN_USE", in_use)
+        segmk.add_site_tag(site, "IN_USE", in_use)
 
-    if in_use:
-        for param, param_info in attrs.items():
-            value = params[param]
-            param_type = param_info["type"]
-            param_digits = param_info["digits"]
-            param_values = param_info["values"]
+        if in_use:
+            for param, param_info in attrs.items():
+                value = params[param]
+                param_type = param_info["type"]
+                param_digits = param_info["digits"]
+                param_values = param_info["values"]
 
-            if param_type == INT:
-                param_encodings = param_info["encoding"]
-                param_encoding = param_encodings[param_values.index(value)]
-                bitstr = [
-                    int(x) for x in "{value:0{digits}b}".format(
-                        value=param_encoding, digits=param_digits)[::-1]
-                ]
+                if param_type == INT:
+                    param_encodings = param_info["encoding"]
+                    param_encoding = param_encodings[param_values.index(value)]
+                    bitstr = [
+                        int(x) for x in "{value:0{digits}b}".format(
+                            value=param_encoding, digits=param_digits)[::-1]
+                    ]
 
-                for i in range(param_digits):
-                    segmk.add_site_tag(site, '%s[%u]' % (param, i), bitstr[i])
-            else:
-                assert param_type == BIN
-                bitstr = [
-                    int(x) for x in "{value:0{digits}b}".format(
-                        value=value, digits=param_digits)[::-1]
-                ]
+                    for i in range(param_digits):
+                        segmk.add_site_tag(
+                            site, '%s[%u]' % (param, i), bitstr[i])
+                else:
+                    assert param_type == BIN
+                    bitstr = [
+                        int(x) for x in "{value:0{digits}b}".format(
+                            value=value, digits=param_digits)[::-1]
+                    ]
 
-                for i in range(param_digits):
-                    segmk.add_site_tag(site, "%s[%u]" % (param, i), bitstr[i])
+                    for i in range(param_digits):
+                        segmk.add_site_tag(
+                            site, "%s[%u]" % (param, i), bitstr[i])
 
-        for param, invert in [("GTGREFCLK1", 0), ("GTGREFCLK0", 0),
-                              ("PLL0LOCKDETCLK", 1), ("PLL1LOCKDETCLK",
-                                                      1), ("DRPCLK", 1)]:
-            if invert:
-                segmk.add_site_tag(site, "ZINV_" + param, 1 ^ params[param])
-            else:
-                segmk.add_site_tag(site, "INV_" + param, params[param])
+            for param, invert in [("GTGREFCLK1", 0), ("GTGREFCLK0", 0),
+                                  ("PLL0LOCKDETCLK", 1), ("PLL1LOCKDETCLK",
+                                                          1), ("DRPCLK", 1)]:
+                if invert:
+                    segmk.add_site_tag(
+                        site, "ZINV_" + param, 1 ^ params[param])
+                else:
+                    segmk.add_site_tag(site, "INV_" + param, params[param])
 
     segmk.compile(bitfilter=bitfilter)
     segmk.write()

--- a/fuzzers/063-gtp-common-conf/generate.py
+++ b/fuzzers/063-gtp-common-conf/generate.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import json
+import os
+from enum import Enum
+
+from prjxray.segmaker import Segmaker
+
+INT = "INT"
+BIN = "BIN"
+
+
+def bitfilter(frame, bit):
+    # Filter out interconnect bits.
+    if frame not in [28, 29]:
+        return False
+
+    return True
+
+
+def main():
+    segmk = Segmaker("design.bits")
+
+    fuz_dir = os.getenv("FUZDIR", None)
+    assert fuz_dir
+    with open(os.path.join(fuz_dir, "attrs.json"), "r") as attr_file:
+        attrs = json.load(attr_file)
+
+    print("Loading tags")
+    with open('params.json') as f:
+        params = json.load(f)
+
+        site = params['site']
+
+        for param, param_info in attrs.items():
+            value = params[param]
+            param_type = param_info["type"]
+            param_digits = param_info["digits"]
+            param_values = param_info["values"]
+
+            if param_type == INT:
+                param_encodings = param_info["encoding"]
+                param_encoding = param_encodings[param_values.index(value)]
+                bitstr = [
+                    int(x) for x in "{value:0{digits}b}".format(
+                        value=param_encoding, digits=param_digits)[::-1]
+                ]
+
+                for i in range(param_digits):
+                    segmk.add_site_tag(site, '%s[%u]' % (param, i), bitstr[i])
+            else:
+                assert param_type == BIN
+                bitstr = [
+                    int(x) for x in "{value:0{digits}b}".format(
+                        value=value, digits=param_digits)[::-1]
+                ]
+
+                for i in range(param_digits):
+                    segmk.add_site_tag(site, '%s[%u]' % (param, i), bitstr[i])
+
+    segmk.compile(bitfilter=bitfilter)
+    segmk.write()
+
+
+if __name__ == '__main__':
+    main()

--- a/fuzzers/063-gtp-common-conf/generate.tcl
+++ b/fuzzers/063-gtp-common-conf/generate.tcl
@@ -1,0 +1,28 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+proc run {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+    set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
+    set_property IS_ENABLED 0 [get_drc_checks {UCIO-1}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-48}]
+
+    place_design
+    route_design
+
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+}
+
+run

--- a/fuzzers/063-gtp-common-conf/generate.tcl
+++ b/fuzzers/063-gtp-common-conf/generate.tcl
@@ -17,6 +17,7 @@ proc run {} {
     set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
     set_property IS_ENABLED 0 [get_drc_checks {UCIO-1}]
     set_property IS_ENABLED 0 [get_drc_checks {REQP-48}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-1619}]
 
     place_design
     route_design

--- a/fuzzers/063-gtp-common-conf/pushdb.sh
+++ b/fuzzers/063-gtp-common-conf/pushdb.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if ! test $(find . -name "segdata_gtp_common_mid_right.txt" | wc -c) -eq 0
+then
+    ${XRAY_MERGEDB} gtp_common_mid_right build/segbits_gtp_common.db
+    ${XRAY_MERGEDB} mask_gtp_common_mid_right build/mask_gtp_common.db
+    ${XRAY_MERGEDB} gtp_common_mid_left build/segbits_gtp_common.db
+    ${XRAY_MERGEDB} mask_gtp_common_mid_left build/mask_gtp_common.db
+fi
+
+if ! test $(find . -name "segdata_gtp_common.txt" | wc -c) -eq 0
+then
+    ${XRAY_MERGEDB} gtp_common build/segbits_gtp_common.db
+    ${XRAY_MERGEDB} mask_gtp_common build/mask_gtp_common.db
+fi

--- a/fuzzers/063-gtp-common-conf/pushdb.sh
+++ b/fuzzers/063-gtp-common-conf/pushdb.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 if ! test $(find . -name "segdata_gtp_common_mid_right.txt" | wc -c) -eq 0
 then

--- a/fuzzers/063-gtp-common-conf/pushdb.sh
+++ b/fuzzers/063-gtp-common-conf/pushdb.sh
@@ -7,16 +7,16 @@
 #
 # SPDX-License-Identifier: ISC
 
-if ! test $(find . -name "segdata_gtp_common_mid_right.txt" | wc -c) -eq 0
+if ! test $(find ${BUILD_DIR} -name "segdata_gtp_common_mid_right.txt" | wc -c) -eq 0
 then
-    ${XRAY_MERGEDB} gtp_common_mid_right build/segbits_gtp_common.db
-    ${XRAY_MERGEDB} mask_gtp_common_mid_right build/mask_gtp_common.db
-    ${XRAY_MERGEDB} gtp_common_mid_left build/segbits_gtp_common.db
-    ${XRAY_MERGEDB} mask_gtp_common_mid_left build/mask_gtp_common.db
+    ${XRAY_MERGEDB} gtp_common_mid_right ${BUILD_DIR}/segbits_gtp_common.db
+    ${XRAY_MERGEDB} mask_gtp_common_mid_right ${BUILD_DIR}/mask_gtp_common.db
+    ${XRAY_MERGEDB} gtp_common_mid_left ${BUILD_DIR}/segbits_gtp_common.db
+    ${XRAY_MERGEDB} mask_gtp_common_mid_left ${BUILD_DIR}/mask_gtp_common.db
 fi
 
-if ! test $(find . -name "segdata_gtp_common.txt" | wc -c) -eq 0
+if ! test $(find ${BUILD_DIR} -name "segdata_gtp_common.txt" | wc -c) -eq 0
 then
-    ${XRAY_MERGEDB} gtp_common build/segbits_gtp_common.db
-    ${XRAY_MERGEDB} mask_gtp_common build/mask_gtp_common.db
+    ${XRAY_MERGEDB} gtp_common ${BUILD_DIR}/segbits_gtp_common.db
+    ${XRAY_MERGEDB} mask_gtp_common ${BUILD_DIR}/mask_gtp_common.db
 fi

--- a/fuzzers/063-gtp-common-conf/top.py
+++ b/fuzzers/063-gtp-common-conf/top.py
@@ -33,7 +33,6 @@ def gen_sites():
         if gridinfo.tile_type not in [
                 "GTP_COMMON",
                 "GTP_COMMON_MID_RIGHT",
-                "GTP_COMMON_MID_RIGHT",
         ]:
             continue
 
@@ -41,7 +40,7 @@ def gen_sites():
             if site_type != "GTPE2_COMMON":
                 continue
 
-            return site_name, site_type
+            yield site_name, site_type
 
 
 def main():
@@ -55,66 +54,69 @@ module top(
 assign out = in;
 ''')
 
-    site_name, site_type = gen_sites()
+    params_list = list()
 
-    params = dict()
-    params['site'] = site_name
+    for site_name, site_type in gen_sites():
+        params = dict()
+        params['site'] = site_name
 
-    verilog_attr = ""
+        verilog_attr = ""
 
-    verilog_attr = "#("
+        verilog_attr = "#("
 
-    fuz_dir = os.getenv("FUZDIR", None)
-    assert fuz_dir
-    with open(os.path.join(fuz_dir, "attrs.json"), "r") as attrs_file:
-        attrs = json.load(attrs_file)
+        fuz_dir = os.getenv("FUZDIR", None)
+        assert fuz_dir
+        with open(os.path.join(fuz_dir, "attrs.json"), "r") as attrs_file:
+            attrs = json.load(attrs_file)
 
-    in_use = bool(random.randint(0, 9))
-    params["IN_USE"] = in_use
+        in_use = bool(random.randint(0, 9))
+        params["IN_USE"] = in_use
 
-    if in_use:
-        for param, param_info in attrs.items():
-            param_type = param_info["type"]
-            param_values = param_info["values"]
-            param_digits = param_info["digits"]
+        if in_use:
+            for param, param_info in attrs.items():
+                param_type = param_info["type"]
+                param_values = param_info["values"]
+                param_digits = param_info["digits"]
 
-            if param_type == INT:
-                value = random.choice(param_values)
-                value_str = value
-            else:
-                assert param_type == BIN
-                value = random.randint(0, param_values[0])
-                value_str = "{digits}'b{value:0{digits}b}".format(
-                    value=value, digits=param_digits)
+                if param_type == INT:
+                    value = random.choice(param_values)
+                    value_str = value
+                else:
+                    assert param_type == BIN
+                    value = random.randint(0, param_values[0])
+                    value_str = "{digits}'b{value:0{digits}b}".format(
+                        value=value, digits=param_digits)
 
-            params[param] = value
+                params[param] = value
 
-            verilog_attr += """
-        .{}({}),""".format(param, value_str)
+                verilog_attr += """
+            .{}({}),""".format(param, value_str)
 
-        for param in ["GTGREFCLK1", "GTGREFCLK0", "PLL0LOCKDETCLK",
-                      "PLL1LOCKDETCLK", "DRPCLK"]:
-            is_inverted = random.randint(0, 1)
+            for param in ["GTGREFCLK1", "GTGREFCLK0", "PLL0LOCKDETCLK",
+                          "PLL1LOCKDETCLK", "DRPCLK"]:
+                is_inverted = random.randint(0, 1)
 
-            params[param] = is_inverted
+                params[param] = is_inverted
 
-            verilog_attr += """
-        .IS_{}_INVERTED({}),""".format(param, is_inverted)
+                verilog_attr += """
+            .IS_{}_INVERTED({}),""".format(param, is_inverted)
 
-        verilog_attr = verilog_attr.rstrip(",")
-        verilog_attr += "\n)"
+            verilog_attr = verilog_attr.rstrip(",")
+            verilog_attr += "\n)"
 
-        print("(* KEEP, DONT_TOUCH *)")
-        print(
-            """GTPE2_COMMON {} gtp_common (
-    .GTREFCLK0(1'b0),
-    .GTREFCLK1(1'b0)
-);""".format(verilog_attr))
+            print("(* KEEP, DONT_TOUCH, LOC=\"{}\" *)".format(site_name))
+            print(
+                """GTPE2_COMMON {attrs} {site} (
+        .GTREFCLK0(1'b0),
+        .GTREFCLK1(1'b0)
+    );""".format(attrs=verilog_attr, site=site_name))
+
+        params_list.append(params)
 
     print("endmodule")
 
     with open('params.json', 'w') as f:
-        json.dump(params, f, indent=2)
+        json.dump(params_list, f, indent=2)
 
 
 if __name__ == '__main__':

--- a/fuzzers/063-gtp-common-conf/top.py
+++ b/fuzzers/063-gtp-common-conf/top.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import json
+import os
+import random
+from collections import namedtuple
+
+random.seed(int(os.getenv("SEED"), 16))
+from prjxray import util
+from prjxray import verilog
+from prjxray.db import Database
+
+INT = "INT"
+BIN = "BIN"
+
+
+def gen_sites():
+    db = Database(util.get_db_root(), util.get_part())
+    grid = db.grid()
+    for tile_name in sorted(grid.tiles()):
+        loc = grid.loc_of_tilename(tile_name)
+        gridinfo = grid.gridinfo_at_loc(loc)
+
+        if gridinfo.tile_type not in [
+                "GTP_COMMON",
+                "GTP_COMMON_MID_RIGHT",
+                "GTP_COMMON_MID_RIGHT",
+        ]:
+            continue
+
+        for site_name, site_type in gridinfo.sites.items():
+            if site_type != "GTPE2_COMMON":
+                continue
+
+            return site_name, site_type
+
+
+def main():
+    print('''
+module top();
+''')
+
+    site_name, site_type = gen_sites()
+
+    params = dict()
+    params['site'] = site_name
+
+    verilog_attr = ""
+
+    verilog_attr = "#("
+
+    fuz_dir = os.getenv("FUZDIR", None)
+    assert fuz_dir
+    with open(os.path.join(fuz_dir, "attrs.json"), "r") as attrs_file:
+        attrs = json.load(attrs_file)
+
+    for param, param_info in attrs.items():
+        param_type = param_info["type"]
+        param_values = param_info["values"]
+        param_digits = param_info["digits"]
+
+        if param_type == INT:
+            value = random.choice(param_values)
+            value_str = value
+        else:
+            assert param_type == BIN
+            value = random.randint(0, param_values[0])
+            value_str = "{digits}'b{value:0{digits}b}".format(
+                value=value, digits=param_digits)
+
+        params[param] = value
+
+        verilog_attr += """
+    .{}({}),""".format(param, value_str)
+
+    verilog_attr = verilog_attr.rstrip(",")
+    verilog_attr += "\n)"
+
+    print("(* KEEP, DONT_TOUCH *)")
+    print("GTPE2_COMMON {} gtp_common ();".format(verilog_attr))
+    print("endmodule")
+
+    with open('params.json', 'w') as f:
+        json.dump(params, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -158,6 +158,7 @@ $(eval $(call fuzzer,076-ps7,,all))
 endif
 ifeq ($(XRAY_DATABASE),artix7)
 $(eval $(call fuzzer,061-pcie-conf,005-tilegrid,all))
+$(eval $(call fuzzer,063-gtp-common-conf,005-tilegrid,part))
 endif
 endif
 endif

--- a/prjxray/segmaker.py
+++ b/prjxray/segmaker.py
@@ -331,6 +331,7 @@ class Segmaker:
                     'IDELAY': name_y0y1,
                     'ILOGIC': name_y0y1,
                     'OLOGIC': name_y0y1,
+                    'IBUFDS': name_y0y1,
                 }.get(site_prefix, name_default)()
                 self.verbose and print(
                     'site %s w/ %s prefix => tag %s' %

--- a/utils/mergedb.sh
+++ b/utils/mergedb.sh
@@ -160,6 +160,9 @@ case "$1" in
 	pcie_bot)
 		cp "$2" "$tmp1" ;;
 
+	gtp_common)
+		cp "$2" "$tmp1" ;;
+
 	mask_*)
 		db=$XRAY_DATABASE_DIR/$XRAY_DATABASE/$1.db
 		ismask=true

--- a/utils/mergedb.sh
+++ b/utils/mergedb.sh
@@ -163,6 +163,12 @@ case "$1" in
 	gtp_common)
 		cp "$2" "$tmp1" ;;
 
+	gtp_common_mid_left)
+		sed < "$2" > "$tmp1" -e 's/^GTP_COMMON_MID_RIGHT\./GTP_COMMON_MID_LEFT./' ;;
+
+	gtp_common_mid_right)
+		cp "$2" "$tmp1" ;;
+
 	mask_*)
 		db=$XRAY_DATABASE_DIR/$XRAY_DATABASE/$1.db
 		ismask=true


### PR DESCRIPTION
This PR is based on top of https://github.com/SymbiFlow/prjxray/pull/1547 is still a WIP for the following reasons:

- requires some docstrings
- need to add support for the `IS_INVERTED` features.

The idea of this fuzzer is to have a json file containing a list of parameters of four kinds:
- *INT*: This is an integer parameter that requires X number of bits.
- *BIN*: This is a parameter with X numbers of required bits

Given that the GTP common does not have any string parameter, the above parameter types are the only ones.

The json file contains also an `encoding` field, which, as far as I have understood, should be interpreted as the binary representation of the value assigned, and this is relevant mostly for the *INT* parameter type.

E.g.:
The `PLL0_REFCLK_DIV` parameter has two possible values, 1 and 2. The encoding of the value one is 16 and the parameter has 5 possible digits. This means that the value one should be encoded as `00100`