### PR TITLE
Use std::variant instead of absl::variant

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(libprjxray
 	xilinx/xc7series/ecc.cc
 )
 target_include_directories(libprjxray PUBLIC "include")
-target_link_libraries(libprjxray absl::optional absl::variant absl::strings absl::span absl::time yaml-cpp)
+target_link_libraries(libprjxray absl::optional absl::strings absl::span absl::time yaml-cpp)
 
 if (PRJXRAY_BUILD_TESTING)
 	add_executable(big_endian_span_test big_endian_span_test.cc)

--- a/lib/include/prjxray/xilinx/architectures.h
+++ b/lib/include/prjxray/xilinx/architectures.h
@@ -10,8 +10,8 @@
 #ifndef PRJXRAY_LIB_XILINX_ARCHITECTURES_H_
 #define PRJXRAY_LIB_XILINX_ARCHITECTURES_H_
 
-#include <absl/types/variant.h>
 #include <memory>
+#include <variant>
 #include <vector>
 
 #include <prjxray/xilinx/configuration_packet.h>
@@ -31,7 +31,7 @@ class UltraScalePlus;
 class Architecture {
        public:
 	using Container =
-	    absl::variant<Series7, UltraScale, UltraScalePlus, Spartan6>;
+	    std::variant<Series7, UltraScale, UltraScalePlus, Spartan6>;
 	Architecture(const std::string& name) : name_(name) {}
 	const std::string& name() const { return name_; }
 	virtual ~Architecture() {}

--- a/tools/bitread.cc
+++ b/tools/bitread.cc
@@ -351,5 +351,5 @@ int main(int argc, char** argv) {
 	xilinx::Architecture::Container arch_container =
 	    xilinx::ArchitectureFactory::create_architecture(
 	        FLAGS_architecture);
-	return absl::visit(BitReader(in_bytes), arch_container);
+	return std::visit(BitReader(in_bytes), arch_container);
 }

--- a/tools/bittool.cc
+++ b/tools/bittool.cc
@@ -72,7 +72,7 @@ int ListConfigPackets(int argc, char* argv[]) {
 	    static_cast<uint8_t*>(in_file->data()), in_file->size());
 	xilinx::Architecture::Container arch_container =
 	    xilinx::ArchitectureFactory::create_architecture(architecture);
-	return absl::visit(ConfigPacketsLister(in_bytes), arch_container);
+	return std::visit(ConfigPacketsLister(in_bytes), arch_container);
 }
 
 struct DebugFrameAddressesDumper {
@@ -149,7 +149,7 @@ int DumpDebugbitstreamFrameAddresses(int argc, char* argv[]) {
 	    static_cast<uint8_t*>(in_file->data()), in_file->size());
 	xilinx::Architecture::Container arch_container =
 	    xilinx::ArchitectureFactory::create_architecture(architecture);
-	return absl::visit(DebugFrameAddressesDumper(in_bytes), arch_container);
+	return std::visit(DebugFrameAddressesDumper(in_bytes), arch_container);
 }
 
 struct DeviceIdGetter {
@@ -231,7 +231,7 @@ int GetDeviceId(int argc, char* argv[]) {
 
 	xilinx::Architecture::Container arch_container =
 	    xilinx::ArchitectureFactory::create_architecture(architecture);
-	return absl::visit(DeviceIdGetter(in_bytes), arch_container);
+	return std::visit(DeviceIdGetter(in_bytes), arch_container);
 }
 
 int main(int argc, char* argv[]) {

--- a/tools/xc7frames2bit.cc
+++ b/tools/xc7frames2bit.cc
@@ -88,5 +88,5 @@ int main(int argc, char* argv[]) {
 	xilinx::Architecture::Container arch_container =
 	    xilinx::ArchitectureFactory::create_architecture(
 	        FLAGS_architecture);
-	return absl::visit(Frames2BitWriter(), arch_container);
+	return std::visit(Frames2BitWriter(), arch_container);
 }

--- a/tools/xc7patch.cc
+++ b/tools/xc7patch.cc
@@ -151,5 +151,5 @@ int main(int argc, char* argv[]) {
 	xilinx::Architecture::Container arch_container =
 	    xilinx::ArchitectureFactory::create_architecture(
 	        FLAGS_architecture);
-	return absl::visit(BitstreamPatcher(), arch_container);
+	return std::visit(BitstreamPatcher(), arch_container);
 }


### PR DESCRIPTION
Abseil deprecated this function, as it is a thin wrapper for the standard library.

Closes: #2566