### PR TITLE
Add kokoro hostcheck

### DIFF
--- a/.github/kokoro/db-full.sh
+++ b/.github/kokoro/db-full.sh
@@ -11,6 +11,7 @@ set -e
 
 cd github/$KOKORO_DIR/
 
+source ./.github/kokoro/steps/hostcheck.sh
 source ./.github/kokoro/steps/hostsetup.sh
 source ./.github/kokoro/steps/hostinfo.sh
 source ./.github/kokoro/steps/git.sh

--- a/.github/kokoro/db-quick.sh
+++ b/.github/kokoro/db-quick.sh
@@ -11,6 +11,7 @@ set -e
 
 cd github/$KOKORO_DIR/
 
+source ./.github/kokoro/steps/hostcheck.sh
 source ./.github/kokoro/steps/hostsetup.sh
 source ./.github/kokoro/steps/hostinfo.sh
 source ./.github/kokoro/steps/git.sh

--- a/.github/kokoro/steps/hostcheck.sh
+++ b/.github/kokoro/steps/hostcheck.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (C) 2017-2021  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+set -e
+
+echo
+echo "========================================"
+echo "Check storage"
+echo "----------------------------------------"
+set -x +e
+mount | grep /tmpfs
+MOUNT_RET=$?
+set +x -e
+if [[ $MOUNT_RET != 0 ]] ; then
+	echo "----------------------------------------"
+	echo "Error: No storage is mounted on /tmpfs."
+	echo "----------------------------------------"
+
+	echo "========================================"
+	echo "Dmesg dump"
+	echo "----------------------------------------"
+	dmesg
+
+	exit $MOUNT_RET
+fi


### PR DESCRIPTION
Validated with a check if `/tmpfs2` is mounted:

```
========================================
Check storage
----------------------------------------
++ mount
++ grep /tmpfs2
++ MOUNT_RET=1
++ set +x -e
----------------------------------------
Error: No storage is mounted on /tmpfs.
----------------------------------------
========================================
Dmesg dump
----------------------------------------
[    0.000000] Initializing cgroup subsys cpuset
[    0.000000] Initializing cgroup subsys cpu
[    0.000000] Initializing cgroup subsys cpuacct
```