### PR TITLE
030-iob: increase fuzzer efficiency

### DIFF
--- a/fuzzers/030-iob/Makefile
+++ b/fuzzers/030-iob/Makefile
@@ -5,7 +5,7 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
-N := 50
+N := 20
 SPECIMENS_DEPS := build/iobanks.txt
 include ../fuzzer.mk
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR lets choose a different I/O settings for each bank instead of each specimen. This way we need less specimens.

Given that there are quite some I/O settings missing, this enhancement is required to keep the number of specimens low also for when other settings will be added.