### PR TITLE
Fix 065 gtp common pips

### DIFF
--- a/fuzzers/065-gtp-common-pips/Makefile
+++ b/fuzzers/065-gtp-common-pips/Makefile
@@ -6,7 +6,8 @@
 #
 # SPDX-License-Identifier: ISC
 export FUZDIR=$(shell pwd)
-PIP_TYPE?=gtp_common_${XRAY_PART}
+PIP_TYPE?=gtp_common_mid_${XRAY_PART}
+PIP_FILE?=gtp_common_mid
 SEG_TYPE?=gtp_common_mid_left
 PIPLIST_TCL=$(FUZDIR)/gtp_common_pip_list.tcl
 
@@ -14,13 +15,15 @@ BUILD_DIR = ${FUZDIR}/build_${XRAY_PART}
 RUN_OK = run.${XRAY_PART}.ok
 
 TODO_RE=".*"
+EXCLUDE_RE=".*HCLK_GTP_CK_MUX.*"
+PIP_DIR=${XRAY_FUZZERS_DIR}/piplist/build/$(PIP_TYPE)
 
-MAKETODO_FLAGS=--pip-type ${PIP_TYPE} --seg-type $(SEG_TYPE) --re $(TODO_RE) --sides ""
-N = 100
+MAKETODO_FLAGS=--pip-type ${PIP_FILE} --seg-type $(SEG_TYPE) --re $(TODO_RE) --sides "" --exclude-re $(EXCLUDE_RE) --pip-dir $(PIP_DIR)
+N = 60
 
 SEGMATCH_FLAGS=-c 2
 SPECIMENS_DEPS=$(BUILD_DIR)/cmt_regions.csv
-A_PIPLIST=gtp_common_${XRAY_PART}.txt
+A_PIPLIST=gtp_common_mid.txt
 
 CHECK_ARGS= --zero-entries --timeout-iters 5 --todo-dir $(BUILD_DIR)/todo
 

--- a/fuzzers/065-gtp-common-pips/generate.py
+++ b/fuzzers/065-gtp-common-pips/generate.py
@@ -33,7 +33,7 @@ def bitfilter(frame, word):
 def read_pip_data(pipfile, pipdata, tile_ports):
     part = os.getenv('XRAY_PART')
     with open(os.path.join(os.getenv('FUZDIR'), '..', 'piplist', 'build',
-                           'gtp_common_{}'.format(part), pipfile)) as f:
+                           'gtp_common_mid_{}'.format(part), pipfile)) as f:
         for l in f:
             tile_type, dst, src = l.strip().split('.')
             if tile_type not in pipdata:
@@ -53,8 +53,7 @@ def main():
     ignpip = set()
     tile_ports = {}
 
-    part = os.getenv('XRAY_PART')
-    read_pip_data('gtp_common_{}.txt'.format(part), pipdata, tile_ports)
+    read_pip_data('gtp_common_mid.txt', pipdata, tile_ports)
 
     print("Loading tags from design.txt.")
     with open("design.txt", "r") as f:
@@ -87,6 +86,9 @@ def main():
             if pdir == 0:
                 tiledata[tile]["srcs"].add(dst)
                 tiledata[tile]["dsts"].add(src)
+
+            if "HCLK_GTP_CK_MUX" in src:
+                ignpip.add((src, dst))
 
     for tile, pips_srcs_dsts in tiledata.items():
         tile_type = pips_srcs_dsts["type"]

--- a/fuzzers/065-gtp-common-pips/generate.tcl
+++ b/fuzzers/065-gtp-common-pips/generate.tcl
@@ -8,7 +8,7 @@
 source "$::env(XRAY_DIR)/utils/utils.tcl"
 
 proc load_todo {{dir "dst"}} {
-    set fp [open "../../todo_all.txt" r]
+    set fp [open "$::env(FUZDIR)/../piplist/build/gtp_common_mid_$::env(XRAY_PART)/gtp_common_mid.txt" r]
 
     # Create map of pip source to remaining destinations for that pip
     set todo_map [dict create]

--- a/fuzzers/065-gtp-common-pips/gtp_common_pip_list.tcl
+++ b/fuzzers/065-gtp-common-pips/gtp_common_pip_list.tcl
@@ -46,4 +46,4 @@ create_project -force -part $::env(XRAY_PART) design design
 set_property design_mode PinPlanning [current_fileset]
 open_io_design -name io_1
 
-print_tile_pips GTP_COMMON_MID_LEFT gtp_common_$::env(XRAY_PART).txt
+print_tile_pips GTP_COMMON_MID_LEFT gtp_common_mid.txt

--- a/fuzzers/065-gtp-common-pips/top.py
+++ b/fuzzers/065-gtp-common-pips/top.py
@@ -320,12 +320,12 @@ module top(
 
             use_gtp_channel, use_ibufds, use_cmt = todo_pips()
 
-            if (chance < 0.3 and use_cmt) or not cmt_clock_used:
+            if (chance < 0.2 and use_cmt) or not cmt_clock_used:
                 # There must always be at least one CMT clock used
                 # to trigger the bits for the GTP_COMMON and IBUFDS pips
                 cmt_clock_used = True
                 clock_name = cmt_clock_sources.get_random_source(cmt)
-            elif chance > 0.3 and chance < 0.4 and use_ibufds:
+            elif chance > 0.2 and chance < 0.4 and use_ibufds:
                 clock_name = ibufds_clock_sources.get_random_source(cmt)
             elif chance < 0.7 and use_gtp_channel:
                 clock_name = gtp_channel_clock_sources.get_random_source(cmt)

--- a/fuzzers/065b-gtp-common-pips/Makefile
+++ b/fuzzers/065b-gtp-common-pips/Makefile
@@ -1,0 +1,62 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+export FUZDIR=$(shell pwd)
+PIP_TYPE?=gtp_common_mid_${XRAY_PART}
+PIP_FILE?=gtp_common_mid_ck_mux
+SEG_TYPE?=gtp_common_mid_left
+PIPLIST_TCL=$(FUZDIR)/gtp_common_pip_list.tcl
+
+BUILD_DIR = ${FUZDIR}/build_${XRAY_PART}
+RUN_OK = run.${XRAY_PART}.ok
+
+TODO_RE=".*HCLK_GTP_CK_MUX.*"
+PIP_DIR=${XRAY_FUZZERS_DIR}/piplist/build/$(PIP_TYPE)
+
+MAKETODO_FLAGS=--pip-type ${PIP_FILE} --seg-type $(SEG_TYPE) --re $(TODO_RE) --sides "" --pip-dir $(PIP_DIR)
+N = 20
+
+SEGMATCH_FLAGS=-c 3
+SPECIMENS_DEPS=$(BUILD_DIR)/cmt_regions.csv
+A_PIPLIST=gtp_common_mid_ck_mux.txt
+
+CHECK_ARGS= --zero-entries --timeout-iters 5 --todo-dir $(BUILD_DIR)/todo
+
+include ../pip_loop.mk
+
+$(BUILD_DIR)/segbits_gtp_common.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} ${SEGMATCH_FLAGS} -o $(BUILD_DIR)/segbits_gtp_common.rdb \
+		$(shell find $(BUILD_DIR) -name segdata_gtp_common*.txt)
+
+RDBS = $(BUILD_DIR)/segbits_gtp_common.rdb
+
+database: ${RDBS}
+	${XRAY_DBFIXUP} --db-root $(BUILD_DIR) --zero-db bits.dbf \
+		--seg-fn-in $(BUILD_DIR)/segbits_gtp_common.rdb \
+		--seg-fn-out $(BUILD_DIR)/segbits_gtp_common.db
+
+	# Keep a copy to track iter progress
+	cp $(BUILD_DIR)/segbits_gtp_common.rdb $(BUILD_DIR)/$(ITER)/segbits_gtp_common.rdb
+	cp $(BUILD_DIR)/segbits_gtp_common.db $(BUILD_DIR)/$(ITER)/segbits_gtp_common.db
+
+	# Clobber existing .db to eliminate potential conflicts
+	cp ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/segbits*.db $(BUILD_DIR)/database/${XRAY_DATABASE}
+	XRAY_DATABASE_DIR=$(BUILD_DIR)/database ${XRAY_MERGEDB} gtp_common_mid_left $(BUILD_DIR)/segbits_gtp_common.db
+	XRAY_DATABASE_DIR=$(BUILD_DIR)/database ${XRAY_MERGEDB} gtp_common_mid_right $(BUILD_DIR)/segbits_gtp_common.db
+
+$(BUILD_DIR)/cmt_regions.csv: output_cmt.tcl
+	mkdir -p $(BUILD_DIR)
+	cd $(BUILD_DIR)/ && ${XRAY_VIVADO} -mode batch -source ${FUZDIR}/output_cmt.tcl
+
+clean_all:
+	rm -rf build_* run.*.ok
+
+pushdb: database
+	${XRAY_MERGEDB} gtp_common_mid_left $(BUILD_DIR)/segbits_gtp_common.db
+	${XRAY_MERGEDB} gtp_common_mid_right $(BUILD_DIR)/segbits_gtp_common.db
+
+.PHONY: database pushdb run clean

--- a/fuzzers/065b-gtp-common-pips/generate.py
+++ b/fuzzers/065b-gtp-common-pips/generate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+from prjxray.segmaker import Segmaker
+import os
+import os.path
+
+
+def bitfilter(frame, word):
+    word = int(word / 32)
+
+    # Clock-related PIPs in the GTP_COMMON_MID_[LEFT|RIGHT] have bits
+    # from frame 0 to 7, hence, all the other frames are skipped.
+    if frame not in [0, 1, 2, 3, 4, 5, 6, 7]:
+        return False
+
+    # All the Clock-related PIPs have bits at word 50 in the GTP_COMMON tile.
+    # Filter out all bits not belonging to word 50.
+    if word != 50:
+        return False
+
+    return True
+
+
+def read_pip_data(pipfile, pipdata, tile_ports):
+    part = os.getenv('XRAY_PART')
+    with open(os.path.join(os.getenv('FUZDIR'), '..', 'piplist', 'build',
+                           'gtp_common_mid_{}'.format(part), pipfile)) as f:
+        for l in f:
+            tile_type, dst, src = l.strip().split('.')
+            if tile_type not in pipdata:
+                pipdata[tile_type] = []
+                tile_ports[tile_type] = set()
+
+            pipdata[tile_type].append((src, dst))
+            tile_ports[tile_type].add(src)
+            tile_ports[tile_type].add(dst)
+
+
+def main():
+    segmk = Segmaker("design.bits")
+
+    tiledata = {}
+    pipdata = {}
+    ignpip = set()
+    tile_ports = {}
+
+    read_pip_data('gtp_common_mid_ck_mux.txt', pipdata, tile_ports)
+
+    print("Loading tags from design.txt.")
+    with open("design.txt", "r") as f:
+        for line in f:
+            tile, pip, src, dst, pnum, pdir = line.split()
+
+            if not tile.startswith('GTP_COMMON_MID'):
+                continue
+
+            pip_prefix, _ = pip.split(".")
+            tile_from_pip, tile_type = pip_prefix.split('/')
+            assert tile == tile_from_pip
+            _, src = src.split("/")
+            _, dst = dst.split("/")
+            pnum = int(pnum)
+            pdir = int(pdir)
+
+            if tile not in tiledata:
+                tiledata[tile] = {
+                    "type": tile_type,
+                    "pips": set(),
+                    "srcs": set(),
+                    "dsts": set()
+                }
+
+            tiledata[tile]["pips"].add((src, dst))
+            tiledata[tile]["srcs"].add(src)
+            tiledata[tile]["dsts"].add(dst)
+
+            if pdir == 0:
+                tiledata[tile]["srcs"].add(dst)
+                tiledata[tile]["dsts"].add(src)
+
+            if "HCLK_GTP_CK_MUX" not in src:
+                ignpip.add((src, dst))
+
+    for tile, pips_srcs_dsts in tiledata.items():
+        tile_type = pips_srcs_dsts["type"]
+        pips = pips_srcs_dsts["pips"]
+
+        for src, dst in pipdata["GTP_COMMON"]:
+            if (src, dst) in ignpip:
+                pass
+            elif (src, dst) in pips:
+                segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 1)
+            elif src not in tiledata[tile]["srcs"] and dst not in tiledata[
+                    tile]["dsts"]:
+                segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
+
+    segmk.compile(bitfilter=bitfilter)
+    segmk.write()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/065b-gtp-common-pips/generate.tcl
+++ b/fuzzers/065b-gtp-common-pips/generate.tcl
@@ -1,0 +1,206 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+source "$::env(XRAY_DIR)/utils/utils.tcl"
+
+proc load_todo {{dir "dst"}} {
+    set fp [open "../../todo_all.txt" r]
+
+    # Create map of pip source to remaining destinations for that pip
+    set todo_map [dict create]
+    for {gets $fp line} {$line != ""} {gets $fp line} {
+        set parts [split $line .]
+        if {$dir == "dsts"} {
+            dict lappend todo_map [lindex $parts 2] [list [lindex $parts 0] [lindex $parts 1]]
+        } elseif {$dir == "srcs"} {
+            dict lappend todo_map [lindex $parts 1] [list [lindex $parts 0] [lindex $parts 2]]
+        } else {
+            error "Incorrect argument. Available options: src, dst"
+        }
+    }
+    close $fp
+    return $todo_map
+}
+
+proc shuffle_list {list} {
+    set l [llength $list]
+    for {set i 0} {$i<=$l} {incr i} {
+        set x [lindex $list [set p [expr {int(rand()*$l)}]]]
+        set list [lreplace $list $p $p]
+        set list [linsert $list [expr {int(rand()*$l)}] $x]
+    }
+
+    return $list
+}
+
+# Get the dictionary of nets with one corresponding source wire
+# of a PIP from the todo list
+proc get_nets_with_todo_pip_wires {direction net_regexp wire_regexp {verbose false}} {
+    set todo_map [load_todo $direction]
+    set nets [get_nets]
+    set todo_nets [dict create]
+
+    foreach net $nets {
+        if {![regexp $net_regexp $net]} {
+            continue
+        }
+        # Check to see if this net is one we are interested in*
+        set wires [get_wires -of_objects $net -filter {TILE_NAME =~ "*GTP_COMMON_MID*" && NAME =~ "*CK_IN*"} -quiet]
+
+        set wire_found 0
+        foreach wire $wires {
+            if [regexp $wire_regexp $wire] {
+                set wire_found 1
+                break
+            }
+        }
+
+        if {$wire_found == 0} {
+            if {$verbose} {
+                puts "$net not going to a GTP common wire, skipping."
+            }
+            continue
+        }
+
+        set tile [lindex [split $wire /] 0]
+        set wire [lindex [split $wire /] 1]
+        set tile_type [get_property TILE_TYPE [get_tiles $tile]]
+
+        dict set todo_nets $net [list $tile $wire]
+    }
+
+    return $todo_nets
+}
+
+proc route_todo {} {
+    set verbose false
+
+    set used_destinations [dict create]
+
+    # Re-route CMT-related nets, which are originated from the fabric's PLL/MMCM primitives
+    set todo_map [load_todo "srcs"]
+    set pll_nets [get_nets_with_todo_pip_wires "srcs" "pll_clock" "HCLK_GTP_CK_IN" $verbose]
+    set mmcm_nets [get_nets_with_todo_pip_wires "srcs" "mmcm_clock" "HCLK_GTP_CK_IN" $verbose]
+    set cmt_nets [dict merge $pll_nets $mmcm_nets]
+    puts "CMT nets: $cmt_nets"
+    dict for {net tile_wire} $cmt_nets {
+        route_design -unroute -nets $net
+    }
+
+    dict for {net tile_wire} $cmt_nets {
+        set tile [lindex $tile_wire 0]
+        set wire [lindex $tile_wire 1]
+        set dsts [dict keys $todo_map]
+        set tile_type [get_property TILE_TYPE [get_tiles $tile]]
+        set todos {}
+
+        # All clock nets which have a source belonging to a PLL/MMCM tile can be routed to any
+        # HCLK_GTP_CK_MUX --> HCLK_GTP_CK_IN wire pair, hence we build a list of all the remaining
+        # PIPs to choose from.
+        puts "Rerouting net $net at $tile / $wire (type $tile_type)"
+
+        foreach dst $dsts {
+            set srcs [dict get $todo_map $dst]
+            foreach src $srcs {
+                # For each HCLK_GTP_CK_IN wire, get the source node (HCLK_GTP_CK_MUX) from the todo_map
+                # that still needs to be documented.
+                #
+                # Each HCLK_GTP_CK_IN has two possible HCLK_GTP_CK_MUX sources to be paired with.
+                set src_wire [lindex $src 1]
+
+                set wire_pairs [list $src_wire $dst]
+                lappend todos $wire_pairs
+            }
+        }
+
+        set todos_length [llength $todos]
+        if {$todos_length == 0} {
+            continue
+        }
+
+        puts "All todos for $tile_type / $wire"
+        foreach src_wire $todos {
+            puts "  - $src_wire"
+        }
+
+        set todos [shuffle_list $todos]
+
+        set target_node [get_nodes -of_objects [get_site_pins -filter {DIRECTION == IN} -of_objects $net]]
+        puts "Target node: $target_node"
+        route_design -unroute -nets $net
+
+        # Find an output in the todo list that can drive.
+        foreach wire_pair $todos {
+
+            set src_wire [lindex $wire_pair 0]
+            set dst_wire [lindex $wire_pair 1]
+
+            set used_dst_wire [dict exists $used_destinations "$tile/$dst_wire"]
+            set used_src_wire [dict exists $used_destinations "$tile/$src_wire"]
+
+            # If one between MUX or IN wire pairs is already used, skip this todo
+            if { $used_dst_wire || $used_src_wire } {
+                puts "Not routing to $tile / $src_wire or $dst_wire, in use."
+                continue
+            }
+
+            set origin_src_wire [get_wires "$tile/$src_wire"]
+            set origin_src_node [get_nodes -of_objects $origin_src_wire]
+            if {[llength $origin_src_node] == 0} {
+                error "Failed to find node for $tile/$src_wire."
+            }
+
+            set origin_dst_wire [get_wires "$tile/$dst_wire"]
+            set origin_dst_node [get_nodes -of_objects $origin_dst_wire]
+            if {[llength $origin_dst_node] == 0} {
+                error "Failed to find node for $tile/$dst_wire."
+            }
+
+            # Route the net through the desired node
+            puts "Attempting to route to $src_wire and $dst_wire for net $net."
+            route_via $net [list $origin_src_node $origin_dst_node]
+
+            puts "Target node: $target_node"
+            puts "Origin src wire: $origin_src_wire"
+            puts "Origin src node: $origin_src_node"
+            puts "Origin dst wire: $origin_dst_wire"
+            puts "Origin dst node: $origin_dst_node"
+
+            dict set used_destinations "$origin_dst_wire" 1
+            dict set used_destinations "$origin_src_wire" 1
+
+            break
+        }
+    }
+}
+
+proc run {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-123}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-161}]
+
+    set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets]
+
+    place_design -directive Quick
+    route_design -directive Quick
+    route_todo
+    route_design
+
+
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+    write_pip_txtdata design.txt
+}
+
+run

--- a/fuzzers/065b-gtp-common-pips/gtp_common_pip_list.tcl
+++ b/fuzzers/065b-gtp-common-pips/gtp_common_pip_list.tcl
@@ -1,0 +1,50 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+proc print_tile_pips {tile_type filename} {
+    set fp [open $filename w]
+    set pips [dict create]
+    foreach tile [get_tiles -filter "TYPE == $tile_type"] {
+        foreach pip [lsort [get_pips -of_objects  $tile]] {
+            set src [get_wires -uphill -of_objects $pip]
+            set dst [get_wires -downhill -of_objects $pip]
+
+            # Skip pips with disconnected nodes
+            set src_node [get_nodes -of_objects $src]
+
+            if { $src_node == {} } {
+                continue
+            }
+
+            set dst_node [get_nodes -of_objects $dst]
+            if { $dst_node == {} } {
+                continue
+            }
+
+            set dst_wire [regsub {.*/} $dst ""]
+            set dst_hclk_match [regexp {HCLK_GTP_CK_IN[0-9]+} $dst_wire]
+
+            set src_wire [regsub {.*/} $src ""]
+            set src_cmt_match [regexp {HCLK_GTP_CK_MUX[0-9]+} $src_wire]
+
+            if { $dst_hclk_match && $src_cmt_match } {
+                set pip_string "GTP_COMMON.[regsub {.*/} $dst ""].[regsub {.*/} $src ""]"
+                if ![dict exists $pips $pip_string] {
+                    puts $fp $pip_string
+                    dict set pips $pip_string 1
+                }
+            }
+        }
+    }
+    close $fp
+}
+
+create_project -force -part $::env(XRAY_PART) design design
+set_property design_mode PinPlanning [current_fileset]
+open_io_design -name io_1
+
+print_tile_pips GTP_COMMON_MID_LEFT gtp_common_mid_ck_mux.txt

--- a/fuzzers/065b-gtp-common-pips/output_cmt.tcl
+++ b/fuzzers/065b-gtp-common-pips/output_cmt.tcl
@@ -1,0 +1,18 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+create_project -force -part $::env(XRAY_PART) design design
+set_property design_mode PinPlanning [current_fileset]
+open_io_design -name io_1
+
+set fp [open "cmt_regions.csv" "w"]
+foreach site_type {MMCME2_ADV GTPE2_COMMON PLLE2_ADV BUFHCE} {
+    foreach site [get_sites -filter "SITE_TYPE == $site_type"] {
+        puts $fp "$site,[get_property CLOCK_REGION $site]"
+    }
+}
+close $fp

--- a/fuzzers/065b-gtp-common-pips/top.py
+++ b/fuzzers/065b-gtp-common-pips/top.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+import os
+import random
+random.seed(int(os.getenv("SEED"), 16))
+from prjxray import util
+from prjxray.db import Database
+
+
+def read_site_to_cmt():
+    """ Yields clock sources and which CMT they route within. """
+    fuzdir = os.getenv('FUZDIR')
+    part = os.getenv('XRAY_PART')
+
+    with open(os.path.join(fuzdir, 'build_{}'.format(part),
+                           'cmt_regions.csv')) as f:
+        for l in f:
+            site, cmt = l.strip().split(',')
+            yield (site, cmt)
+
+
+class ClockSources(object):
+    """ Class for tracking clock sources.
+    """
+
+    def __init__(self, limit=14):
+        self.sources = {}
+        self.source_to_cmt = {}
+        self.used_sources_from_cmt = {}
+        self.limit = limit
+
+    def add_clock_source(self, source, cmt):
+        """ Adds a source from a specific CMT.
+
+        """
+        if cmt not in self.sources:
+            self.sources[cmt] = []
+
+        self.sources[cmt].append(source)
+        self.source_to_cmt[source] = cmt
+
+    def sources_depleted(self, cmt):
+        if cmt in self.sources:
+            if cmt not in self.used_sources_from_cmt:
+                return False
+
+            return self.sources[cmt] == self.used_sources_from_cmt[cmt]
+
+        return True
+
+    def get_random_source(self, cmt, no_repeats=True):
+        """ Get a random source that is routable to the specific CMT.
+
+        get_random_source will return a source that is either cmt='ANY',
+        cmt equal to the input CMT, or the adjecent CMT.
+
+        """
+
+        choices = []
+
+        if cmt in self.sources:
+            choices.extend(self.sources[cmt])
+
+        random.shuffle(choices)
+        for source in choices:
+
+            source_cmt = self.source_to_cmt[source]
+
+            if source_cmt not in self.used_sources_from_cmt:
+                self.used_sources_from_cmt[source_cmt] = set()
+
+            if no_repeats and source in self.used_sources_from_cmt[source_cmt]:
+                continue
+
+            if len(self.used_sources_from_cmt[source_cmt]) >= self.limit:
+                continue
+
+            self.used_sources_from_cmt[source_cmt].add(source)
+            return source
+
+        return None
+
+
+def print_bufhce(name, net):
+    print(
+        """
+(* KEEP, DONT_TOUCH, LOC="{site}" *)
+BUFHCE {site} (
+.I({clock})
+);""".format(site=name, clock=net))
+
+
+def main():
+    """
+    GTP_COMMON_MID has clock pips from:
+
+    14 clocks lines from the HROW spine
+    """
+
+    cmt_clock_sources = ClockSources()
+    site_to_cmt = dict(read_site_to_cmt())
+    clock_region_limit = dict()
+    clock_region_serdes_location = dict()
+
+    db = Database(util.get_db_root(), util.get_part())
+    grid = db.grid()
+
+    def gen_sites(desired_site_type):
+        for tile_name in sorted(grid.tiles()):
+            loc = grid.loc_of_tilename(tile_name)
+            gridinfo = grid.gridinfo_at_loc(loc)
+            for site, site_type in gridinfo.sites.items():
+                if site_type == desired_site_type:
+                    yield tile_name, site
+
+    clock_region_sites = set()
+
+    def get_clock_region_site(site_type, clk_reg):
+        for site_name, reg in site_to_cmt.items():
+            if site_name.startswith(site_type) and reg in clk_reg:
+                if site_name not in clock_region_sites:
+                    clock_region_sites.add(site_name)
+                    return site_name
+
+    cmt_with_gtp = set()
+    for tile_name, site in gen_sites('GTPE2_COMMON'):
+        cmt_with_gtp.add(site_to_cmt[site])
+
+    print('''module top();
+
+(* KEEP, DONT_TOUCH *)
+LUT6 dummy();
+''')
+
+    for _, site in gen_sites('MMCME2_ADV'):
+        if site_to_cmt[site] not in cmt_with_gtp:
+            continue
+
+        mmcm_clocks = [
+            'mmcm_clock_{site}_{idx}'.format(site=site, idx=idx)
+            for idx in range(7)
+        ]
+
+        for clk in mmcm_clocks:
+            cmt_clock_sources.add_clock_source(clk, site_to_cmt[site])
+
+        print(
+            """
+    wire cin1_{site}, cin2_{site}, {c0}, {c1}, {c2}, {c3}, {c4}, {c5};
+    (* KEEP, DONT_TOUCH, LOC = "{site}" *)
+    MMCME2_ADV pll_{site} (
+        .CLKIN1(cin1_{site}),
+        .CLKIN2(cin2_{site}),
+        .CLKOUT0({c0}),
+        .CLKOUT1({c1}),
+        .CLKOUT2({c2}),
+        .CLKOUT3({c3}),
+        .CLKOUT4({c4}),
+        .CLKOUT5({c5}),
+        .CLKOUT6({c6})
+    );""".format(
+                site=site,
+                c0=mmcm_clocks[0],
+                c1=mmcm_clocks[1],
+                c2=mmcm_clocks[2],
+                c3=mmcm_clocks[3],
+                c4=mmcm_clocks[4],
+                c5=mmcm_clocks[5],
+                c6=mmcm_clocks[6]))
+
+    for _, site in gen_sites('PLLE2_ADV'):
+        if site_to_cmt[site] not in cmt_with_gtp:
+            continue
+
+        pll_clocks = [
+            'pll_clock_{site}_{idx}'.format(site=site, idx=idx)
+            for idx in range(7)
+        ]
+
+        for clk in pll_clocks:
+            cmt_clock_sources.add_clock_source(clk, site_to_cmt[site])
+
+        print(
+            """
+    wire cin1_{site}, cin2_{site}, clkfbin_{site}, {c0}, {c1}, {c2}, {c3}, {c4}, {c5}, {c6};
+    (* KEEP, DONT_TOUCH, LOC = "{site}" *)
+    PLLE2_ADV pll_{site} (
+        .CLKIN1(cin1_{site}),
+        .CLKIN2(cin2_{site}),
+        .CLKFBIN(clkfbin_{site}),
+        .CLKOUT0({c0}),
+        .CLKOUT1({c1}),
+        .CLKOUT2({c2}),
+        .CLKOUT3({c3}),
+        .CLKOUT4({c4}),
+        .CLKOUT5({c5}),
+        .CLKFBOUT({c6})
+    );""".format(
+                site=site,
+                c0=pll_clocks[0],
+                c1=pll_clocks[1],
+                c2=pll_clocks[2],
+                c3=pll_clocks[3],
+                c4=pll_clocks[4],
+                c5=pll_clocks[5],
+                c6=pll_clocks[6],
+            ))
+
+    for cmt in cmt_with_gtp:
+        for _, bufhce in gen_sites('BUFHCE'):
+            if site_to_cmt[bufhce] != cmt:
+                continue
+
+            if random.random() < 0.7:
+                clock_name = cmt_clock_sources.get_random_source(cmt)
+            else:
+                continue
+
+            if clock_name is None:
+                continue
+
+            print_bufhce("{}".format(bufhce), clock_name)
+
+    print('endmodule')
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -161,6 +161,7 @@ $(eval $(call fuzzer,061-pcie-conf,005-tilegrid,all))
 $(eval $(call fuzzer,063-gtp-common-conf,005-tilegrid,part))
 $(eval $(call fuzzer,064-gtp-channel-conf,005-tilegrid,part))
 $(eval $(call fuzzer,065-gtp-common-pips,005-tilegrid,part))
+$(eval $(call fuzzer,065b-gtp-common-pips,005-tilegrid,part))
 $(eval $(call fuzzer,066-gtp-int-pips,005-tilegrid,all))
 endif
 endif


### PR DESCRIPTION
This PR splits the 065-gtp-common-pips fuzzer in two, due to a difference in the number of bits for the PIPs, the TODO lists that needed to be generated, as well as the piplist.

The GTP_COMMON pips can be divided in two categories:

- PIPs connecting GTP_CHANNEL and IBUFDS_GTE2 wires to the clock spine
- PIPs connecting clock wires from the CMT

The second kind of PIPs has three bits, which are missed with the previous version of the fuzzer.