### PR TITLE
065-gtp-common-pips: fix overlapping piplist project names

### DIFF
--- a/fuzzers/065-gtp-common-pips/gtp_common_pip_list.tcl
+++ b/fuzzers/065-gtp-common-pips/gtp_common_pip_list.tcl
@@ -42,7 +42,7 @@ proc print_tile_pips {tile_type filename} {
     close $fp
 }
 
-create_project -force -part $::env(XRAY_PART) design design
+create_project -force -part $::env(XRAY_PART) design_gtp_ibufds design_gtp_ibufds
 set_property design_mode PinPlanning [current_fileset]
 open_io_design -name io_1
 

--- a/fuzzers/065b-gtp-common-pips/gtp_common_pip_list.tcl
+++ b/fuzzers/065b-gtp-common-pips/gtp_common_pip_list.tcl
@@ -43,7 +43,7 @@ proc print_tile_pips {tile_type filename} {
     close $fp
 }
 
-create_project -force -part $::env(XRAY_PART) design design
+create_project -force -part $::env(XRAY_PART) design_ck_mux design_ck_mux
 set_property design_mode PinPlanning [current_fileset]
 open_io_design -name io_1
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This fixes an issue discovered in [this master CI build](https://source.cloud.google.com/results/invocations/7379c769-f46e-440a-8777-8d34c075860e).

065- and 065b-gtp-common-pips share the piplist directory and the vivado project needs to be located in separate directories.