### PR TITLE
063-gtp-common-conf: add DRP_ENABLE feature

### DIFF
--- a/fuzzers/063-gtp-common-conf/generate.tcl
+++ b/fuzzers/063-gtp-common-conf/generate.tcl
@@ -17,6 +17,7 @@ proc run {} {
     set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
     set_property IS_ENABLED 0 [get_drc_checks {UCIO-1}]
     set_property IS_ENABLED 0 [get_drc_checks {REQP-48}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-47}]
     set_property IS_ENABLED 0 [get_drc_checks {REQP-1619}]
 
     place_design


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR enables a feature that is triggered on specific connectivity of the DRP (Dynamic Reconfiguration Port) port in the GTP_CHANNEL primitives.

Basically, this feature should enable the DRP for all of the tiles in the column, as the bits appear in the words belonging to the GTP_COMMON tile.

It is enough to have one only GTP_CHANNEL primitive with all the required DRP ports connected accordingly, to enable this feature.