### PR TITLE
005-tilegrid: Extract frames count information from part's json

### DIFF
--- a/fuzzers/005-tilegrid/add_tdb.py
+++ b/fuzzers/005-tilegrid/add_tdb.py
@@ -123,6 +123,7 @@ def run(fn_in, fn_out, verbose=False):
         ("pcie_int_interface", int_frames, int_words),
     ]
 
+    tile_frames_map = localutil.TileFrames()
     for (subdir, frames, words) in tdb_fns:
         tdb_fn = os.path.join(
             subdir, 'build_{}'.format(os.environ['XRAY_PART']),
@@ -134,7 +135,8 @@ def run(fn_in, fn_out, verbose=False):
         for (tile, frame, wordidx) in load_db(tdb_fn):
             tilej = database[tile]
             verbose and print("Add %s %08X_%03u" % (tile, frame, wordidx))
-            localutil.add_tile_bits(tile, tilej, frame, wordidx, frames, words)
+            localutil.add_tile_bits(
+                tile, tilej, frame, wordidx, frames, words, tile_frames_map)
 
     # Save
     xjson.pprint(open(fn_out, "w"), database)


### PR DESCRIPTION
This PR adds automatic frames count extraction from the `part.json` of a given part to the `005-tilegrid` fuzzer.
Porting this solution form U-Ray was mentioned in PR #1603
When the specified frames count value exceeds the maximum allowed value a warning is displayed and the value falls back to the maximum allowed.