### PR TITLE
Fuzzer-071 Generates ppips for DSP

### DIFF
--- a/fuzzers/071-ppips/generate.tcl
+++ b/fuzzers/071-ppips/generate.tcl
@@ -90,6 +90,22 @@ proc write_bram_ppips_db {filename tile} {
     close $fp
 }
 
+proc write_dsp_ppips_db {filename tile} {
+    set fp [open $filename "w"]
+    set tile [get_tiles $tile]
+    set tile_type [get_property TILE_TYPE $tile]
+
+    foreach pip [get_pips -of_objects $tile] {
+        set dst_wire [get_wires -downhill -of_objects $pip]
+        if {[get_pips -uphill -of_objects [get_nodes -of_objects $dst_wire]] == $pip} {
+            set src_wire [get_wires -uphill -of_objects $pip]
+            puts $fp "${tile_type}.[regsub {.*/} $dst_wire ""].[regsub {.*/} $src_wire ""] always"
+        }
+    }
+
+    close $fp
+}
+
 proc write_hclk_ppips_db {filename tile} {
     set fp [open $filename "w"]
     set tile [get_tiles $tile]
@@ -281,6 +297,7 @@ foreach tile_type {CLBLM_L CLBLM_R CLBLL_L CLBLL_R} {
 }
 
 foreach tile_type {INT_L INT_R  BRAM_INT_INTERFACE_L BRAM_INT_INTERFACE_R \
+            DSP_INT_INTERFACE_L DSP_INT_INTERFACE_R \
             CLK_HROW_TOP_R CLK_HROW_BOT_R CLK_BUFG_TOP_R CLK_BUFG_BOT_R \
             IO_INT_INTERFACE_R IO_INT_INTERFACE_L \
             BRKH_INT HCLK_L HCLK_R HCLK_CMT \
@@ -318,6 +335,14 @@ foreach tile_type {BRAM_L BRAM_R} {
     if {[llength $tiles] != 0} {
         set tile [lindex $tiles 0]
         write_bram_ppips_db "ppips_[string tolower $tile_type].db" $tile
+    }
+}
+
+foreach tile_type {DSP_L DSP_R} {
+    set tiles [get_tiles -filter "TILE_TYPE == $tile_type"]
+    if {[llength $tiles] != 0} {
+        set tile [lindex $tiles 0]
+        write_dsp_ppips_db "ppips_[string tolower $tile_type].db" $tile
     }
 }
 


### PR DESCRIPTION
The current `ppips_dsp_[lr].db` are empty and should contain information required for routing DSPs. An example of a generated `ppips_dsp_l.db` is attached to this PR for the zynq7010.

[ppips_dsp_l.db.zip](https://github.com/SymbiFlow/prjxray/files/6394677/ppips_dsp_l.db.zip)


Signed-off-by: Ian Taras <itaras@isi.edu>