### PR TITLE
005-tilegrid: fix GTP common frames

### DIFF
--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -108,7 +108,7 @@ def run(fn_in, fn_out, verbose=False):
         ("hclk_cmt", 30, 10),
         ("hclk_ioi", 42, 1),
         ("pcie", 36, 101),
-        ("gtp_common", 42, 101),
+        ("gtp_common", 32, 101),
         ("gtp_channel", 32, 22),
         ("clb_int", int_frames, int_words),
         ("iob_int", int_frames, int_words),


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Changing max frames for GTP_COMMON from 42 to 32. This was causing a huge cascading errors while running fasm2frames, resulting in a bugged frames file.