### PR TITLE
Add a missing include

### DIFF
--- a/lib/include/prjxray/memory_mapped_file.h
+++ b/lib/include/prjxray/memory_mapped_file.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <string>
 
+#include <cstdint>
+
 #include <absl/types/span.h>
 
 namespace prjxray {


### PR DESCRIPTION
Newer GCC is a bit more picky, so this needs to be included explicitly.