### PR TITLE
Fix wrong parameter in get_part_resources()

### DIFF
--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -64,7 +64,7 @@ def get_part_resources(file_path, part):
     with open(filename, 'r') as stream:
         res_mapping = yaml.load(stream, Loader=yaml.FullLoader)
     res = res_mapping.get(part, None)
-    assert res, "Part {} not found in {}".format(part, part_mapping)
+    assert res, "Part {} not found in {}".format(part, res_mapping)
     return res
 
 


### PR DESCRIPTION
The assertion error for `get_part_resources()` should print `res_mapping` instead of `part_mapping` (which is not defined in this function).

This PR supersedes #1835 since the DCO check of that one was messed up by me again.

Signed-off-by: Steve <steve.bohan.liu@outlook.com>