### PR TITLE
Add missing cstdint include in `memory_mapped_file.h`

### DIFF
--- a/lib/include/prjxray/memory_mapped_file.h
+++ b/lib/include/prjxray/memory_mapped_file.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 #include <absl/types/span.h>
 


### PR DESCRIPTION
I get this error while trying to build prjxray :
```
In file included from /home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/segbits_file_reader.h:17,
                 from /home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/database.h:17,
                 from /home/builder/.cache/yay/prjxray-git/src/prjxray/lib/database.cc:10:
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:30:20: error: ‘uint8_t’ was not declared in this scope
   30 |         absl::Span<uint8_t> as_bytes() const {
      |                    ^~~~~~~
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:17:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   16 | #include <absl/types/span.h>
  +++ |+#include <cstdint>
   17 |
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:30:27: error: template argument 1 is invalid
   30 |         absl::Span<uint8_t> as_bytes() const {
      |                           ^
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h: In member function ‘int prjxray::MemoryMappedFile::as_bytes() const’:
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:31:37: error: ‘uint8_t’ does not name a type
   31 |                 return {static_cast<uint8_t*>(data_), size_};
      |                                     ^~~~~~~
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:31:37: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:31:44: error: expected ‘>’ before ‘*’ token
   31 |                 return {static_cast<uint8_t*>(data_), size_};
      |                                            ^
/home/builder/.cache/yay/prjxray-git/src/prjxray/lib/include/prjxray/memory_mapped_file.h:31:60: error: cannot convert ‘<brace-enclosed initializer list>’ to ‘int’ in return
   31 |                 return {static_cast<uint8_t*>(data_), size_};
      |                                                            ^
make[2]: *** [lib/CMakeFiles/libprjxray.dir/build.make:79: lib/CMakeFiles/libprjxray.dir/database.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:5877: lib/CMakeFiles/libprjxray.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```