### PR TITLE
Update reference to yaml-cpp

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(libprjxray
 	xilinx/xc7series/ecc.cc
 )
 target_include_directories(libprjxray PUBLIC "include")
-target_link_libraries(libprjxray absl::optional absl::variant absl::strings absl::span absl::time yaml-cpp)
+target_link_libraries(libprjxray absl::optional absl::variant absl::strings absl::span absl::time yaml-cpp::yaml-cpp)
 
 if (PRJXRAY_BUILD_TESTING)
 	add_executable(big_endian_span_test big_endian_span_test.cc)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(gen_part_base_yaml
 	absl::optional
 	absl::span
 	libprjxray
-	yaml-cpp
+	yaml-cpp::yaml-cpp
 	gflags
 )
 add_executable(xc7patch xc7patch.cc)


### PR DESCRIPTION
Starting from yaml-cpp 0.9, clients should link against "yaml-cpp::yaml-cpp", and the unqualified "yaml-cpp" name is deprecated. This generates warnings, and will stop working in yaml-cpp 0.10.

Closes: #2565