### PR TITLE
database: artix7: Fix wrong device fabric mapping

### DIFF
--- a/database/artix7/mapping/devices.yaml
+++ b/database/artix7/mapping/devices.yaml
@@ -6,4 +6,4 @@
 "xc7a50t":
   fabric: "xc7a50t"
 "xc7a35t":
-  fabric: "xc7a50t"
+  fabric: "xc7a35t"


### PR DESCRIPTION
The xc7a35t devices do not use the xc7a50t fabric.

Signed-off-by: Daniel Schultz <d.schultz@phytec.de>