### PR TITLE
101-dsp-pips: solve DSP-related PIPs

### DIFF
--- a/fuzzers/101-dsp-pips/Makefile
+++ b/fuzzers/101-dsp-pips/Makefile
@@ -1,0 +1,61 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+export FUZDIR=$(shell pwd)
+PIP_TYPE?=dsp
+PIPLIST_TCL=$(FUZDIR)/dsp_pip_list.tcl
+
+BUILD_DIR = build
+RUN_OK = run.ok
+
+TODO_RE=".*"
+
+MAKETODO_FLAGS=--pip-type ${PIP_TYPE} --seg-type $(PIP_TYPE) --re $(TODO_RE) --sides "l,r"
+N = 1
+
+SEGMATCH_FLAGS=-c 1
+
+A_PIPLIST=dsp_l.txt
+
+CHECK_ARGS= --zero-entries --timeout-iters 2
+
+include ../pip_loop.mk
+
+$(BUILD_DIR)/segbits_dsp_l.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} ${SEGMATCH_FLAGS} -o $(BUILD_DIR)/segbits_dsp_l.rdb \
+		$(shell find $(BUILD_DIR) -name segdata_dsp_l.txt)
+
+$(BUILD_DIR)/segbits_dsp_r.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} ${SEGMATCH_FLAGS} -o $(BUILD_DIR)/segbits_dsp_r.rdb \
+		$(shell find $(BUILD_DIR) -name segdata_dsp_r.txt)
+
+RDBS = $(BUILD_DIR)/segbits_dsp_l.rdb $(BUILD_DIR)/segbits_dsp_r.rdb
+
+database: ${RDBS}
+	${XRAY_DBFIXUP} --db-root $(BUILD_DIR) --zero-db bits.dbf \
+		--seg-fn-in $(BUILD_DIR)/segbits_dsp_l.rdb \
+		--seg-fn-out $(BUILD_DIR)/segbits_dsp_l.db
+	${XRAY_DBFIXUP} --db-root $(BUILD_DIR) --zero-db bits.dbf \
+		--seg-fn-in $(BUILD_DIR)/segbits_dsp_r.rdb \
+		--seg-fn-out $(BUILD_DIR)/segbits_dsp_r.db
+
+	# Keep a copy to track iter progress
+	cp $(BUILD_DIR)/segbits_dsp_l.rdb $(BUILD_DIR)/$(ITER)/segbits_dsp_l.rdb
+	cp $(BUILD_DIR)/segbits_dsp_l.db $(BUILD_DIR)/$(ITER)/segbits_dsp_l.db
+	cp $(BUILD_DIR)/segbits_dsp_r.rdb $(BUILD_DIR)/$(ITER)/segbits_dsp_r.rdb
+	cp $(BUILD_DIR)/segbits_dsp_r.db $(BUILD_DIR)/$(ITER)/segbits_dsp_r.db
+
+	# Clobber existing .db to eliminate potential conflicts
+	cp ${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/segbits*.db $(BUILD_DIR)/database/${XRAY_DATABASE}
+	XRAY_DATABASE_DIR=$(BUILD_DIR)/database ${XRAY_MERGEDB} dsp_l $(BUILD_DIR)/segbits_dsp_l.db
+	XRAY_DATABASE_DIR=$(BUILD_DIR)/database ${XRAY_MERGEDB} dsp_r $(BUILD_DIR)/segbits_dsp_r.db
+
+pushdb: database
+	${XRAY_MERGEDB} dsp_l $(BUILD_DIR)/segbits_dsp_l.db
+	${XRAY_MERGEDB} dsp_r $(BUILD_DIR)/segbits_dsp_r.db
+
+.PHONY: database pushdb run clean

--- a/fuzzers/101-dsp-pips/dsp_pip_list.tcl
+++ b/fuzzers/101-dsp-pips/dsp_pip_list.tcl
@@ -1,0 +1,45 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+proc print_tile_pips {tile_type filename} {
+    set fp [open $filename w]
+    set pips [dict create]
+    foreach tile [get_tiles -filter "TYPE =~ $tile_type*"] {
+        foreach pip [lsort [get_pips -of_objects  $tile]] {
+            set src [get_wires -uphill -of_objects $pip]
+            set dst [get_wires -downhill -of_objects $pip]
+
+            # Skip pips with disconnected nodes
+            set src_node [get_nodes -of_objects $src]
+
+            if { $src_node == {} || !([regexp "VCC" $src_node] || [regexp "GND" $src_node]) } {
+                continue
+            }
+
+            set dst_node [get_nodes -of_objects $dst]
+            if { $dst_node == {} } {
+                continue
+            }
+
+            if { [llength [get_nodes -uphill -of_objects [get_nodes -of_objects $dst]]] != 1 } {
+                set pip_string "$tile_type.[regsub {.*/} $dst ""].[regsub {.*/} $src ""]"
+                if ![dict exists $pips $pip_string] {
+                    puts $fp $pip_string
+                    dict set pips $pip_string 1
+                }
+            }
+        }
+    }
+    close $fp
+}
+
+create_project -force -part $::env(XRAY_PART) design design
+set_property design_mode PinPlanning [current_fileset]
+open_io_design -name io_1
+
+print_tile_pips DSP_R dsp_r.txt
+print_tile_pips DSP_L dsp_l.txt

--- a/fuzzers/101-dsp-pips/generate.py
+++ b/fuzzers/101-dsp-pips/generate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+from prjxray.segmaker import Segmaker
+import os
+import os.path
+
+
+def bitfilter(frame, word):
+    if frame not in [26, 27]:
+        return False
+
+    return True
+
+
+def read_pip_data(pipfile, pipdata, tile_ports):
+    with open(os.path.join(os.getenv('FUZDIR'), '..', 'piplist', 'build',
+                           'dsp', pipfile)) as f:
+        for l in f:
+            tile_type, dst, src = l.strip().split('.')
+            if tile_type not in pipdata:
+                pipdata[tile_type] = []
+                tile_ports[tile_type] = set()
+
+            pipdata[tile_type].append((src, dst))
+            tile_ports[tile_type].add(src)
+            tile_ports[tile_type].add(dst)
+
+
+def main():
+    segmk = Segmaker("design.bits")
+
+    tiledata = {}
+    pipdata = {}
+    ignpip = set()
+    tile_ports = {}
+
+    read_pip_data('dsp_r.txt', pipdata, tile_ports)
+    read_pip_data('dsp_l.txt', pipdata, tile_ports)
+
+    print("Loading tags from design.txt.")
+    with open("design.txt", "r") as f:
+        for line in f:
+            tile, pip, src, dst, pnum, pdir = line.split()
+
+            if not tile.startswith('DSP'):
+                continue
+
+            pip_prefix, _ = pip.split(".")
+            tile_from_pip, tile_type = pip_prefix.split('/')
+            assert tile == tile_from_pip
+            _, src = src.split("/")
+            _, dst = dst.split("/")
+            pnum = int(pnum)
+            pdir = int(pdir)
+
+            if tile not in tiledata:
+                tiledata[tile] = {
+                    "type": tile_type,
+                    "pips": set(),
+                    "srcs": set(),
+                    "dsts": set()
+                }
+
+            tiledata[tile]["pips"].add((src, dst))
+            tiledata[tile]["srcs"].add(src)
+            tiledata[tile]["dsts"].add(dst)
+
+            if pdir == 0:
+                tiledata[tile]["srcs"].add(dst)
+                tiledata[tile]["dsts"].add(src)
+
+    for tile, pips_srcs_dsts in tiledata.items():
+        tile_type = pips_srcs_dsts["type"]
+        pips = pips_srcs_dsts["pips"]
+
+        for src, dst in pipdata[tile_type]:
+            if (src, dst) in ignpip:
+                pass
+            elif (src, dst) in pips:
+                segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 1)
+            else:
+                segmk.add_tile_tag(tile, "%s.%s" % (dst, src), 0)
+
+    segmk.compile(bitfilter=bitfilter)
+    segmk.write()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/101-dsp-pips/generate.tcl
+++ b/fuzzers/101-dsp-pips/generate.tcl
@@ -1,0 +1,35 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+source "$::env(XRAY_DIR)/utils/utils.tcl"
+
+proc run {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+    set_property IS_ENABLED 0 [get_drc_checks {DSPS-1}]
+    set_property IS_ENABLED 0 [get_drc_checks {DSPS-3}]
+    set_property IS_ENABLED 0 [get_drc_checks {DSPS-5}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-21}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-25}]
+
+    set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets]
+
+    place_design -directive Quick
+    route_design -directive Quick
+
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+    write_pip_txtdata design.txt
+}
+
+run

--- a/fuzzers/101-dsp-pips/ports.py
+++ b/fuzzers/101-dsp-pips/ports.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+ports = {
+    "DSP48E1": [
+        ("ALUMODE", 4),
+        ("CARRYINSEL", 3),
+        ("CEAD", 1),
+        ("CEALUMODE", 1),
+        ("CED", 1),
+        ("CEINMODE", 1),
+        ("D", 25),
+        ("INMODE", 5),
+        ("OPMODE", 7),
+        ("RSTD", 1),
+    ],
+}

--- a/fuzzers/101-dsp-pips/top.py
+++ b/fuzzers/101-dsp-pips/top.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+import os
+import random
+import math
+random.seed(int(os.getenv("SEED"), 16))
+from prjxray import util
+from prjxray.lut_maker import LutMaker
+from prjxray.db import Database
+
+from ports import ports
+
+
+def print_site(ports, luts, site, site_type):
+    verilog_ports = ""
+    verilog_wires = ""
+
+    for port, width in ports:
+        verilog_ports += """
+    .{port}({port}_{site}),""".format(
+            port=port, site=site)
+        verilog_wires += "wire [{}:0] {}_{};\n".format(width - 1, port, site)
+
+        for idx in range(0, width):
+            rand = random.random()
+
+            if rand < 0.45:
+                source = "1'b0"
+            elif rand < 0.9:
+                source = "1'b1"
+            else:
+                source = luts.get_next_output_net()
+
+            verilog_wires += "assign {}_{}[{}] = {};\n".format(
+                port, site, idx, source)
+
+        verilog_wires += "\n"
+
+    verilog_ports = verilog_ports.rstrip(",")
+
+    print(
+        """
+{wires}
+
+(* KEEP, DONT_TOUCH, LOC = "{site}" *)
+{site_type} #(.AREG(2), .BREG(2)) {site}_instance (
+{ports}
+);""".format(
+            wires=verilog_wires,
+            ports=verilog_ports,
+            site=site,
+            site_type=site_type))
+
+
+def main():
+    db = Database(util.get_db_root(), util.get_part())
+    grid = db.grid()
+
+    luts = LutMaker()
+
+    def gen_sites(desired_site_type):
+        for tile_name in sorted(grid.tiles()):
+            loc = grid.loc_of_tilename(tile_name)
+            gridinfo = grid.gridinfo_at_loc(loc)
+            for site, site_type in gridinfo.sites.items():
+                if site_type == desired_site_type:
+                    yield tile_name, site
+
+    print('''
+module top();
+
+    (* KEEP, DONT_TOUCH *)
+    LUT6 dummy();
+''')
+
+    for site_type in ["DSP48E1"]:
+        for _, site in gen_sites(site_type):
+            print_site(ports[site_type], luts, site, site_type)
+
+    for l in luts.create_wires_and_luts():
+        print(l)
+
+    print('endmodule')
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -168,6 +168,7 @@ endif
 endif
 endif
 $(eval $(call fuzzer,100-dsp-mskpat,005-tilegrid,all))
+$(eval $(call fuzzer,101-dsp-pips,005-tilegrid,all))
 
 quick:
 	$(MAKE) QUICK=Y


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The DSP tiles have `TIEOFF` sites which can be used instead of the INT `TIEOFF`s. These "internal" `TIEOFF`s add some extra PIPs for some of the DSP inputs.

This fuzzer documents these GND and VCC PIPs.