### PR TITLE
Add another missing include

### DIFF
--- a/tools/bits2rbt/header.cc
+++ b/tools/bits2rbt/header.cc
@@ -1,6 +1,7 @@
 #include "header.h"
 #include <algorithm>
 #include <ctime>
+#include <cassert>
 #include <sstream>
 
 Header::Header(const std::string& line,


### PR DESCRIPTION
This code uses `assert`, but does not include `<cassert>`, leading to build failures with gcc 15.