### PR TITLE
Fix wrong parameter in get_part_resources()

### DIFF
--- a/fuzzers/005-tilegrid/Makefile
+++ b/fuzzers/005-tilegrid/Makefile
@@ -30,6 +30,7 @@ TILEGRID_TDB_DEPENDENCIES += hclk_cmt/$(BUILD_FOLDER)/segbits_tilegrid.tdb
 TILEGRID_TDB_DEPENDENCIES += pll/$(BUILD_FOLDER)/segbits_tilegrid.tdb
 TILEGRID_TDB_DEPENDENCIES += hclk_ioi/$(BUILD_FOLDER)/segbits_tilegrid.tdb
 TILEGRID_TDB_DEPENDENCIES += mmcm/$(BUILD_FOLDER)/segbits_tilegrid.tdb
+TILEGRID_TDB_DEPENDENCIES += dsp_int/$(BUILD_FOLDER)/segbits_tilegrid.tdb
 GENERATE_FULL_ARGS=
 
 # Artix7 only fuzzers
@@ -49,11 +50,6 @@ endif
 # Kintex7 only fuzzers
 ifeq (${XRAY_DATABASE}, kintex7)
 TILEGRID_TDB_DEPENDENCIES += orphan_int_column/$(BUILD_FOLDER)/segbits_tilegrid.tdb
-endif
-
-# Disable DSP INT fuzzer on kintex7.  It doesn't work, and isn't required.
-ifneq (${XRAY_DATABASE}, kintex7)
-TILEGRID_TDB_DEPENDENCIES += dsp_int/$(BUILD_FOLDER)/segbits_tilegrid.tdb
 endif
 
 BASICDB_TILEGRID=$(BUILD_FOLDER)/basicdb/${XRAY_FABRIC}/tilegrid.json

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -64,7 +64,6 @@ def get_part_resources(file_path, part):
     with open(filename, 'r') as stream:
         res_mapping = yaml.load(stream, Loader=yaml.FullLoader)
     res = res_mapping.get(part, None)
-    #making a change to create a new commit and then sign off
     assert res, "Part {} not found in {}".format(part, res_mapping)
     return res
 

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -64,7 +64,7 @@ def get_part_resources(file_path, part):
     with open(filename, 'r') as stream:
         res_mapping = yaml.load(stream, Loader=yaml.FullLoader)
     res = res_mapping.get(part, None)
-    assert res, "Part {} not found in {}".format(part, part_mapping)
+    assert res, "Part {} not found in {}".format(part, res_mapping)
     return res
 
 

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -64,6 +64,7 @@ def get_part_resources(file_path, part):
     with open(filename, 'r') as stream:
         res_mapping = yaml.load(stream, Loader=yaml.FullLoader)
     res = res_mapping.get(part, None)
+    #making a change to create a new commit and then sign off
     assert res, "Part {} not found in {}".format(part, res_mapping)
     return res
 


### PR DESCRIPTION
The assertion error for `get_part_resources()` should print `res_mapping` instead of `part_mapping` (the latter isn't even defined in `get_part_resources()`). See #1834 for details.