### PR TITLE
065-gtp-common-pips: increase specimens count

### DIFF
--- a/fuzzers/065-gtp-common-pips/Makefile
+++ b/fuzzers/065-gtp-common-pips/Makefile
@@ -16,7 +16,7 @@ RUN_OK = run.${XRAY_PART}.ok
 TODO_RE=".*"
 
 MAKETODO_FLAGS=--pip-type ${PIP_TYPE} --seg-type $(SEG_TYPE) --re $(TODO_RE) --sides ""
-N = 60
+N = 100
 
 SEGMATCH_FLAGS=-c 2
 SPECIMENS_DEPS=$(BUILD_DIR)/cmt_regions.csv


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR increases the specimen count from 60 to 100 for the 065-gtp-common-pips. This because it appears to be harder to get PIPs in following iterations. With this change, the fuzzer takes only one iteration to finish, while, with 60 specimens per iteration, the fuzzer took a total of 4 iterations (at least locally).