### PR TITLE
Rework pcie-conf fuzzer

### DIFF
--- a/fuzzers/061-pcie-conf/Makefile
+++ b/fuzzers/061-pcie-conf/Makefile
@@ -5,23 +5,67 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
+
+SHELL = bash
+
 N ?= 40
 
-include ../fuzzer.mk
+BUILD_DIR = build_${XRAY_PART}
 
-database: build/segbits_pcie_bot.db
+SPECIMENS := $(addprefix ${BUILD_DIR}/specimen_,$(shell seq -f '%03.0f' $(N)))
+SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
+FUZDIR ?= ${PWD}
+CELLS_DATA_DIR = ${XRAY_FAMILY_DIR}/cells_data
 
-build/segbits_pcie_bot.rdb: $(SPECIMENS_OK)
-	${XRAY_SEGMATCH} -o build/segbits_pcie_bot.rdb $(addsuffix /segdata_pcie_bot.txt,$(SPECIMENS))
+all: database
 
-build/segbits_pcie_bot.db: build/segbits_pcie_bot.rdb
-	${XRAY_DBFIXUP} --db-root build --zero-db bits.dbf \
-		--seg-fn-in build/segbits_pcie_bot.rdb \
-		--seg-fn-out build/segbits_pcie_bot.db
-	${XRAY_MASKMERGE} build/mask_pcie_bot.db $(addsuffix /segdata_pcie_bot.txt,$(SPECIMENS))
+$(SPECIMENS_OK): $(SPECIMENS_DEPS)
+	mkdir -p ${BUILD_DIR}
+	bash ${XRAY_DIR}/utils/top_generate.sh $(subst /OK,,$@)
+
+run:
+	$(MAKE) clean
+	$(MAKE) attrs
+	$(MAKE) database
+	$(MAKE) pushdb
+	touch run.${XRAY_PART}.ok
+
+clean:
+	rm -rf ${BUILD_DIR} run.${XRAY_PART}.ok
+
+.PHONY: all run clean
+
+attrs: $(FUZDIR)/attrs.json
+
+$(FUZDIR)/attrs.json: $(FUZDIR)/params.py
+	python3 $(FUZDIR)/params.py --attrs-file $(FUZDIR)/attrs.json
+
+# These are pins that are hard to parse as a regexp given that the port name ends with a number, which is misinterpreted
+# as the index in the port bus
+SPECIAL_PINS = EDTCHANNELSIN1,EDTCHANNELSIN2,EDTCHANNELSIN3,EDTCHANNELSIN4,EDTCHANNELSIN5,EDTCHANNELSIN6,EDTCHANNELSIN7,EDTCHANNELSIN8,LL2SENDASREQL1,LL2SENDENTERL1,LL2SENDENTERL23,USERCLK2,EDTCHANNELSOUT1,EDTCHANNELSOUT2,EDTCHANNELSOUT3,EDTCHANNELSOUT4,EDTCHANNELSOUT5,EDTCHANNELSOUT6,EDTCHANNELSOUT7,EDTCHANNELSOUT8
+
+$(BUILD_DIR)/pcie_2_1_ports.csv: generate_ports.tcl
+	env FILE_NAME=$(BUILD_DIR)/pcie_2_1_pins.csv ${XRAY_VIVADO} -mode batch -source generate_ports.tcl
+
+$(BUILD_DIR)/pcie_2_1_ports.json: $(BUILD_DIR)/pcie_2_1_ports.csv
+	python3 ${XRAY_UTILS_DIR}/make_ports.py $(BUILD_DIR)/pcie_2_1_pins.csv $(BUILD_DIR)/pcie_2_1_ports.json --special-pins $(SPECIAL_PINS)
+
+database: $(BUILD_DIR)/segbits_pcie_bot.db $(BUILD_DIR)/pcie_2_1_ports.json
+
+$(BUILD_DIR)/segbits_pcie_bot.rdb: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} -o $(BUILD_DIR)/segbits_pcie_bot.rdb $(addsuffix /segdata_pcie_bot.txt,$(SPECIMENS))
+
+$(BUILD_DIR)/segbits_pcie_bot.db: $(BUILD_DIR)/segbits_pcie_bot.rdb
+	${XRAY_DBFIXUP} --db-root $(BUILD_DIR) --zero-db bits.dbf \
+		--seg-fn-in $(BUILD_DIR)/segbits_pcie_bot.rdb \
+		--seg-fn-out $(BUILD_DIR)/segbits_pcie_bot.db
+	${XRAY_MASKMERGE} $(BUILD_DIR)/mask_pcie_bot.db $(addsuffix /segdata_pcie_bot.txt,$(SPECIMENS))
 
 pushdb:
-	${XRAY_MERGEDB} pcie_bot build/segbits_pcie_bot.db
-	${XRAY_MERGEDB} mask_pcie_bot build/mask_pcie_bot.db
+	${XRAY_MERGEDB} pcie_bot $(BUILD_DIR)/segbits_pcie_bot.db
+	${XRAY_MERGEDB} mask_pcie_bot $(BUILD_DIR)/mask_pcie_bot.db
+	mkdir -p $(CELLS_DATA_DIR)
+	cp $(FUZDIR)/attrs.json $(CELLS_DATA_DIR)/pcie_2_1_attrs.json
+	cp $(BUILD_DIR)/pcie_2_1_ports.json $(CELLS_DATA_DIR)/pcie_2_1_ports.json
 
 .PHONY: database pushdb

--- a/fuzzers/061-pcie-conf/generate_ports.tcl
+++ b/fuzzers/061-pcie-conf/generate_ports.tcl
@@ -1,0 +1,36 @@
+# Copyright (C) 2017-2021  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+proc dump_pins {file_name site_prefix} {
+    set fp [open $file_name w]
+
+    puts $fp "name,is_input,is_output"
+    set site [lindex [get_sites $site_prefix*] 0]
+
+    set pins [get_site_pins -of_objects $site]
+    foreach pin $pins {
+        set connected_pip [get_pips -of_objects [get_nodes -of_objects $pin]]
+
+        if { $connected_pip == "" } {
+            continue
+        }
+
+        set pin_name [lindex [split $pin "/"] 1]
+        set is_input [get_property IS_INPUT $pin]
+        set is_output [get_property IS_OUTPUT $pin]
+
+        puts $fp "$pin_name,$is_input,$is_output"
+    }
+    close $fp
+}
+
+create_project -force -name design -part $::env(XRAY_PART)
+set_property design_mode PinPlanning [current_fileset]
+open_io_design -name io_1
+
+dump_pins $::env(FILE_NAME) PCIE

--- a/fuzzers/061-pcie-conf/params.py
+++ b/fuzzers/061-pcie-conf/params.py
@@ -9,6 +9,10 @@
 #
 # SPDX-License-Identifier: ISC
 
+import argparse
+import json
+from collections import OrderedDict
+
 boolean_params = [
     ("AER_CAP_ECRC_CHECK_CAPABLE", 1),
     ("AER_CAP_ECRC_GEN_CAPABLE", 1),
@@ -300,3 +304,37 @@ int_params = [
     ("SPARE_BIT7", 1),
     ("SPARE_BIT8", 1),
 ]
+
+
+def dump_json():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--attrs-file", help="JSON output path", required=True)
+    args = parser.parse_args()
+
+    data = OrderedDict()
+
+    # Prepare BOOL type attributes
+    for param in boolean_params:
+        data[param[0]] = {
+            "type": "BOOL",
+            "values": ["FALSE", "TRUE"],
+            "digits": param[1]
+        }
+
+    # Prepare BIN type attributes
+    for param in (hex_params + int_params):
+        data[param[0]] = {
+            "type": "BIN",
+            "values": [(1 << param[1]) - 1],
+            "digits": param[1]
+        }
+
+    data = dict(sorted(data.items()))
+
+    # Emit JSON
+    with open(args.attrs_file, "w") as f:
+        json.dump(data, f, indent=4)
+
+
+if __name__ == "__main__":
+    dump_json()


### PR DESCRIPTION
There are several changes introduced in this PR:
* Unification of the parameters used in the fuzzer. Parameters were translated to the JSON format (the same as in GTP fuzzers)
* Added generate_port script used to export JSON file with ports definitions of the PCIE_2_1 site
* Added exporting ports and attributes JSON files to prxjray-db

Depends on `make_ports.py` tool introduced in: https://github.com/SymbiFlow/prjxray/pull/1614